### PR TITLE
refactor(byllm): simplify _call_sync timeout via Future.result()

### DIFF
--- a/docs/docs/community/release_notes/unreleased/byllm/5713.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/byllm/5713.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: simplify `_call_sync` timeout handling**: Replace nested `threading.Thread` + manual `result_box`/`error_box` pattern with `concurrent.futures.Future.result(timeout=...)`. Behavior preserved (including daemon-leak semantics on timeout) while cutting the function from 25 to 19 lines and removing redundant exception-capture plumbing. Addresses item 3 of #5711.

--- a/jac-byllm/byllm/parallel.jac
+++ b/jac-byllm/byllm/parallel.jac
@@ -25,7 +25,11 @@ import logging;
 import os;
 import time;
 
-import from concurrent.futures { ThreadPoolExecutor, as_completed }
+import from concurrent.futures {
+    ThreadPoolExecutor,
+    TimeoutError as _FuturesTimeout,
+    as_completed
+}
 import from byllm.types { ToolCallResultMsg }
 
 glob _plog = logging.getLogger("byllm.parallel"),
@@ -95,31 +99,30 @@ def _index_by_identity(seq: list, item: Any) -> int {
 }
 
 
-"""Call a synchronous tool, optionally wrapping in a thread with timeout."""
+"""Call a synchronous tool, optionally wrapping with timeout.
+
+Uses a one-shot ThreadPoolExecutor so Future.result(timeout=...) handles
+both timeout and exception propagation natively. shutdown(wait=False)
+preserves the prior daemon-leak semantics: on timeout, the in-flight tool
+keeps running in the background; the outer pool worker is freed immediately.
+"""
 def _call_sync(tc: Any, timeout: Any) -> Any {
     if timeout is None {
         return tc();
     }
-    import threading;
-    result_box: list = [None];
-    error_box: list = [None];
-    def _worker {
+    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="byllm-tool-timeout");
+    try {
+        f = pool.submit(tc);
         try {
-            result_box[0] = tc();
-        } except Exception as e {
-            error_box[0] = e;
+            return f.result(timeout=timeout);
+        } except _FuturesTimeout {
+            raise TimeoutError(
+                f"Tool '{tc.tool.get_name()}' timed out after {timeout}s"
+            );
         }
+    } finally {
+        pool.shutdown(wait=False);
     }
-    t = threading.Thread(target=_worker, daemon=True);
-    t.start();
-    t.join(timeout=timeout);
-    if t.is_alive() {
-        raise TimeoutError(f"Tool '{tc.tool.get_name()}' timed out after {timeout}s");
-    }
-    if error_box[0] is not None {
-        raise error_box[0];
-    }
-    return result_box[0];
 }
 
 


### PR DESCRIPTION
## Summary

Addresses item 3 of #5711.

`_call_sync` runs inside `_WORKER_POOL` (a `ThreadPoolExecutor`) yet spawned its own `threading.Thread` with manual `result_box`/`error_box` slots to capture the tool result and any raised exception. `concurrent.futures.Future` already provides exactly those semantics.

This PR replaces the manual plumbing with a one-shot `ThreadPoolExecutor` + `Future.result(timeout=...)`. `shutdown(wait=False)` preserves the prior `daemon=True` leak behavior: on timeout the in-flight tool keeps running in the background and the outer pool worker is freed immediately.

## Behavior parity

Smoke-tested four paths against the new implementation:

- `timeout=None` returns the tool's value inline
- Tool finishes within timeout returns the value
- Tool exceeds timeout raises `TimeoutError` with the same `Tool '{name}' timed out after {t}s` message format
- Tool exceptions propagate with original type and message

The 40 existing tests in `jac-byllm/tests/test_parallel.jac` pass unchanged.

## Test plan

- [x] `pytest -x jac-byllm/tests/test_parallel.jac` (40 passed locally)
- [x] Manual smoke test for the four `_call_sync` paths above
- [ ] CI green on `test-jaseci` / `Run package tests` job