### PR TITLE
fix(jaclang): avoid duplicate UniTree enrich in type check

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6323.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6323.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Avoid duplicate UniTree enrichment**: Prevent `jac check` from rerunning `UniTreeEnrichPass` after IR generation so native compatibility state is produced only once.

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -137,15 +137,15 @@ def get_type_check_sched -> list[type[Transform[uni.Module, uni.Module]]] {
         import from jaclang.compiler.passes.main.portability_check_pass {
             PortabilityCheckPass
         }
-        import from jaclang.compiler.passes.main.unitree_enrich_pass {
-            UniTreeEnrichPass
-        }
         import from jaclang.compiler.passes.tool.jac_auto_lint_pass { JacLintCheckPass }
+        # UniTreeEnrichPass is intentionally omitted: it already runs at
+        # the tail of get_ir_gen_sched() and its exit_module rewrites
+        # native_compat non-idempotently, corrupting NaIRGenPass state
+        # if run a second time. See #6323.
         return [
             TypeCheckPass,
             StaticAnalysisPass,
             PortabilityCheckPass,
-            UniTreeEnrichPass,
             JacLintCheckPass
         ];
     } except ImportError {

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -744,8 +744,9 @@ impl JacCompiler.compile(
     }
     if run_type_check {
         # Explicit `jac check` (options.type_check=True) runs the full
-        # schedule — TypeCheckPass + StaticAnalysis + Portability + the
-        # enrich-pass-second-pass + Lint.
+        # diagnostics schedule. UniTreeEnrichPass is intentionally not part of
+        # that schedule because get_ir_gen_sched() already ran it once and its
+        # native_compat pass state must not be recomputed from a partial walk.
         #
         # The implicit native run (.na.jac trigger) only needs Expr.type
         # populated for NaIRGenPass, so it runs the inference-only schedule

--- a/jac/tests/compiler/test_compiler_schedules.jac
+++ b/jac/tests/compiler/test_compiler_schedules.jac
@@ -1,0 +1,29 @@
+"""Tests for compiler pass schedule invariants."""
+
+import from jaclang.jac0core.compiler {
+    get_ir_gen_sched,
+    get_type_check_sched,
+    get_native_inference_sched
+}
+import from jaclang.compiler.passes.main.type_checker_pass { TypeCheckPass }
+import from jaclang.compiler.passes.main.unitree_enrich_pass { UniTreeEnrichPass }
+
+
+test "type check schedule does not rerun unitree enrich" {
+    ir_sched = get_ir_gen_sched();
+    type_check_sched = get_type_check_sched();
+    native_inference_sched = get_native_inference_sched();
+
+    assert UniTreeEnrichPass in ir_sched , (
+        "IR generation should be the single producer of UniTreeEnrichPass state"
+    );
+    assert TypeCheckPass in type_check_sched , (
+        "explicit type checking should still run TypeCheckPass"
+    );
+    assert UniTreeEnrichPass not in type_check_sched , (
+        "explicit type checking must not rerun UniTreeEnrichPass"
+    );
+    assert native_inference_sched == [TypeCheckPass] , (
+        "implicit native inference should remain TypeCheckPass-only"
+    );
+}


### PR DESCRIPTION
Fixes #6323

Summary:
- Remove UniTreeEnrichPass from the explicit type-check schedule because IR generation already owns that pass.
- Update the compiler pipeline comment to match the schedule.
- Add a schedule regression test that keeps UniTreeEnrichPass out of type-check and native inference.
- Add the jaclang release-note fragment.

Root cause:
- UniTreeEnrichPass records native compatibility state from its pass-local walk. Running it again after IR generation can recompute native_compat from a different context and corrupt native auto-promotion state.

Tests:
- PYTHONPATH=/Users/raghavendramachikatla/jaseci/jac python3 -m jaclang test jac/tests/compiler/test_compiler_schedules.jac --verbose
- PYTHONPATH=/Users/raghavendramachikatla/jaseci/jac python3 -m jaclang test jac/tests/compiler/passes/native/test_native_gen_pass.jac --test_name auto_promote_chess_jac_detects_native_compatible --verbose
- git diff --check