### PR TITLE
fix(jaclang): show clean error for invalid jac.toml (closes #5740)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5743.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5743.bugfix.md
@@ -1,0 +1,1 @@
+- **Cleaner errors for invalid `jac.toml`**: Malformed `jac.toml` files (duplicate keys, malformed sections) now surface a one-line error with the file path and a hint, instead of dumping a raw `tomllib.TOMLDecodeError` traceback that pointed at internal Jac code. Affects `jac install` and any other command that loads project config. Closes #5740.

--- a/jac/jaclang/project/config.jac
+++ b/jac/jaclang/project/config.jac
@@ -235,6 +235,14 @@ def discover_config_files(
 # Parse TOML data into JacConfig object
 def _parse_toml_data(data: dict[str, Any], toml_path: Path | None = None) -> JacConfig;
 
+# Read + parse a TOML file; raises ValueError with a user-friendly message
+# wrapping any tomllib.TOMLDecodeError so callers don't surface a raw traceback.
+def _read_toml_file(toml_path: Path) -> dict;
+
+# Parse a TOML string; same error-wrapping contract as _read_toml_file. The
+# optional toml_path is only used to enrich the error message.
+def _parse_toml_str(toml_str: str, toml_path: Path | None = None) -> dict;
+
 # Recursively apply environment variable interpolation
 def _interpolate_recursive(`obj: Any) -> Any;
 

--- a/jac/jaclang/project/impl/config.impl.jac
+++ b/jac/jaclang/project/impl/config.impl.jac
@@ -108,13 +108,10 @@ impl JacConfig.discover(
 }
 
 impl JacConfig.load(toml_path: Path) -> JacConfig {
-    import tomllib;
     if not toml_path.exists() {
         raise FileNotFoundError(f"Configuration file not found: {toml_path}");
     }
-    with open(toml_path, "rb") as f {
-        data = tomllib.load(f);
-    }
+    data = _read_toml_file(toml_path);
     config = _parse_toml_data(data, toml_path);
     config.config_files = [toml_path];
     config.apply_env_interpolation();
@@ -124,8 +121,7 @@ impl JacConfig.load(toml_path: Path) -> JacConfig {
 impl JacConfig.from_toml_str(
     toml_str: str, toml_path: Path | None = None
 ) -> JacConfig {
-    import tomllib;
-    data = tomllib.loads(toml_str);
+    data = _parse_toml_str(toml_str, toml_path);
     return _parse_toml_data(data, toml_path);
 }
 
@@ -302,13 +298,10 @@ impl JacConfig.apply_profile_overlay(profile_name: str | None = None) -> None {
 }
 
 impl JacConfig.merge_from_toml_file(toml_path: Path) -> None {
-    import tomllib;
     if not toml_path.exists() {
         return;
     }
-    with open(toml_path, "rb") as f {
-        data = tomllib.load(f);
-    }
+    data = _read_toml_file(toml_path);
     data = _interpolate_recursive(data);
     section_map: dict = {
         "run": self.run,
@@ -494,9 +487,7 @@ impl JacConfig.save -> None {
     }
     # Load existing data or start fresh
     if self.toml_path.exists() {
-        with open(self.toml_path, "rb") as f {
-            doc = tomllib.load(f);
-        }
+        doc = _read_toml_file(self.toml_path);
     } else {
         doc = {};
     }
@@ -728,6 +719,33 @@ impl JacConfig.remove_dependency(
 # ===============================================================================
 # Helper Functions Implementation
 # ===============================================================================
+impl _read_toml_file(toml_path: Path) -> dict {
+    import tomllib;
+    try {
+        with open(toml_path, "rb") as f {
+            return tomllib.load(f);
+        }
+    } except tomllib.TOMLDecodeError as e {
+        raise ValueError(
+            f"Invalid TOML in {toml_path}: {e}.\n"
+            "Hint: check for duplicate keys or malformed sections."
+        );
+    }
+}
+
+impl _parse_toml_str(toml_str: str, toml_path: Path | None = None) -> dict {
+    import tomllib;
+    try {
+        return tomllib.loads(toml_str);
+    } except tomllib.TOMLDecodeError as e {
+        location = f" in {toml_path}" if toml_path is not None else "";
+        raise ValueError(
+            f"Invalid TOML{location}: {e}.\n"
+            "Hint: check for duplicate keys or malformed sections."
+        );
+    }
+}
+
 impl _parse_toml_data(
     data: dict[str, Any], toml_path: Path | None = None
 ) -> JacConfig {


### PR DESCRIPTION
## Summary
- Wrap the four `tomllib.load` / `tomllib.loads` call sites in `jac/jaclang/project/impl/config.impl.jac` (lines 116, 128, 310, 498 on main) with a `TOMLDecodeError` handler that re-raises a `ValueError` carrying the file path, the underlying parse message, and a hint about duplicate keys / malformed sections.
- Adds two private helpers `_read_toml_file(toml_path)` and `_parse_toml_str(toml_str, toml_path=None)` in the existing helpers section, and routes `JacConfig.load`, `JacConfig.from_toml_str`, `JacConfig.merge_from_toml_file`, and `JacConfig.save` through them.
- Closes #5740.

## Before
```
Warning: Failed to apply profile: Cannot overwrite a value (at line 186, column 30)
✖ Error: Error executing 'install': Cannot overwrite a value (at line 186, column 30)
Traceback (most recent call last):
  File ".../config.impl.jac", line 116, in load
    data = tomllib.load(f);
  ...
tomllib.TOMLDecodeError: Cannot overwrite a value (at line 186, column 30)
```

## After
Reproduced locally with a `jac.toml` containing a duplicate `[run]` section and ran `jac install`:
```
Warning: Failed to apply profile: Invalid TOML in /tmp/jac_repro_5740/jac.toml: Cannot declare ('run',) twice (at line 8, column 5).
Hint: check for duplicate keys or malformed sections.
✖ Error: Error executing 'install': Invalid TOML in /tmp/jac_repro_5740/jac.toml: Cannot declare ('run',) twice (at line 8, column 5).
Hint: check for duplicate keys or malformed sections.
```
Also exercised `JacConfig.from_toml_str` (with and without a `toml_path`) and `JacConfig.merge_from_toml_file` directly; all three carry the file path when one is known and omit it cleanly when none is.

## Scope note
The issue also points at `tomllib.load` calls in `jac/jaclang/cli/commands/impl/config.impl.jac` (lines 1190 and 1229 in `_save_config_with_setting` / `_save_config_without_setting`). Those weren't listed in the issue's "Suggested Fix", so I left them out of this PR. Happy to follow up in the same shape if you'd like them in scope.

## Test plan
- [x] Reproduced original traceback on stock `main`
- [x] Patched + reran `jac install` against the same fixture: clean error, no traceback chain pointing at internal Jac code
- [x] Direct API tests on `JacConfig.load`, `JacConfig.from_toml_str` (path + no-path), `JacConfig.merge_from_toml_file`
- [x] Valid `jac.toml` still loads (no regression on the happy path)
- [x] `jac check` produces no new errors/warnings inside the helper region (lines 720–755)
- [x] Pre-commit: `Ban em-dashes`, `Validate release note fragment filenames`, `jac-format` all pass locally (the markdownlint-cli2 hook fails to install on this machine due to a local node version, will run on pre-commit.ci)