### PR TITLE
fix(type-checker): apply the descriptor protocol on member access

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6300.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6300.bugfix.md
@@ -1,0 +1,1 @@
+- Accessing an attribute whose type is a descriptor (a class defining `__get__`) now resolves to the value `__get__` returns instead of the descriptor object, so using that attribute no longer raises spurious type errors.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -882,6 +882,51 @@ impl TypeEvaluator.get_getter_type_from_property(
     return func_type.return_type;
 }
 
+"""Descriptor protocol: type of `obj.attr` when `attr`'s type defines __get__.
+
+Instance access evaluates to __get__'s return type. `owner_inst` (an instance
+of the accessed class) selects the instance-access overload over the
+class-access one by assignability to its `obj` parameter; TypeVars are bound
+from the descriptor instance. Returns None when `member_ty` is not a descriptor.
+"""
+impl TypeEvaluator._resolve_descriptor_get(
+    member_ty: TypeBase, owner_inst: TypeBase
+) -> (TypeBase | None) {
+    if not isinstance(member_ty, types.ClassType) or not member_ty.is_instance() {
+        return None;
+    }
+    get_member = self._lookup_class_member(member_ty, "__get__");
+    if get_member is None {
+        return None;
+    }
+    base = self.get_type_of_symbol(get_member.symbol);
+    overloads = [base] + [self.get_type_of_symbol(o) for o in get_member.overloads];
+    fallback: TypeBase | None = None;
+    for fn in overloads {
+        if not isinstance(fn, types.FunctionType) {
+            continue;
+        }
+        spec = fn.specialize(member_ty);
+        params = spec.parameters or [];
+        if len(params) < 2 or params[1].param_type is None {
+            continue;
+        }
+        if spec.return_type is None
+        or isinstance(spec.return_type, types.UnknownType) {
+            continue;
+        }
+        # Select the overload whose `obj` parameter accepts the owner instance.
+        # The class-access overload takes None and is not selected.
+        if self.assign_type(owner_inst, params[1].param_type) {
+            return spec.return_type;
+        }
+        if fallback is None {
+            fallback = spec.return_type;
+        }
+    }
+    return fallback;
+}
+
 """Classify a symbol's writability for property-aware assignment checking.
 
 Delegates to _classify_property_symbol for the decorator walk, then

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -889,6 +889,18 @@ impl TypeEvaluator._get_type_of_expression_core(
                             expr.right.type = cfg_narrowed or prop_return_type;
                             return expr.right.type;
                         }
+                        # Descriptor protocol: a member whose type defines
+                        # __get__ evaluates to that method's result.
+                        if desc_ty := self._resolve_descriptor_get(
+                            member_ty, base_type
+                        ) {
+                            member.symbol.add_use(expr.right);
+                            cfg_narrowed = self.get_narrowed_type_for_expr(
+                                expr, desc_ty, expr
+                            );
+                            expr.right.type = cfg_narrowed or desc_ty;
+                            return expr.right.type;
+                        }
                         # NOTE: If this atom trailer is called `<atom_trailer>()` we can resolve
                         # which overload is being called based on the arguments, and update the type
                         # based on the call, maybe for future.

--- a/jac/jaclang/compiler/type_system/type_evaluator.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.jac
@@ -407,6 +407,10 @@ obj TypeEvaluator {
     def _classify_property_symbol(symbol: uni.Symbol) -> type_utils.PropertyWriteKind;
     # Property type utilities — both delegate to _classify_property_symbol.
     def get_getter_type_from_property(symbol: uni.Symbol) -> (TypeBase | None);
+    # Descriptor protocol: instance-access type of a member defining __get__.
+    def _resolve_descriptor_get(
+        member_ty: TypeBase, owner_inst: TypeBase
+    ) -> (TypeBase | None);
     # Classifies a property symbol's writability for assignment checking.
     # Returns a PropertyWriteResult with kind:
     #   NOT_PROPERTY → normal field, caller should fall through

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_descriptor_get.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_descriptor_get.jac
@@ -1,0 +1,12 @@
+"""Fixture: a Python descriptor (defines __get__) is unwrapped on access.
+
+Expected: 0 errors. `r.rowcount` resolves to __get__'s instance-access return
+(int), not the descriptor object, so the comparison typechecks.
+"""
+
+import from checker_descriptor_get_mod { Result }
+
+def use_it {
+    r = Result();
+    x = r.rowcount > 0;
+}

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_descriptor_get_mod.py
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_descriptor_get_mod.py
@@ -1,0 +1,21 @@
+# Fixture modeling a generic descriptor; loose annotations are intentional.
+# ruff: noqa: ANN401, N801
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar, overload
+
+_T_co = TypeVar("_T_co", covariant=True)
+
+
+class memoized_property(Generic[_T_co]):
+    fget: Callable[..., _T_co]
+
+    def __init__(self, fget: Callable[..., _T_co]) -> None: ...
+    @overload
+    def __get__(self, obj: None, cls: Any) -> "memoized_property[_T_co]": ...
+    @overload
+    def __get__(self, obj: object, cls: Any) -> _T_co: ...
+    def __get__(self, obj, cls): ...
+
+
+class Result:
+    rowcount: memoized_property[int]

--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -30,6 +30,7 @@ Bug index:
   #STUB-VGUARD - Module-level version-guarded stub symbols (e.g. datetime.UTC) resolve as Unknown
   #HOGEN-1 - TypeVars not bound through function-typed args; blocks generic decorator-application
   #WITHAS-1 - `with cm() as x` bound x to the manager not __enter__'s result; async with used sync protocol
+  #DESC-1 - Descriptor member (defines __get__) not unwrapped to __get__'s instance-access result
 """
 
 import os;
