### PR TITLE
install.sh: fail closed on missing checksum or hashing tool

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,6 +30,7 @@ CORE_ONLY=false
 STANDALONE=false
 VERSION=""
 UNINSTALL=false
+NO_VERIFY_CHECKSUM=false
 
 # --- Colors and output helpers ---
 
@@ -68,11 +69,12 @@ USAGE:
     curl -fsSL ... | bash -s -- [OPTIONS]
 
 OPTIONS:
-    --core        Install only jaclang (no plugins)
-    --standalone  Download a pre-built standalone binary from GitHub Releases
-    --version V   Install a specific version (e.g., 2.3.1)
-    --uninstall   Remove Jac installation
-    --help        Print this help message
+    --core                Install only jaclang (no plugins)
+    --standalone          Download a pre-built standalone binary from GitHub Releases
+    --version V           Install a specific version (e.g., 2.3.1)
+    --uninstall           Remove Jac installation
+    --no-verify-checksum  Skip SHA-256 verification of standalone binary (NOT recommended)
+    --help                Print this help message
 
 EXAMPLES:
     # Full ecosystem (all plugins) via uv
@@ -146,6 +148,10 @@ parse_args() {
                 ;;
             --uninstall)
                 UNINSTALL=true
+                shift
+                ;;
+            --no-verify-checksum)
+                NO_VERIFY_CHECKSUM=true
                 shift
                 ;;
             --help | -h)
@@ -354,9 +360,15 @@ install_standalone() {
         exit 1
     fi
 
-    # Verify checksum if available
-    if curl -fsSL -o "${tmpdir}/${asset}.sha256" "$checksum_url" 2>/dev/null; then
-        info "Verifying checksum..."
+    # Verify checksum (fail closed unless --no-verify-checksum is set)
+    if [[ "$NO_VERIFY_CHECKSUM" == "true" ]]; then
+        warn "Skipping checksum verification (--no-verify-checksum)."
+    elif ! curl -fsSL -o "${tmpdir}/${asset}.sha256" "$checksum_url" 2>/dev/null; then
+        err "Could not download checksum file: ${checksum_url}"
+        err "Refusing to install an unverified binary."
+        err "Re-run with --no-verify-checksum to override (NOT recommended)."
+        exit 1
+    else
         local expected actual
         expected=$(awk '{print $1}' "${tmpdir}/${asset}.sha256")
 
@@ -365,10 +377,13 @@ install_standalone() {
         elif has_cmd shasum; then
             actual=$(shasum -a 256 "${tmpdir}/${asset}" | awk '{print $1}')
         else
-            warn "Neither sha256sum nor shasum found, skipping checksum verification."
-            actual="$expected"
+            err "Neither sha256sum nor shasum is available."
+            err "Refusing to install an unverified binary."
+            err "Install one of those tools, or re-run with --no-verify-checksum (NOT recommended)."
+            exit 1
         fi
 
+        info "Verifying checksum..."
         if [[ "$expected" != "$actual" ]]; then
             err "Checksum verification failed!"
             err "  Expected: ${expected}"
@@ -376,8 +391,6 @@ install_standalone() {
             exit 1
         fi
         info "Checksum verified."
-    else
-        warn "Checksum file not available, skipping verification."
     fi
 
     # Install binary


### PR DESCRIPTION
## Summary

The `--standalone` install path in `scripts/install.sh` silently skipped binary verification in two scenarios:

1. **No hashing tool present** — when neither `sha256sum` nor `shasum` was on the host, the code set `actual=\"\$expected\"`, so the equality check at the next line trivially passed. Only a `warn` was printed; the install otherwise looked successful.
2. **`.sha256` file 404 / unreachable** — the `if curl -fsSL -o ... 2>/dev/null` wrapper meant any download failure dropped through to a `warn` and the binary was installed anyway.

Together these two paths mean a standalone install could end up running an unverified binary on a normal-looking successful run. This is the kind of thing the verification step exists to prevent.

## Changes

- Both \"can't verify\" paths now `exit 1` instead of silently continuing.
- New `--no-verify-checksum` flag for users who genuinely need to opt out (air-gapped rollouts, releases without checksums, etc.). Logged as a `warn` so it's visible.
- Help text updated.

Happy path is unchanged: when both the `.sha256` file and a hashing tool are available, the verification logic is identical to before.

## Test plan

- [ ] `bash -n scripts/install.sh` passes (done locally).
- [ ] On a host with `sha256sum`: run `bash scripts/install.sh --standalone` against a known-good release and confirm \"Checksum verified.\" still prints.
- [ ] Simulate missing `.sha256`: temporarily point `checksum_url` at a 404 — confirm the script now exits with the new error message.
- [ ] Simulate missing tool: run with `PATH` stripped of `sha256sum`/`shasum` — confirm the script exits with the new error.
- [ ] `--no-verify-checksum`: confirm the install still proceeds (with a warning) when the flag is passed.