### PR TITLE
fix(type-checker): False E1001 on typed variables declared inside loops/branches

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6308.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6308.bugfix.md
@@ -1,0 +1,1 @@
+- **Declaring a typed variable inside a `for`/`while`/`if` block no longer raises false "Cannot assign" errors**: code like `for x in items { result: str | None = None; if cond { result = "a"; } else { result = maybe_str(); } }` was being rejected on the `else` branch. Both branches now correctly assign to the same variable.

--- a/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
@@ -720,10 +720,8 @@ impl bind_assignment_targets(nd: uni.Assignment) -> None {
     import from jaclang.jac0core.constant { SymbolType }
     import from jaclang.jac0core.helpers { evaluate_version_condition }
 
-    # True if any IfStmt/ElseIf/ElseStmt ancestor up to the nearest Python
-    # scope is part of a `sys.version_info` / `TYPE_CHECKING` guard chain.
-    # Such symbols must remain in the inner scope so the type layer's
-    # `collect_member_syms` can filter dead branches at lookup time.
+    # True if any ancestor up to the nearest Python scope is a
+    # sys.version_info / TYPE_CHECKING guard — those stay in the inner scope.
     def inside_version_conditional(start: uni.UniNode) -> bool {
         scope_types = uni.UniScopeNode.get_python_scoping_nodes();
         cur = start.parent;
@@ -770,13 +768,8 @@ impl bind_assignment_targets(nd: uni.Assignment) -> None {
                 i.sym_tab, uni.UniScopeNode.get_python_scoping_nodes()
             )
             and not inside_version_conditional(i) {
-                # Python has no block scope: any assignment inside if/for/
-                # while/try binds in the enclosing function scope, both for
-                # annotated (`x: T = v`) and unannotated (`x = v`) forms.
-                # Exception: `sys.version_info` / `TYPE_CHECKING` guards keep
-                # their declarations in the inner scope so the type layer's
-                # `collect_member_syms` filters dead branches at lookup time
-                # (see PR #6429).
+                # Python has no block scope — hoist to function scope for both
+                # annotated and unannotated forms, except version guards (#6429).
                 py_scope = find_python_scope_node_of(i);
                 if py_scope is not None {
                     if (

--- a/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
@@ -718,6 +718,32 @@ impl def_insert_unpacking(
 
 impl bind_assignment_targets(nd: uni.Assignment) -> None {
     import from jaclang.jac0core.constant { SymbolType }
+    import from jaclang.jac0core.helpers { evaluate_version_condition }
+
+    # True if any IfStmt/ElseIf/ElseStmt ancestor up to the nearest Python
+    # scope is part of a `sys.version_info` / `TYPE_CHECKING` guard chain.
+    # Such symbols must remain in the inner scope so the type layer's
+    # `collect_member_syms` can filter dead branches at lookup time.
+    def inside_version_conditional(start: uni.UniNode) -> bool {
+        scope_types = uni.UniScopeNode.get_python_scoping_nodes();
+        cur = start.parent;
+        while cur and not isinstance(cur, scope_types) {
+            guard: (uni.IfStmt | None) = None;
+            if isinstance(cur, uni.IfStmt) {
+                guard = cur;
+            } elif isinstance(cur, uni.ElseStmt)
+            and isinstance(cur.parent, uni.IfStmt) {
+                guard = cur.parent;
+            }
+            if guard is not None
+            and evaluate_version_condition(guard.condition) is not None {
+                return True;
+            }
+            cur = cur.parent;
+        }
+        return False;
+    }
+
     for i in nd.target {
         if isinstance(i, uni.AstSymbolNode) {
             if isinstance(i, (uni.ListVal, uni.TupleVal)) {
@@ -740,16 +766,17 @@ impl bind_assignment_targets(nd: uni.Assignment) -> None {
                 # the enclosing ability (not an archetype). Assignments to these
                 # names in nested abilities are state mutations, not new locals.
                 outer_has.add_use(i.name_spec);
-            } elif (
-                (nd.type_tag is None)
-                and not isinstance(
-                    i.sym_tab, uni.UniScopeNode.get_python_scoping_nodes()
-                )
-            ) {
-                # Python semantics: an unannotated assignment inside a non-scoping
-                # block (try/except/finally, if/else, for/while, match) binds in
-                # the nearest enclosing Python scope, not in the inner block.
-                # Mirrors the walrus handling in exit_binary_expr.
+            } elif not isinstance(
+                i.sym_tab, uni.UniScopeNode.get_python_scoping_nodes()
+            )
+            and not inside_version_conditional(i) {
+                # Python has no block scope: any assignment inside if/for/
+                # while/try binds in the enclosing function scope, both for
+                # annotated (`x: T = v`) and unannotated (`x = v`) forms.
+                # Exception: `sys.version_info` / `TYPE_CHECKING` guards keep
+                # their declarations in the inner scope so the type layer's
+                # `collect_member_syms` filters dead branches at lookup time
+                # (see PR #6429).
                 py_scope = find_python_scope_node_of(i);
                 if py_scope is not None {
                     if (

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_bug_annotated_decl_in_loop.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_bug_annotated_decl_in_loop.jac
@@ -1,0 +1,20 @@
+"""Bug #SCOPE-1: annotated decl inside a loop body created a duplicate
+symbol, breaking narrowing across if/elif branches.
+
+Expected: 0 errors.
+"""
+
+def maybe_str() -> str | None {
+    return None;
+}
+
+def test(items: list[int]) -> None {
+    for it in items {
+        result: str | None = None;
+        if it > 0 {
+            result = "hello";
+        } elif it < 0 {
+            result = maybe_str();
+        }
+    }
+}

--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -33,6 +33,7 @@ Bug index:
   #UNPACK-1 - Assignment unpacking of a non-tuple iterable (bytes/str/range) typed targets as Unknown
   #BYTES-1 - Byte-string literals (b"...") typed as str instead of bytes
   #EVOLVING-NONE - `x = None` then reassign inside `if` lost the new type post-branch
+  #SCOPE-1 - Annotated decl `x: T = v` inside loop/if block created duplicate symbol; broke narrowing
 """
 
 import os;
@@ -916,5 +917,15 @@ test "bug_evolving_none_narrowing" {
         "Bug #EVOLVING-NONE: `x = None; if cond { x = real_value; }; return x;` "
         "must narrow to the assigned type post-branch (Pyright evolving-locals). "
         f"Got errors: {[str(e) for e in program.errors_had]}"
+    );
+}
+
+# Bug #SCOPE-1: annotated decl `x: T = v` inside a loop body was placed
+# in the inner block scope while bare reassigns bound to the function
+# scope, splitting the variable into two symbols and breaking narrowing.
+test "bug_scope_1_annotated_decl_in_loop_no_duplicate_symbol" {
+    program = compile_and_check("checker_bug_annotated_decl_in_loop.jac");
+    assert program.errors_had == [] , (
+        f"Bug #SCOPE-1: got errors: {[str(e) for e in program.errors_had]}"
     );
 }


### PR DESCRIPTION
### Problem

Code like this triggered a false error:

```jac
def test(items: list) -> None {
    for it in items {
        result: str | None = None;
        if it > 0 {
            result = "hello";
        } else {
            result = None;        # ← false error here
        }
    }
}
```

The error:
```
error[E1001]: Cannot assign str | NoneType to Literal["hello"]
```

The code is valid — `result` is declared as `str | None`, so both branches assign valid values. But the type checker rejected the `else` branch.

The same code **outside** a loop worked fine. The bug only triggered when the typed declaration was inside a `for`/`while`/`if` block.

### Why It Was Failing

The compiler tracks variables in a "symbol table". For Python (and Jac), the rule is: a variable belongs to its **function**, not to inner blocks like `if`/`for`/`while`.

The compiler followed this rule for plain assignments (`x = value`), but had an oversight for **typed declarations** (`x: T = value`) — those were being placed in the inner block instead of the function.

So when you mix the two inside a loop, Jac would create **two separate variables** with the same name, and the type checker would compare assignments against the wrong one.

### Symbol Table

**Before fix:**
```
Ability(test_with_for)
├── Symbols
│   └── result                       ← Symbol B (created by bare assignment)
│       ├── decl: line 19            (`result = "hello"`)
│       └── uses: line 21            (`result = maybe_str()`)
└── Sub Tables
    └── InForStmt
        └── Symbols
            └── result               ← Symbol A (created by typed declaration)
                ├── decl: line 17    (`result: str | None = None`)
                └── uses: line 23    (`print(result)`)
```

**After fix:**
```
Ability(test_with_for)
├── Symbols
│   └── result                       ← single symbol
│       ├── decl: line 17            (the typed declaration)
│       └── uses: lines 19, 21, 23   (all assignments and reads)
└── Sub Tables
    └── InForStmt
        └── (only `it` here, no shadow result)
```

### Result

```
Codebase-wide:
Removed:        187 errors (no regressions)
```