### PR TITLE
Fix bytes + str type checking

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6446.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6446.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Reject mixed bytes and string addition**: Resolve chained imported type aliases in stdlib stubs so `bytes.__add__` checks `Buffer` instead of accepting any argument.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -827,25 +827,70 @@ impl TypeEvaluator._set_symbol_to_expr(expr: uni.Expr, sym: uni.Symbol) -> TypeB
 
 """Resolve the imported symbols to the actual symbol."""
 impl TypeEvaluator.resolve_imported_symbols(sym: uni.Symbol) -> uni.Symbol {
-    if (
-        isinstance(sym.decl, uni.Name) and sym.decl.find_parent_of_type(uni.ModuleItem)
+    resolved = sym;
+    seen: set[int] = set();
+    while (
+        isinstance(resolved.decl, uni.Name)
+        and resolved.decl.find_parent_of_type(uni.ModuleItem)
     ) {
-        mod_item = sym.decl.find_parent_of_type(uni.ModuleItem);
+        if id(resolved) in seen {
+            return resolved;
+        }
+        seen.add(id(resolved));
+        mod_item = resolved.decl.find_parent_of_type(uni.ModuleItem);
         assert (mod_item is not None);
         self.get_type_of_module(mod_item.from_mod_path);
-        if isinstance(mod_item.name, uni.Name) and mod_item.name.sym {
-            return mod_item.name.sym;
+        if (
+            isinstance(mod_item.name, uni.Name)
+            and mod_item.name.sym
+            and mod_item.name.sym is not resolved
+        ) {
+            resolved = mod_item.name.sym;
+            continue;
         }
         # Symbol not resolved yet - call get_type_of_module_item to set it up.
         # This is needed when modules are loaded from JIR cache and their
         # import statements haven't been processed by the type evaluator.
         self.get_type_of_module_item(mod_item);
-        if isinstance(mod_item.name, uni.Name) and mod_item.name.sym {
-            return mod_item.name.sym;
+        if (
+            isinstance(mod_item.name, uni.Name)
+            and mod_item.name.sym
+            and mod_item.name.sym is not resolved
+        ) {
+            resolved = mod_item.name.sym;
+            continue;
         }
-        return sym;
+        if isinstance(mod_item.name, uni.Name)
+        and (import_node := mod_item.parent_of_type(uni.Import))
+        and import_node.from_loc
+        and isinstance(
+            from_mod_type := self.get_type_of_module(import_node.from_loc),
+            types.ModuleType
+        )
+        and from_mod_type.symbol_table {
+            target_sym = type_utils.lookup_symtab(
+                from_mod_type.symbol_table,
+                mod_item.name.value,
+                self.builtins_module
+            );
+            if target_sym is None and isinstance(from_mod_type.symbol_table, uni.Module) {
+                target_sym = self._resolve_star_import_symbol(
+                    from_mod_type.symbol_table,
+                    mod_item.name.value
+                );
+            }
+            if target_sym and target_sym is not resolved {
+                mod_item.name.sym = target_sym;
+                if mod_item.alias {
+                    mod_item.alias.sym = target_sym;
+                }
+                resolved = target_sym;
+                continue;
+            }
+        }
+        return resolved;
     }
-    return sym;
+    return resolved;
 }
 
 """Set symbol and type for a module item node and its alias if present."""

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/imported.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/imported.impl.jac
@@ -200,14 +200,18 @@ impl TypeEvaluator._resolve_star_import_symbol(
         }
         # Resolve the submodule path (e.g., .queues -> asyncio/queues.pyi).
         resolved = star_mod_path.resolve_relative_path_list();
-        if not resolved or len(resolved) < 2 {
+        if not resolved {
             continue;
         }
         submod_base = resolved[-1];  # e.g., ".../asyncio/queues"
         # Try common extensions to find the actual file.
         submod: uni.Module | None = None;
-        for ext in (".pyi", ".py", ".jac") {
-            candidate = submod_base + ext;
+        candidate_paths: list[str] = (
+            [submod_base]
+            if submod_base.endswith((".pyi", ".py", ".jac"))
+            else [submod_base + ext for ext in (".pyi", ".py", ".jac")]
+        );
+        for candidate in candidate_paths {
             if Path(candidate).exists() {
                 submod = self._import_module_from_path(
                     candidate, importer_path=self._resolve_importer_path(mod)

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_bug_bytes_str_add.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_bug_bytes_str_add.jac
@@ -1,0 +1,13 @@
+"""Fixture for #6446: bytes + str must not match bytes.__add__."""
+
+def bytes_plus_str(b: bytes, s: str) -> any {
+    return b + s;          # Error: str is not a readable buffer
+}
+
+def str_plus_bytes(b: bytes, s: str) -> any {
+    return s + b;          # Error: bytes is not a str
+}
+
+def bytes_plus_bytes(a: bytes, b: bytes) -> bytes {
+    return a + b;          # OK
+}

--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -31,6 +31,7 @@ Bug index:
   #HOGEN-1 - TypeVars not bound through function-typed args; blocks generic decorator-application
   #WITHAS-1 - `with cm() as x` bound x to the manager not __enter__'s result; async with used sync protocol
   #UNPACK-1 - Assignment unpacking of a non-tuple iterable (bytes/str/range) typed targets as Unknown
+  #6446   - Chained imported TypeAlias targets collapsed to Unknown, allowing bytes + str
 """
 
 import os;
@@ -892,6 +893,24 @@ test "bug_withas_1_async_with_as_binds_and_checks" {
     assert program.errors_had == [] , (
         "Bug #WITHAS-1: `async with cm() as x` must verify the async protocol "
         "and bind x to the awaited __aenter__ result. "
+        f"Got errors: {[str(e) for e in program.errors_had]}"
+    );
+}
+
+# Bug #6446: `bytes.__add__` takes ReadableBuffer, which is a chained alias
+# through `_typeshed -> typing_extensions -> collections.abc`. The import
+# resolver stopped at the intermediate imported Buffer symbol, so the parameter
+# became Unknown and accepted `bytes + str`.
+test "bug_6446_bytes_str_add_rejected" {
+    program = compile_and_check("checker_bug_bytes_str_add.jac");
+    e1055 = [
+        e
+        for e in program.errors_had
+        if e.code and e.code.code == "E1055"
+    ];
+    assert len(e1055) == 2 and len(program.errors_had) == 2 , (
+        "Bug #6446: bytes + str and str + bytes must both reject with E1055, "
+        "while bytes + bytes remains valid. "
         f"Got errors: {[str(e) for e in program.errors_had]}"
     );
 }


### PR DESCRIPTION
## Summary
- Resolve chained imported symbols so stdlib aliases like `_typeshed.ReadableBuffer` reach the real `collections.abc.Buffer` protocol.
- Allow star-import re-export resolution for already-resolved `.pyi` paths such as `collections/abc.pyi -> _collections_abc.pyi`.
- Add a regression for #6446 proving `bytes + str` and `str + bytes` reject while `bytes + bytes` remains valid.

Fixes #6446

## Tests
- `PYTHONPATH=/Users/raghavendramachikatla/jaseci/jac python3 -m jaclang test jac/tests/compiler/passes/main/test_checker_bugs.jac --test_name bug_6446_bytes_str_add_rejected --verbose`
- `PYTHONPATH=/Users/raghavendramachikatla/jaseci/jac python3 -m jaclang test jac/tests/compiler/passes/main/test_checker_bugs.jac --verbose`
- `PYTHONPATH=/Users/raghavendramachikatla/jaseci/jac python3 -m jaclang test jac/tests/compiler/passes/main/test_sym_tab_build_pass.jac --verbose`
- `git diff --check`