### PR TITLE
ci(jac-check): read .jacignore via array to avoid word-splitting and globbing

### DIFF
--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -42,4 +42,8 @@ jobs:
 
       - name: Run jac check (using .jacignore)
         run: |
-          jac check . --ignore tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ') --nowarn
+          ignore_patterns=()
+          if [[ -f .jacignore ]]; then
+            mapfile -t ignore_patterns < <(grep -v '^[[:space:]]*#' .jacignore | grep -v '^[[:space:]]*$' || true)
+          fi
+          jac check . --ignore tests checker_*.jac *_err.jac "${ignore_patterns[@]}" --nowarn


### PR DESCRIPTION
## Summary

The Jac type-check workflow currently builds the ignore list with unquoted command substitution:

\`\`\`bash
jac check . --ignore tests checker_*.jac *_err.jac \\
    \$(grep -v '^#' .jacignore | grep -v '^[[:space:]]*\$' | tr '\\n' ' ') \\
    --nowarn
\`\`\`

Bash then word-splits the substitution on \`\$IFS\` **and** runs pathname expansion. So:

- A pattern containing a space (e.g. \`some dir/foo.jac\`) is silently split into two args.
- A pattern that happens to glob-match something in the repo root (e.g. \`*\` or \`*.jac\`) is replaced by the matching paths before \`jac check\` ever sees it.
- Patterns from \`.jacignore\` reach \`jac check\` rewritten by the shell instead of as written.

This isn't a security issue — \`.jacignore\` lives in-repo, and \`;\` / backticks aren't re-evaluated by word-splitting — but the behavior is wrong and surprising.

## Change

Read the file into a bash array via \`mapfile\` and expand it as \`\"\${ignore_patterns[@]}\"\` so each pattern reaches \`jac check\` exactly as written. Empty / missing \`.jacignore\` is preserved as a no-op.

The grep filter is also tightened from \`'^#'\` to \`'^[[:space:]]*#'\` so indented comment lines are still skipped (the \`^[[:space:]]*\$\` blank-line filter already handled indented blanks).

\`\`\`bash
ignore_patterns=()
if [[ -f .jacignore ]]; then
  mapfile -t ignore_patterns < <(grep -v '^[[:space:]]*#' .jacignore | grep -v '^[[:space:]]*\$' || true)
fi
jac check . --ignore tests checker_*.jac *_err.jac \"\${ignore_patterns[@]}\" --nowarn
\`\`\`

No release-note fragment is needed: this PR doesn't touch any of the directories tracked by \`scripts/check-release-notes.sh\` (only \`.github/workflows/jac-check.yml\`).

## Test plan

- [ ] CI \`Jac Type Check\` job runs on this PR and produces the same pass/fail set as before.
- [ ] (Manually) add a temporary indented-comment line to \`.jacignore\` on a sandbox branch and confirm it's skipped (the prior pattern would have included it).
- [ ] Add a temporary line containing a space to \`.jacignore\` and confirm \`jac check\` receives it as a single arg.