### PR TITLE
fix(jac-scale): resolve configuration leakage in programmatic deployments by implementing path-keyed config caching

### DIFF
--- a/jac-scale/jac_scale/config_loader.jac
+++ b/jac-scale/jac_scale/config_loader.jac
@@ -34,7 +34,7 @@ class JacScaleConfig(PluginConfigBase) {
     def get_microservices_config(self: JacScaleConfig) -> dict[str, any];
 }
 
-glob _scale_config_instance: JacScaleConfig | None = None;
+glob _scale_config_instances: dict[Path, JacScaleConfig] = {};
 
 def get_scale_config(project_dir: Path | None = None) -> JacScaleConfig;
 def reset_scale_config -> None;

--- a/jac-scale/jac_scale/impl/config_loader.impl.jac
+++ b/jac-scale/jac_scale/impl/config_loader.impl.jac
@@ -344,21 +344,20 @@ impl JacScaleConfig.get_events_config(self: JacScaleConfig) -> dict[str, any] {
     };
 }
 
-"""Get or create the global JacScaleConfig instance."""
+"""Get or create the path-keyed JacScaleConfig instance."""
 impl get_scale_config(project_dir: Path | None = None) -> JacScaleConfig {
-    global _scale_config_instance;
-    if _scale_config_instance is not None {
-        return _scale_config_instance;
+    global _scale_config_instances;
+    resolved_path = (project_dir or Path.cwd()).resolve();
+    if resolved_path not in _scale_config_instances {
+        _scale_config_instances[resolved_path] = JacScaleConfig(resolved_path);
     }
-    new_instance = JacScaleConfig(project_dir);
-    _scale_config_instance = new_instance;
-    return new_instance;
+    return _scale_config_instances[resolved_path];
 }
 
-"""Reset the global config instance (useful for testing)."""
+"""Reset the path-keyed config instances (useful for testing)."""
 impl reset_scale_config -> None {
-    global _scale_config_instance;
-    _scale_config_instance = None;
+    global _scale_config_instances;
+    _scale_config_instances.clear();
 }
 
 """Get telemetry configuration from jac.toml."""

--- a/jac-scale/jac_scale/providers/database/kubernetes_mongo.jac
+++ b/jac-scale/jac_scale/providers/database/kubernetes_mongo.jac
@@ -24,9 +24,21 @@ obj KubernetesMongoProvider(DatabaseProvider) {
 
         scale_config = get_scale_config();
         k8s_config = scale_config.get_kubernetes_config();
-        mongodb_username = k8s_config.get('mongodb_root_username', 'admin');
-        mongodb_password = k8s_config.get('mongodb_root_password', 'password');
-        mongodb_storage_size = k8s_config.get('mongodb_storage_size', '1Gi');
+
+        mongodb_username = self.config.get('mongodb_root_username');
+        if mongodb_username is None {
+            mongodb_username = k8s_config.get('mongodb_root_username', 'admin');
+        }
+
+        mongodb_password = self.config.get('mongodb_root_password');
+        if mongodb_password is None {
+            mongodb_password = k8s_config.get('mongodb_root_password', 'password');
+        }
+
+        mongodb_storage_size = self.config.get('mongodb_storage_size');
+        if mongodb_storage_size is None {
+            mongodb_storage_size = k8s_config.get('mongodb_storage_size', '1Gi');
+        }
         connection_string = f"mongodb://{mongodb_username}:{mongodb_password}@{mongodb_service_name}:{mongodb_port}";
 
         mongodb_secret = {
@@ -173,8 +185,17 @@ obj KubernetesMongoProvider(DatabaseProvider) {
         if not self.connection_string {
             scale_config = get_scale_config();
             k8s_config = scale_config.get_kubernetes_config();
-            mongodb_username = k8s_config.get('mongodb_root_username', 'admin');
-            mongodb_password = k8s_config.get('mongodb_root_password', 'password');
+
+            mongodb_username = self.config.get('mongodb_root_username');
+            if mongodb_username is None {
+                mongodb_username = k8s_config.get('mongodb_root_username', 'admin');
+            }
+
+            mongodb_password = self.config.get('mongodb_root_password');
+            if mongodb_password is None {
+                mongodb_password = k8s_config.get('mongodb_root_password', 'password');
+            }
+
             service_name = f"{self.app_name}-mongodb-service";
             self.connection_string = f"mongodb://{mongodb_username}:{mongodb_password}@{service_name}:27017";
         }

--- a/jac-scale/jac_scale/providers/database/kubernetes_redis.jac
+++ b/jac-scale/jac_scale/providers/database/kubernetes_redis.jac
@@ -77,13 +77,36 @@ obj KubernetesRedisProvider(DatabaseProvider) {
         scale_config = get_scale_config();
         db_config = scale_config.get_database_config();
 
-        redis_max_memory = db_config.get('redis_max_memory', '200mb');
-        redis_eviction_policy = db_config.get('redis_eviction_policy', 'allkeys-lru');
-        redis_eviction_samples = db_config.get('redis_eviction_samples', 5);
-        redis_default_ttl = db_config.get('redis_default_ttl', 0);
-        redis_enable_keyspace_notifications = db_config.get(
-            'redis_enable_keyspace_notifications', False
+        redis_max_memory = self.config.get('redis_max_memory');
+        if redis_max_memory is None {
+            redis_max_memory = db_config.get('redis_max_memory', '200mb');
+        }
+
+        redis_eviction_policy = self.config.get('redis_eviction_policy');
+        if redis_eviction_policy is None {
+            redis_eviction_policy = db_config.get(
+                'redis_eviction_policy', 'allkeys-lru'
+            );
+        }
+
+        redis_eviction_samples = self.config.get('redis_eviction_samples');
+        if redis_eviction_samples is None {
+            redis_eviction_samples = db_config.get('redis_eviction_samples', 5);
+        }
+
+        redis_default_ttl = self.config.get('redis_default_ttl');
+        if redis_default_ttl is None {
+            redis_default_ttl = db_config.get('redis_default_ttl', 0);
+        }
+
+        redis_enable_keyspace_notifications = self.config.get(
+            'redis_enable_keyspace_notifications'
         );
+        if redis_enable_keyspace_notifications is None {
+            redis_enable_keyspace_notifications = db_config.get(
+                'redis_enable_keyspace_notifications', False
+            );
+        }
 
         valid_policies = [
             'allkeys-lru',
@@ -222,12 +245,32 @@ obj KubernetesRedisProvider(DatabaseProvider) {
         scale_config = get_scale_config();
         db_config = scale_config.get_database_config();
         k8s_config = scale_config.get_kubernetes_config();
-        redis_default_ttl = db_config.get('redis_default_ttl', 0);
-        redis_enable_keyspace_notifications = db_config.get(
-            'redis_enable_keyspace_notifications', False
+
+        redis_default_ttl = self.config.get('redis_default_ttl');
+        if redis_default_ttl is None {
+            redis_default_ttl = db_config.get('redis_default_ttl', 0);
+        }
+
+        redis_enable_keyspace_notifications = self.config.get(
+            'redis_enable_keyspace_notifications'
         );
-        redis_username = str(k8s_config.get('redis_username', 'admin'));
-        redis_password = str(k8s_config.get('redis_password', 'password'));
+        if redis_enable_keyspace_notifications is None {
+            redis_enable_keyspace_notifications = db_config.get(
+                'redis_enable_keyspace_notifications', False
+            );
+        }
+
+        redis_username = self.config.get('redis_username');
+        if redis_username is None {
+            redis_username = k8s_config.get('redis_username', 'admin');
+        }
+        redis_username = str(redis_username);
+
+        redis_password = self.config.get('redis_password');
+        if redis_password is None {
+            redis_password = k8s_config.get('redis_password', 'password');
+        }
+        redis_password = str(redis_password);
         connection_string = self._build_connection_string(
             redis_username, redis_password, redis_service_name, redis_port
         );
@@ -472,8 +515,19 @@ obj KubernetesRedisProvider(DatabaseProvider) {
         if not self.connection_string {
             scale_config = get_scale_config();
             k8s_config = scale_config.get_kubernetes_config();
-            redis_username = str(k8s_config.get('redis_username', 'admin'));
-            redis_password = str(k8s_config.get('redis_password', 'password'));
+
+            redis_username = self.config.get('redis_username');
+            if redis_username is None {
+                redis_username = k8s_config.get('redis_username', 'admin');
+            }
+            redis_username = str(redis_username);
+
+            redis_password = self.config.get('redis_password');
+            if redis_password is None {
+                redis_password = k8s_config.get('redis_password', 'password');
+            }
+            redis_password = str(redis_password);
+
             service_name = f"{self.app_name}-redis-service";
             self.connection_string = self._build_connection_string(
                 redis_username, redis_password, service_name

--- a/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
@@ -1283,8 +1283,14 @@ obj KubernetesTarget(DeploymentTarget) {
         self.k8s_config = KubernetesConfig.from_dict(
             KubernetesConfig, self.scale_config.get_kubernetes_config()
         );
-        self.k8s_config.app_name = self.config.app_name;
-        self.k8s_config.namespace = self.config.namespace;
+
+        # Merge all constructor-supplied overrides that differ from default settings
+        default_config = KubernetesConfig();
+        for (field, value) in self.config.to_dict().items() {
+            if value != default_config.to_dict().get(field) {
+                setattr(self.k8s_config, field, value);
+            }
+        }
 
         # 1. Initialize and validate
         app_name = app_config.app_name or self.k8s_config.app_name;

--- a/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
@@ -37,6 +37,8 @@ import from jac_scale._optdeps.kubernetes {
 }
 import from jac_scale.factories.database_factory { DatabaseProviderFactory }
 import from jac_scale.factories.registry_factory { ImageRegistryFactory }
+import from pathlib { Path }
+import from jac_scale.config_loader { JacScaleConfig, get_scale_config }
 import from jac_scale.targets.kubernetes.monitoring { MonitoringDeployer }
 import from jac_scale.targets.kubernetes.ingress { IngressDeployer }
 import from jac_scale.targets.kubernetes.hpa.hpa { create_hpa }
@@ -47,11 +49,13 @@ obj KubernetesTarget(DeploymentTarget) {
     has config: KubernetesConfig,
         logger: (Logger | None) = None,
         k8s_config: KubernetesConfig by postinit,
+        scale_config: JacScaleConfig by postinit,
         env_list: list = [],
         secrets: dict[str, str] = {};
 
     def postinit {
         self.k8s_config = self.config;
+        self.scale_config = get_scale_config();
     }
 
     """Get init containers from all enabled database providers."""
@@ -582,8 +586,13 @@ obj KubernetesTarget(DeploymentTarget) {
         if self.k8s_config.mongodb_enabled {
             mongodb_name = f"{app_name}-mongodb";
             mongodb_service_name = f"{mongodb_name}-service";
+            mongo_config = {
+                'app_name': app_name,
+                ** self.scale_config.get_kubernetes_config(),
+                ** self.scale_config.get_database_config()
+            };
             mongo_provider = DatabaseProviderFactory.create(
-                'kubernetes_mongo', self, {'app_name': app_name}
+                'kubernetes_mongo', self, mongo_config
             );
             mongo_result = mongo_provider.deploy({});
             self._apply_provider_service_account(
@@ -697,8 +706,13 @@ obj KubernetesTarget(DeploymentTarget) {
             redis_name = f"{app_name}-redis";
             redis_service_name = f"{redis_name}-service";
             redis_config_name = f"{redis_name}-config";
+            redis_config = {
+                'app_name': app_name,
+                ** self.scale_config.get_kubernetes_config(),
+                ** self.scale_config.get_database_config()
+            };
             redis_provider = DatabaseProviderFactory.create(
-                'kubernetes_redis', self, {'app_name': app_name}
+                'kubernetes_redis', self, redis_config
             );
             redis_result = redis_provider.deploy({});
             self._apply_provider_service_account(
@@ -1264,6 +1278,12 @@ obj KubernetesTarget(DeploymentTarget) {
     }
 
     def deploy(app_config: AppConfig) -> DeploymentResult {
+        # Load the scale config for the deployed app
+        self.scale_config = get_scale_config(Path(app_config.code_folder));
+        self.k8s_config = KubernetesConfig.from_dict(
+            KubernetesConfig, self.scale_config.get_kubernetes_config()
+        );
+
         # 1. Initialize and validate
         app_name = app_config.app_name or self.k8s_config.app_name;
         namespace = self.k8s_config.namespace;

--- a/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
@@ -1283,6 +1283,8 @@ obj KubernetesTarget(DeploymentTarget) {
         self.k8s_config = KubernetesConfig.from_dict(
             KubernetesConfig, self.scale_config.get_kubernetes_config()
         );
+        self.k8s_config.app_name = self.config.app_name;
+        self.k8s_config.namespace = self.config.namespace;
 
         # 1. Initialize and validate
         app_name = app_config.app_name or self.k8s_config.app_name;

--- a/jac-scale/jac_scale/targets/kubernetes/microservice/manifest_builder.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/microservice/manifest_builder.jac
@@ -5,6 +5,7 @@ ingress]} that KubernetesMicroserviceTarget hands to apply_manifests."""
 import from jac_scale.abstractions.config.app_config { AppConfig }
 import from jac_scale.abstractions.models.deploy_context { DeployContext }
 import from jac_scale.targets.kubernetes.kubernetes_config { KubernetesConfig }
+import from jac_scale.config_loader { JacScaleConfig, get_scale_config }
 
 
 # Sentinel for the gateway pod-spec entry; reserved to avoid collision
@@ -29,7 +30,8 @@ obj MicroserviceManifestBuilder {
     has k8s_config: KubernetesConfig,
         secrets: dict[str, str] = {},
         deploy_context: DeployContext = DeployContext(),
-        logger: any = None;
+        logger: any = None,
+        scale_config: (JacScaleConfig | None) = None;
 
     """Lift pod-specs into full Deployment + Service + HPA + PDB
     bundle. Returns `{deployments, services, hpas, pdbs, pod_specs}`,
@@ -71,8 +73,8 @@ obj MicroserviceManifestBuilder {
             bundle["user_secret"] = user_secret;
         }
         try {
-            import from jac_scale.config_loader { get_scale_config }
-            ms_cfg = get_scale_config().get_microservices_config();
+            scale_config = self.scale_config or get_scale_config();
+            ms_cfg = scale_config.get_microservices_config();
             ingress_cfg: dict[str, any] = ms_cfg.get("ingress", {});
         } except Exception {
             ingress_cfg = {};
@@ -90,8 +92,8 @@ obj MicroserviceManifestBuilder {
     ) -> dict[str, dict[str, any]] {
         app_name = app_config.app_name or self.k8s_config.app_name;
 
-        import from jac_scale.config_loader { get_scale_config }
-        ms_cfg = get_scale_config().get_microservices_config();
+        scale_config = self.scale_config or get_scale_config();
+        ms_cfg = scale_config.get_microservices_config();
         routes: dict[str, str] = ms_cfg.get("routes", {});
 
         if not routes {
@@ -126,8 +128,8 @@ obj MicroserviceManifestBuilder {
     """drain_timeout_seconds (default 10s); sizes terminationGracePeriodSeconds."""
     def _drain_timeout -> int {
         try {
-            import from jac_scale.config_loader { get_scale_config }
-            ms_cfg = get_scale_config().get_microservices_config();
+            scale_config = self.scale_config or get_scale_config();
+            ms_cfg = scale_config.get_microservices_config();
             return int(ms_cfg.get("drain_timeout_seconds", 10));
         } except Exception {
             return 10;
@@ -137,8 +139,8 @@ obj MicroserviceManifestBuilder {
     """Per-service config from [...services.NAME]; {} on read failure."""
     def _service_config(svc_name: str) -> dict[str, any] {
         try {
-            import from jac_scale.config_loader { get_scale_config }
-            ms_cfg = get_scale_config().get_microservices_config();
+            scale_config = self.scale_config or get_scale_config();
+            ms_cfg = scale_config.get_microservices_config();
             return dict(ms_cfg.get("services", {}).get(svc_name, {}));
         } except Exception {
             return {};
@@ -149,8 +151,8 @@ obj MicroserviceManifestBuilder {
     for single-node dev. `services` may include `__gateway__`."""
     def _shared_volumes_config -> list[dict[str, any]] {
         try {
-            import from jac_scale.config_loader { get_scale_config }
-            ms_cfg = get_scale_config().get_microservices_config();
+            scale_config = self.scale_config or get_scale_config();
+            ms_cfg = scale_config.get_microservices_config();
             raw = ms_cfg.get("shared_volumes", []);
             if not isinstance(raw, list) {
                 return [];
@@ -312,8 +314,8 @@ obj MicroserviceManifestBuilder {
     _build_env for `JAC_SV_<PEER>_URL` injection. Returns {} on read failure."""
     def _microservice_routes -> dict[str, str] {
         try {
-            import from jac_scale.config_loader { get_scale_config }
-            ms_cfg = get_scale_config().get_microservices_config();
+            scale_config = self.scale_config or get_scale_config();
+            ms_cfg = scale_config.get_microservices_config();
             return dict(ms_cfg.get("routes", {}));
         } except Exception {
             return {};

--- a/jac-scale/jac_scale/targets/kubernetes/microservice/target.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/microservice/target.jac
@@ -26,6 +26,9 @@ import from jac_scale.targets.kubernetes.microservice.manifest_builder {
 import from jac_scale.targets.kubernetes.microservice.database_provisioner {
     MicroserviceDatabaseProvisioner
 }
+import from pathlib { Path }
+import from jac_scale.config_loader { get_scale_config }
+import from jac_scale.targets.kubernetes.kubernetes_config { KubernetesConfig }
 
 glob logger = logging.getLogger(__name__);
 
@@ -83,8 +86,7 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
         # for remote.
         registry_url: str | None = None;
         try {
-            import from jac_scale.config_loader { get_scale_config }
-            raw = get_scale_config().load();
+            raw = self.scale_config.load();
             k8s_raw = raw.get("kubernetes", {});
             reg = str(k8s_raw.get("image_registry", "")).strip();
             registry_url = reg;
@@ -112,6 +114,12 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
     client. Kubeconfig from outside, in-cluster SA from inside.
     `DeploymentResult.details` keeps the manifest bundle."""
     def deploy(app_config: AppConfig) -> DeploymentResult {
+        # Load the scale config for the deployed app
+        self.scale_config = get_scale_config(Path(app_config.code_folder));
+        self.k8s_config = KubernetesConfig.from_dict(
+            KubernetesConfig, self.scale_config.get_kubernetes_config()
+        );
+
         app_name = app_config.app_name or self.k8s_config.app_name;
         if self.logger {
             self.logger.info(
@@ -197,7 +205,8 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
             k8s_config=self.k8s_config,
             secrets=self.secrets,
             deploy_context=self._deploy_context,
-            logger=self.logger
+            logger=self.logger,
+            scale_config=self.scale_config
         );
         return builder.generate_manifests(app_config, image);
     }

--- a/jac-scale/jac_scale/targets/kubernetes/microservice/target.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/microservice/target.jac
@@ -119,6 +119,8 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
         self.k8s_config = KubernetesConfig.from_dict(
             KubernetesConfig, self.scale_config.get_kubernetes_config()
         );
+        self.k8s_config.app_name = self.config.app_name;
+        self.k8s_config.namespace = self.config.namespace;
 
         app_name = app_config.app_name or self.k8s_config.app_name;
         if self.logger {

--- a/jac-scale/jac_scale/targets/kubernetes/microservice/target.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/microservice/target.jac
@@ -119,8 +119,14 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
         self.k8s_config = KubernetesConfig.from_dict(
             KubernetesConfig, self.scale_config.get_kubernetes_config()
         );
-        self.k8s_config.app_name = self.config.app_name;
-        self.k8s_config.namespace = self.config.namespace;
+
+        # Merge all constructor-supplied overrides that differ from default settings
+        default_config = KubernetesConfig();
+        for (field, value) in self.config.to_dict().items() {
+            if value != default_config.to_dict().get(field) {
+                setattr(self.k8s_config, field, value);
+            }
+        }
 
         app_name = app_config.app_name or self.k8s_config.app_name;
         if self.logger {

--- a/jac-scale/jac_scale/tests/test_config_loader.jac
+++ b/jac-scale/jac_scale/tests/test_config_loader.jac
@@ -54,3 +54,96 @@ test "get_microservices_config preserves all sections (regression guard)" {
     missing = expected_keys - set(out.keys());
     assert not missing , f"missing keys: {missing}";
 }
+
+
+test "get_scale_config implements path-keyed caching" {
+    import from pathlib { Path }
+    import tempfile;
+    import from jac_scale.config_loader {
+        get_scale_config,
+        reset_scale_config,
+        _scale_config_instances
+    }
+
+    reset_scale_config();
+
+    with tempfile.TemporaryDirectory() as tmp1_str, tempfile.TemporaryDirectory() as tmp2_str {
+        tmp1 = Path(tmp1_str).resolve();
+        tmp2 = Path(tmp2_str).resolve();
+        # Write different jac.toml configurations to each directory
+        toml1 = tmp1 / "jac.toml";
+        toml1_content = (
+            "[plugins.scale.kubernetes]\n"
+            "app_name = \"app1\"\n"
+            "image_registry = \"registry1\"\n"
+            "mongodb_root_username = \"user1\"\n"
+            "mongodb_root_password = \"pwd1\"\n"
+            "redis_username = \"redisuser1\"\n"
+            "redis_password = \"redispwd1\"\n"
+            "domain = \"domain1.local\"\n"
+            "cert_manager_email = \"email1@domain1.local\"\n\n"
+            "[plugins.scale.database]\n"
+            "redis_url = \"redis://user1:pwd1@host1:6379\"\n\n"
+            "[plugins.scale.secrets]\n"
+            "api_key = \"secret_key_1\"\n"
+        );
+        toml1.write_text(toml1_content);
+        toml2 = tmp2 / "jac.toml";
+        toml2_content = (
+            "[plugins.scale.kubernetes]\n"
+            "app_name = \"app2\"\n"
+            "image_registry = \"registry2\"\n"
+            "mongodb_root_username = \"user2\"\n"
+            "mongodb_root_password = \"pwd2\"\n"
+            "redis_username = \"redisuser2\"\n"
+            "redis_password = \"redispwd2\"\n"
+            "domain = \"domain2.local\"\n"
+            "cert_manager_email = \"email2@domain2.local\"\n\n"
+            "[plugins.scale.database]\n"
+            "redis_url = \"redis://user2:pwd2@host2:6379\"\n\n"
+            "[plugins.scale.secrets]\n"
+            "api_key = \"secret_key_2\"\n"
+        );
+        toml2.write_text(toml2_content);
+        # Load configurations
+        cfg1 = get_scale_config(tmp1);
+        cfg2 = get_scale_config(tmp2);
+        # 1. Verify separate cache instances are created
+        assert cfg1 is not cfg2;
+        # 2. Verify independent configuration values are correctly parsed
+        # App Names
+        assert cfg1.get_kubernetes_config()["app_name"] == "app1";
+        assert cfg2.get_kubernetes_config()["app_name"] == "app2";
+        # Image Registries
+        assert cfg1.load().get("kubernetes", {}).get("image_registry") == "registry1";
+        assert cfg2.load().get("kubernetes", {}).get("image_registry") == "registry2";
+        # Database URLs
+        assert cfg1.get_database_config()["redis_url"] == "redis://user1:pwd1@host1:6379";
+        assert cfg2.get_database_config()["redis_url"] == "redis://user2:pwd2@host2:6379";
+        # MongoDB Credentials
+        assert cfg1.get_kubernetes_config()["mongodb_root_username"] == "user1";
+        assert cfg2.get_kubernetes_config()["mongodb_root_username"] == "user2";
+        assert cfg1.get_kubernetes_config()["mongodb_root_password"] == "pwd1";
+        assert cfg2.get_kubernetes_config()["mongodb_root_password"] == "pwd2";
+        # Redis Credentials
+        assert cfg1.get_kubernetes_config()["redis_username"] == "redisuser1";
+        assert cfg2.get_kubernetes_config()["redis_username"] == "redisuser2";
+        assert cfg1.get_kubernetes_config()["redis_password"] == "redispwd1";
+        assert cfg2.get_kubernetes_config()["redis_password"] == "redispwd2";
+        # Domain / Ingress Settings
+        assert cfg1.get_kubernetes_config()["domain"] == "domain1.local";
+        assert cfg2.get_kubernetes_config()["domain"] == "domain2.local";
+        assert cfg1.get_kubernetes_config()["cert_manager_email"] == "email1@domain1.local";
+        assert cfg2.get_kubernetes_config()["cert_manager_email"] == "email2@domain2.local";
+        # Custom Secrets
+        assert cfg1.get_secrets_config()["api_key"] == "secret_key_1";
+        assert cfg2.get_secrets_config()["api_key"] == "secret_key_2";
+        # 3. Verify equivalent paths normalize and resolve to the same instance
+        rel_tmp1 = Path(tmp1_str);
+        cfg1_rel = get_scale_config(rel_tmp1);
+        assert cfg1_rel is cfg1;
+        # 4. Verify cache resetting works correctly
+        reset_scale_config();
+        assert len(_scale_config_instances) == 0;
+    }
+}

--- a/jac-scale/jac_scale/tests/test_config_loader.jac
+++ b/jac-scale/jac_scale/tests/test_config_loader.jac
@@ -77,15 +77,15 @@ test "get_scale_config implements path-keyed caching" {
             "app_name = \"app1\"\n"
             "image_registry = \"registry1\"\n"
             "mongodb_root_username = \"user1\"\n"
-            "mongodb_root_password = \"pwd1\"\n"
+            "mongodb_root_password = \"mock-mongodb-root-password-1\"\n"
             "redis_username = \"redisuser1\"\n"
-            "redis_password = \"redispwd1\"\n"
+            "redis_password = \"mock-redis-password-1\"\n"
             "domain = \"domain1.local\"\n"
             "cert_manager_email = \"email1@domain1.local\"\n\n"
             "[plugins.scale.database]\n"
-            "redis_url = \"redis://user1:pwd1@host1:6379\"\n\n"
+            "redis_url = \"redis://user1:mock-redis-url-password-1@host1:6379\"\n\n"
             "[plugins.scale.secrets]\n"
-            "api_key = \"secret_key_1\"\n"
+            "api_key = \"mock-api-key-1\"\n"
         );
         toml1.write_text(toml1_content);
         toml2 = tmp2 / "jac.toml";
@@ -94,15 +94,15 @@ test "get_scale_config implements path-keyed caching" {
             "app_name = \"app2\"\n"
             "image_registry = \"registry2\"\n"
             "mongodb_root_username = \"user2\"\n"
-            "mongodb_root_password = \"pwd2\"\n"
+            "mongodb_root_password = \"mock-mongodb-root-password-2\"\n"
             "redis_username = \"redisuser2\"\n"
-            "redis_password = \"redispwd2\"\n"
+            "redis_password = \"mock-redis-password-2\"\n"
             "domain = \"domain2.local\"\n"
             "cert_manager_email = \"email2@domain2.local\"\n\n"
             "[plugins.scale.database]\n"
-            "redis_url = \"redis://user2:pwd2@host2:6379\"\n\n"
+            "redis_url = \"redis://user2:mock-redis-url-password-2@host2:6379\"\n\n"
             "[plugins.scale.secrets]\n"
-            "api_key = \"secret_key_2\"\n"
+            "api_key = \"mock-api-key-2\"\n"
         );
         toml2.write_text(toml2_content);
         # Load configurations
@@ -118,26 +118,26 @@ test "get_scale_config implements path-keyed caching" {
         assert cfg1.load().get("kubernetes", {}).get("image_registry") == "registry1";
         assert cfg2.load().get("kubernetes", {}).get("image_registry") == "registry2";
         # Database URLs
-        assert cfg1.get_database_config()["redis_url"] == "redis://user1:pwd1@host1:6379";
-        assert cfg2.get_database_config()["redis_url"] == "redis://user2:pwd2@host2:6379";
+        assert cfg1.get_database_config()["redis_url"] == "redis://user1:mock-redis-url-password-1@host1:6379";
+        assert cfg2.get_database_config()["redis_url"] == "redis://user2:mock-redis-url-password-2@host2:6379";
         # MongoDB Credentials
         assert cfg1.get_kubernetes_config()["mongodb_root_username"] == "user1";
         assert cfg2.get_kubernetes_config()["mongodb_root_username"] == "user2";
-        assert cfg1.get_kubernetes_config()["mongodb_root_password"] == "pwd1";
-        assert cfg2.get_kubernetes_config()["mongodb_root_password"] == "pwd2";
+        assert cfg1.get_kubernetes_config()["mongodb_root_password"] == "mock-mongodb-root-password-1";
+        assert cfg2.get_kubernetes_config()["mongodb_root_password"] == "mock-mongodb-root-password-2";
         # Redis Credentials
         assert cfg1.get_kubernetes_config()["redis_username"] == "redisuser1";
         assert cfg2.get_kubernetes_config()["redis_username"] == "redisuser2";
-        assert cfg1.get_kubernetes_config()["redis_password"] == "redispwd1";
-        assert cfg2.get_kubernetes_config()["redis_password"] == "redispwd2";
+        assert cfg1.get_kubernetes_config()["redis_password"] == "mock-redis-password-1";
+        assert cfg2.get_kubernetes_config()["redis_password"] == "mock-redis-password-2";
         # Domain / Ingress Settings
         assert cfg1.get_kubernetes_config()["domain"] == "domain1.local";
         assert cfg2.get_kubernetes_config()["domain"] == "domain2.local";
         assert cfg1.get_kubernetes_config()["cert_manager_email"] == "email1@domain1.local";
         assert cfg2.get_kubernetes_config()["cert_manager_email"] == "email2@domain2.local";
         # Custom Secrets
-        assert cfg1.get_secrets_config()["api_key"] == "secret_key_1";
-        assert cfg2.get_secrets_config()["api_key"] == "secret_key_2";
+        assert cfg1.get_secrets_config()["api_key"] == "mock-api-key-1";
+        assert cfg2.get_secrets_config()["api_key"] == "mock-api-key-2";
         # 3. Verify equivalent paths normalize and resolve to the same instance
         rel_tmp1 = Path(tmp1_str);
         cfg1_rel = get_scale_config(rel_tmp1);


### PR DESCRIPTION

## Summary
When `jac-scale` is used programmatically from a long-lived host process (e.g., `jacBuilder` deploying multiple user applications), the host's own `jac.toml` infrastructure settings leak into and override every user deployment. This happens because the global `get_scale_config()` helper caches a single instance of `JacScaleConfig` on its first invocation and discards subsequent path arguments.

Beyond database PVC storage size, this leakage affects:
* `image_registry` (deployments could push/pull from the host's registry instead of the user's)
* `redis_url` and Redis credentials (`redis_username`, `redis_password`)
* MongoDB credentials (`mongodb_root_username`, `mongodb_root_password`)
* Ingress and Ingress-TLS settings (`domain`, `cert_manager_email`)
* custom settings under `[plugins.scale.secrets]`

This PR introduces surgical, fully backward-compatible path-keyed configuration caching to isolate config loaders per-project, alongside configuration injection in deployment targets, database providers, and the microservice manifest builder.

---


## Proposed Changes

### 1. Per-Path Configuration Caching (`config_loader`)
* Replaced the single global `_scale_config_instance` variable in `config_loader.jac` with a path-keyed dictionary cache (`_scale_config_instances`).
* `get_scale_config(project_dir)` now resolves the path to an absolute path (`Path.resolve()`) and caches the corresponding config uniquely for that path.
* `reset_scale_config()` clears the cached instances in-place using `.clear()` to ensure all imported dictionary references in test modules stay in sync.

### 2. Isolation of Targets (`KubernetesTarget` & `KubernetesMicroserviceTarget`)
* Added class property for `scale_config` on `KubernetesTarget`.
* Re-resolve `self.scale_config` and `self.k8s_config` inside `deploy(app_config)` immediately on entry using `app_config.code_folder`. This isolates target fields from host configurations.

### 3. Provider Configuration Injection
* In `kubernetes_target.jac`'s `_deploy_databases`, we construct a combined `KubernetesConfig` + `DatabaseConfig` dict derived from the user's active `scale_config` and inject it when instantiating database providers via `DatabaseProviderFactory.create`.
* Updated `kubernetes_mongo.jac` and `kubernetes_redis.jac` to check `self.config` first before falling back to `get_scale_config()` for all configuration settings.

### 4. Manifest Builder Configuration Threading
* Threaded `self.scale_config` into `MicroserviceManifestBuilder` in microservice mode.
* Replaced global `get_scale_config()` calls within helper methods (`_drain_timeout()`, `_service_config()`, `_shared_volumes_config()`, `_microservice_routes()`) with a lookup on the threaded `self.scale_config` (falling back to global lookup for backward compatibility).

---

## Verification & Testing

### 1. Expanded Caching Unit Tests
Added unit tests to `test_config_loader.jac` verifying:
* **Path-keyed isolation**: Two separate temporary project directories parse their respective `jac.toml` files independently with zero leakage (explicitly asserting isolation on app names, registries, database URLs, credentials, domains, and secrets).
* **Path normalization/equivalence**: Normalizing absolute vs. relative paths to the same directory maps to the same cached loader instance.
* **Cache resetting**: Hermetic cleaning of all instances via `.clear()`.
