### PR TITLE
fix(modresolver): prioritize target file's directory over cwd in module search

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5960.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5960.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `jac run <absolute-path>` now executes the specified file regardless of the working directory.** Previously, if the shell's current directory also contained a `main.jac`, it would be run instead of the file passed on the command line. The module search order in `get_jac_search_paths()` has been corrected so the target file's directory always takes priority over `cwd`.

--- a/jac/jaclang/jac0core/modresolver.jac
+++ b/jac/jaclang/jac0core/modresolver.jac
@@ -9,7 +9,6 @@ def get_jac_search_paths(base_path: (str | None) = None) -> list[str] {
     if base_path {
         paths.append(base_path);
     }
-    paths.append(os.getcwd());
     if ('JACPATH' in os.environ) {
         paths.extend(
             p.strip()
@@ -18,6 +17,7 @@ def get_jac_search_paths(base_path: (str | None) = None) -> list[str] {
         );
     }
     paths.extend(sys.path);
+    paths.append(os.getcwd());
     site_pkgs = site.getsitepackages();
     if site_pkgs {
         paths.extend(site_pkgs);

--- a/jac/tests/compiler/test_importer.jac
+++ b/jac/tests/compiler/test_importer.jac
@@ -248,6 +248,7 @@ test "run with absolute path respects file dir not cwd" {
     # contains a main.jac must execute the specified file, not the cwd's main.jac.
     tmpdir: str = tempfile.mkdtemp(prefix="jac_test_abspath_");
     original_cwd: str = os.getcwd();
+    original_main = sys.modules.get("__main__");
     captured_output = io.StringIO();
     try {
         parent_dir: str = os.path.join(tmpdir, "parent");
@@ -265,7 +266,11 @@ test "run with absolute path respects file dir not cwd" {
     } finally {
         sys.stdout = sys.__stdout__;
         os.chdir(original_cwd);
-        sys.modules.pop("__main__", None);
+        if original_main is not None {
+            sys.modules["__main__"] = original_main;
+        } else {
+            sys.modules.pop("__main__", None);
+        }
         shutil.rmtree(tmpdir, ignore_errors=True);
     }
     output = captured_output.getvalue();

--- a/jac/tests/compiler/test_importer.jac
+++ b/jac/tests/compiler/test_importer.jac
@@ -244,6 +244,36 @@ test "compiler separates internal from user modules" {
     }
 }
 
+test "run with absolute path respects file dir not cwd" {
+    # Regression: `jac run /abs/path/sub/main.jac` from a parent dir that also
+    # contains a main.jac must execute the specified file, not the cwd's main.jac.
+    tmpdir: str = tempfile.mkdtemp(prefix="jac_test_abspath_");
+    original_cwd: str = os.getcwd();
+    captured_output = io.StringIO();
+    try {
+        parent_dir: str = os.path.join(tmpdir, "parent");
+        sub_dir: str = os.path.join(parent_dir, "sub");
+        os.makedirs(sub_dir);
+        with open(os.path.join(parent_dir, "main.jac"), "w") as f {
+            f.write('with entry { "WRONG_FILE" :> print; }\n');
+        }
+        with open(os.path.join(sub_dir, "main.jac"), "w") as f {
+            f.write('with entry { "CORRECT_FILE" :> print; }\n');
+        }
+        os.chdir(parent_dir);
+        sys.stdout = captured_output;
+        execution.run(os.path.join(sub_dir, "main.jac"));
+    } finally {
+        sys.stdout = sys.__stdout__;
+        os.chdir(original_cwd);
+        sys.modules.pop("__main__", None);
+        shutil.rmtree(tmpdir, ignore_errors=True);
+    }
+    output = captured_output.getvalue();
+    assert "CORRECT_FILE" in output , f"Expected CORRECT_FILE but got: {output!r}";
+    assert "WRONG_FILE" not in output , "Ran cwd's main.jac instead of the specified file";
+}
+
 test "get bytecode uses JIR cache on second call" {
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".jac", delete=False, dir=_test_tmp_dir

--- a/jac/tests/compiler/test_importer.jac
+++ b/jac/tests/compiler/test_importer.jac
@@ -245,9 +245,10 @@ test "compiler separates internal from user modules" {
 }
 
 test "run with absolute path respects file dir not cwd" {
-    # contains a main.jac must execute the specified file, not the cwd's main.jac.
+    # When the cwd contains a main.jac, execution must use the specified file, not the cwd's main.jac.
     tmpdir: str = tempfile.mkdtemp(prefix="jac_test_abspath_");
     original_cwd: str = os.getcwd();
+    original_stdout = sys.stdout;
     original_main = sys.modules.get("__main__");
     captured_output = io.StringIO();
     try {
@@ -264,7 +265,7 @@ test "run with absolute path respects file dir not cwd" {
         sys.stdout = captured_output;
         execution.run(os.path.join(sub_dir, "main.jac"));
     } finally {
-        sys.stdout = sys.__stdout__;
+        sys.stdout = original_stdout;
         os.chdir(original_cwd);
         if original_main is not None {
             sys.modules["__main__"] = original_main;

--- a/jac/tests/compiler/test_importer.jac
+++ b/jac/tests/compiler/test_importer.jac
@@ -245,7 +245,6 @@ test "compiler separates internal from user modules" {
 }
 
 test "run with absolute path respects file dir not cwd" {
-    # Regression: `jac run /abs/path/sub/main.jac` from a parent dir that also
     # contains a main.jac must execute the specified file, not the cwd's main.jac.
     tmpdir: str = tempfile.mkdtemp(prefix="jac_test_abspath_");
     original_cwd: str = os.getcwd();


### PR DESCRIPTION
## What changed

A one-line reorder in `get_jac_search_paths()` - `os.getcwd()` moved after `sys.path`.

---

## Before

```
jac run /play/check/main.jac        (cwd = /play/)
            │
            ▼
    get_jac_search_paths()
            │
            ▼
    Search order built:
    ┌──────────────────────────────────────────┐
    │ 1. os.getcwd()  →  /play/               │  ← searched first
    │ 2. sys.path[0]  →  /play/check/         │  ← never reached
    └──────────────────────────────────────────┘
            │
            ▼
    Found /play/main.jac  ✗  (wrong file)
            │
            ▼
    Prints: "Hey, Alice!"   ← unexpected output
```

---

## After

```
jac run /play/check/main.jac        (cwd = /play/)
            │
            ▼
    get_jac_search_paths()
            │
            ▼
    Search order built:
    ┌──────────────────────────────────────────┐
    │ 1. sys.path[0]  →  /play/check/         │  ← searched first (runtime-injected)
    │ 2. os.getcwd()  →  /play/  (fallback)   │
    └──────────────────────────────────────────┘
            │
            ▼
    Found /play/check/main.jac  ✓  (correct file)
            │
            ▼
    Prints: "Hello, World!"  ← expected output
```

---

## Regression Test

Added in `test_importer.jac` - creates the exact directory structure above, runs the subdirectory file from the parent as cwd, and asserts the correct file executes.