### PR TITLE
fix(docs): object_spatial_references example fails jac check

### DIFF
--- a/docs/docs/assets/examples/object_spatial/object_spatial_references.jac
+++ b/docs/docs/assets/examples/object_spatial/object_spatial_references.jac
@@ -13,12 +13,21 @@ edge connector {
 }
 
 impl Creator.create{
-    end = here;
-    for i = 0 to i < 3 by i += 1 {
-        end ++> (end := node_a(val=i));
+    # Build a chain of node_a's hanging off the entry root: each step
+    # creates a new node, links from `end`, then advances `end` to it.
+    head = node_a(val=0);
+    here ++> head;
+    end = head;
+    for i = 1 to i < 3 by i += 1 {
+        next = node_a(val=i);
+        end ++> next;
+        end = next;
     }
-    end +>: connector : value=i :+> (end := node_a(val=i + 10));
-    root <+: connector : value=i :<+ (end := node_a(val=i + 10));
+    # Typed-edge fan-outs from the chain's tail and from root.
+    fwd_tail = node_a(val=i + 10);
+    end +>: connector(value=i) :+> fwd_tail;
+    bwd_tail = node_a(val=i + 10);
+    root <+: connector(value=i) :<+ bwd_tail;
     visit [-->];
 }
 


### PR DESCRIPTION
## Summary

`docs/docs/assets/examples/object_spatial/object_spatial_references.jac` was the only failing file under `docs/docs/assets/`:

```
✖ Error: error[E1001]: Cannot assign Root to node_a
  --> docs/docs/assets/examples/object_spatial/object_spatial_references.jac:16:5
   16 |     end = here;
   17 |     for i = 0 to i < 3 by i += 1 {
   18 |         end ++> (end := node_a(val=i));
```

(2 errors, identical, both pointing at the `end = here` declaration.)

## Root cause

`end = here;` typed `end` as `Root` (walker enters via `with Root entry`). The walrus chain `(end := node_a(val=i))` then reassigned `end` to a `node_a`, which the type checker rejects since it doesn't widen the inferred type on reassignment.

I tried local-var annotations (`end: Root | node_a = here;`, `end: (Root | node_a) = here;`, `end: Node = here;`) — all three were ignored: the inferred type from the initial value still drove the reassignment check.

## Fix

Rewrote the impl to keep `end` typed as `node_a` from the start:

1. Seed the chain with an explicit `head = node_a(val=0)` linked to `here`.
2. Walk forward by binding each new node to its own typed local (`next`), connecting from `end`, then reassigning `end = next` — no walrus, no reassignment across types.
3. Use named locals (`fwd_tail`, `bwd_tail`) for the typed-edge fan-outs to/from root, replacing the chained walrus there too.

Same graph shape, same `visit [-->]` traversal, same demonstrated edge primitives (default `++>`, typed forward `+>:...:+>`, typed backward `<+:...:<+`).

## Test plan

- [x] `jac check docs/docs/assets/examples/object_spatial/object_spatial_references.jac` -> PASSED (was: 2 errors)
- [x] `jac check docs/docs/assets` -> 12 passed, 0 failed (was: 12 passed, 1 failed)
- [x] `jac run docs/docs/assets/examples/object_spatial/object_spatial_references.jac` -> runs clean, prints `welcome to node_a(val=0)` for the visited head
- [x] Pre-commit clean (jac-format, em-dash ban, fragment validator)
- [x] No release-note fragment needed — `docs/` is not a watched folder in `scripts/check-release-notes.sh`