@@ -882,6 +883,18 @@ test "bug_withas_1_async_with_as_binds_and_checks" {
     assert program.errors_had == [] , (
         "Bug #WITHAS-1: `async with cm() as x` must verify the async protocol "
         "and bind x to the awaited __aenter__ result. "
+        f"Got errors: {[str(e) for e in program.errors_had]}"
+    );
+}
+
+# Bug #DESC-1: a member whose type is a descriptor (defines __get__) resolved
+# to the descriptor object rather than __get__'s result. Member access now
+# applies the descriptor protocol.
+test "bug_desc_1_descriptor_get_unwrapped" {
+    program = compile_and_check("checker_descriptor_get.jac");
+    assert program.errors_had == [] , (
+        "Bug #DESC-1: a descriptor member must resolve to __get__'s "
+        "instance-access return type, not the descriptor object. "
         f"Got errors: {[str(e) for e in program.errors_had]}"
     );
 }


### PR DESCRIPTION
## What

When an attribute's type is a descriptor (a class defining `__get__`), instance access now resolves to `__get__`'s return type instead of the descriptor object.

The accessing instance selects the instance-access `__get__` overload (by assignability to its `obj` parameter) over the class-access one (`obj: None`), and TypeVars are bound from the descriptor instance — so e.g. a `Descriptor[int]` member resolves to `int`. Builtin `property` / `cached_property` keep their existing dedicated handling and are unaffected.

## Why

Member access previously returned the descriptor object itself for any descriptor other than the builtin `property`/`cached_property` special cases. Accessing such a member (common with library descriptors that implement `__get__`) therefore produced spurious type errors (e.g. an operator not supported on the descriptor object). This generalizes member access to the descriptor protocol.

This mirrors Pyright's `applyDescriptorAccessMethod`: on member access, if the member defines `__get__`, evaluate it and use its return. (Pyright builds a synthetic call through `validateCallArgs`; here the matching overload is chosen directly via assignability, since Jac's call machinery is AST-node-keyed — consistent with how existing magic-method resolution already works.)

## Tests

- New `bug_desc_1_descriptor_get_unwrapped`: a descriptor member resolves to `__get__`'s instance-access return type.
- Builtin `@property`/`@cached_property` unchanged; full checker (`test_checker_bugs`, 42) and language (93) suites pass with no regressions.