### PR TITLE
fix(mtir-gen-pass): cross-module parent class with by llm tools crashes compiler

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5817.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5817.bugfix.md
@@ -1,0 +1,1 @@
+- **MTIR Generation Pass**: Compiler no longer crashes when a node class inherits from an imported parent and declares a `by llm(tools=[...])` method. Previously, the MTIR extraction would fail with `ClassInfo.__init__() missing required arguments` when processing cross-module inheritance chains.

--- a/jac/jaclang/compiler/passes/main/impl/mtir_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/mtir_gen_pass.impl.jac
@@ -259,7 +259,15 @@ impl MTIRGenPass._extract_class_info(symbol: uni.Symbol) -> ClassInfo | None {
             } else {
                 base_name = str(base);
             }
-            base_classes.append(ClassInfo(name=base_name, semstr=None));
+            base_classes.append(
+                ClassInfo(
+                    name=base_name,
+                    semstr=None,
+                    fields=[],
+                    base_classes=[],
+                    methods=[]
+                )
+            );
         }
     }
     fields: list[FieldInfo] = [];

--- a/jac/jaclang/compiler/passes/main/impl/mtir_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/mtir_gen_pass.impl.jac
@@ -261,11 +261,7 @@ impl MTIRGenPass._extract_class_info(symbol: uni.Symbol) -> ClassInfo | None {
             }
             base_classes.append(
                 ClassInfo(
-                    name=base_name,
-                    semstr=None,
-                    fields=[],
-                    base_classes=[],
-                    methods=[]
+                    name=base_name, semstr=None, fields=[], base_classes=[], methods=[]
                 )
             );
         }

--- a/jac/tests/compiler/passes/main/fixtures/mtir_cross_module_inherit/main.jac
+++ b/jac/tests/compiler/passes/main/fixtures/mtir_cross_module_inherit/main.jac
@@ -1,0 +1,19 @@
+"""Child node inheriting an imported parent + a `by llm(tools=[...])` method."""
+
+import from parent { Parent }
+
+obj MockLLM {
+    def __call__(**kwargs: dict) -> MockLLM {
+        return self;
+    }
+}
+
+glob llm = MockLLM();
+
+def helper_tool(q: str) -> str {
+    return q;
+}
+
+node Child(Parent) {
+    def step(q: str) -> str by llm(tools=[helper_tool]);
+}

--- a/jac/tests/compiler/passes/main/fixtures/mtir_cross_module_inherit/parent.jac
+++ b/jac/tests/compiler/passes/main/fixtures/mtir_cross_module_inherit/parent.jac
@@ -1,0 +1,3 @@
+node Parent {
+    has name: str = "parent";
+}

--- a/jac/tests/compiler/passes/main/test_mtir_gen_pass.jac
+++ b/jac/tests/compiler/passes/main/test_mtir_gen_pass.jac
@@ -206,3 +206,27 @@ test "mtir gen all genai abilities captured" {
         expected_abilities
     )}";
 }
+
+test "mtir gen cross-module parent with by-llm tools" {
+    prog = JacProgram();
+    prog.compile(os.path.join(FIXTURES, "mtir_cross_module_inherit", "main.jac"));
+    assert not prog.errors_had;
+    assert Jac.program is not None;
+    mtir_map = Jac.program.mtir_map;
+    step_scope = None;
+    for scope in mtir_map {
+        if "step" in scope {
+            step_scope = scope;
+            break;
+        }
+    }
+    assert step_scope is not None , "Child.step should be in mtir_map";
+    method_info = mtir_map[step_scope];
+    assert isinstance(method_info, MethodInfo);
+    assert method_info.parent_class is not None;
+    assert method_info.parent_class.name == "Child";
+    base_names = [b.name for b in method_info.parent_class.base_classes];
+    assert "Parent" in base_names;
+    tool_names = [t.name for t in method_info.tools];
+    assert "helper_tool" in tool_names;
+}


### PR DESCRIPTION
## Problem

Compiler crashed with `ClassInfo.__init__() missing 3 required keyword-only arguments: 'fields', 'base_classes', and 'methods'` when a node class:
- Inherits from a parent defined in another module
- Declares a `by llm(tools=[...])` method

## Root Cause

In `mtir_gen_pass.impl.jac:262`, when extracting class info for base classes, the fallback `ClassInfo` construction for unresolved imported parents omitted the required kwargs `fields`, `base_classes`, and `methods` (which have no defaults).

## Fix

Added the missing required kwargs to the fallback `ClassInfo` constructor call:

```jac
base_classes.append(
    ClassInfo(
        name=base_name,
        semstr=None,
        fields=[],
        base_classes=[],
        methods=[]
    )
);
