### PR TITLE
feat(planner): cross-root chain resolution for multi-hop queries

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6565.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6565.feature.md
@@ -1,0 +1,1 @@
+- **Feat: Cross-root chain resolution**: Add `resolve_chain_cross_root` to TopologyIndex so multi-hop queries crossing user boundaries stay on the fast path (topology index → materialize) instead of falling back to edge-walk. Gated by `[run] cross_root_resolve = true` in jac.toml.

--- a/jac/jaclang/project/config.jac
+++ b/jac/jaclang/project/config.jac
@@ -49,6 +49,7 @@ obj RunConfig {
         cache: bool = True,
         autonative: bool = False,
         topology_index: bool = True,
+        cross_root_resolve: bool = False,
         diagnostics: str = "error";  # "error" | "all" | "none"
 }
 

--- a/jac/jaclang/project/impl/config.impl.jac
+++ b/jac/jaclang/project/impl/config.impl.jac
@@ -856,6 +856,7 @@ impl _parse_toml_data(
             cache=run_data.get("cache", True),
             autonative=run_data.get("autonative", False),
             topology_index=run_data.get("topology_index", True),
+            cross_root_resolve=run_data.get("cross_root_resolve", False),
             diagnostics=run_data.get("diagnostics", "error")
         );
     }

--- a/jac/jaclang/runtimelib/impl/planner.impl.jac
+++ b/jac/jaclang/runtimelib/impl/planner.impl.jac
@@ -497,6 +497,20 @@ impl plan_chain(
     if not isinstance(idx, TopologyIndex) or len(idx) == 0 {
         return None;
     }
+    # Cross-root resolution: resolve multi-hop chains across user boundaries
+    # by hopping between topology indices. Gated by config flag.
+    if len(chain) > 1 {
+        import from jaclang.project.config { get_config }
+        cfg = get_config();
+        if cfg is not None and cfg.run.cross_root_resolve {
+            import from jaclang { JacRuntimeInterface }
+            ctx = JacRuntimeInterface.get_context();
+            result = idx.resolve_chain_cross_root(ctx.mem, origin_ids, chain);
+            if result {
+                return result;
+            }
+        }
+    }
     return idx.resolve_chain(origin_ids, chain, bail_on_intermediate_foreign=True);
 }
 

--- a/jac/jaclang/runtimelib/impl/topology_index.impl.jac
+++ b/jac/jaclang/runtimelib/impl/topology_index.impl.jac
@@ -514,6 +514,9 @@ impl TopologyIndex.resolve_chain_cross_root(
         is_last = hop_idx == len(chain) - 1;
         next_frontier: list[tuple[TopologyIndex, set[UUID]]] = [];
         result_ids: set[UUID] = set();
+        # Accumulate foreign node IDs per root across all frontier entries
+        # so each foreign index is queried once with the full union of IDs.
+        pending_foreign: dict[UUID, set[UUID]] = {};
         for (idx, ids) in frontier {
             hop_result = idx.resolve_chain(ids, [hop]);
             if not hop_result {
@@ -531,29 +534,37 @@ impl TopologyIndex.resolve_chain_cross_root(
                     next_frontier.append((idx, local_ids));
                 }
                 for (foreign_root_id, foreign_node_ids) in cross_root_map.items() {
-                    try {
-                        root_anchor = mem.get(foreign_root_id);
-                        if not isinstance(root_anchor, NodeAnchor) {
-                            _logger.warning(
-                                "cross-root resolve: root %s is not a NodeAnchor, "
-                                "falling back to edge walk",
-                                foreign_root_id
-                            );
-                            return None;
-                        }
-                        foreign_idx = root_anchor.get_topology_index();
-                        if foreign_idx is not None and len(foreign_idx) > 0 {
-                            next_frontier.append((foreign_idx, foreign_node_ids));
-                        }
-                    } except Exception as exc {
+                    pending_foreign.setdefault(foreign_root_id, set()).update(
+                        foreign_node_ids
+                    );
+                }
+            }
+        }
+        # Resolve each foreign root once with the merged node set.
+        if not is_last {
+            for (foreign_root_id, foreign_node_ids) in pending_foreign.items() {
+                try {
+                    root_anchor = mem.get(foreign_root_id);
+                    if not isinstance(root_anchor, NodeAnchor) {
                         _logger.warning(
-                            "cross-root resolve: failed to load root %s (%s), "
+                            "cross-root resolve: root %s is not a NodeAnchor, "
                             "falling back to edge walk",
-                            foreign_root_id,
-                            exc
+                            foreign_root_id
                         );
                         return None;
                     }
+                    foreign_idx = root_anchor.get_topology_index();
+                    if foreign_idx is not None and len(foreign_idx) > 0 {
+                        next_frontier.append((foreign_idx, foreign_node_ids));
+                    }
+                } except Exception as exc {
+                    _logger.warning(
+                        "cross-root resolve: failed to load root %s (%s), "
+                        "falling back to edge walk",
+                        foreign_root_id,
+                        exc
+                    );
+                    return None;
                 }
             }
         }

--- a/jac/jaclang/runtimelib/impl/topology_index.impl.jac
+++ b/jac/jaclang/runtimelib/impl/topology_index.impl.jac
@@ -493,6 +493,65 @@ impl TopologyIndex.get_cross_root_ids(node_ids: set[UUID]) -> dict[UUID, set[UUI
     return result;
 }
 
+"""Resolve a chain across root boundaries hop by hop (iterative)."""
+impl TopologyIndex.resolve_chain_cross_root(
+    mem: any, origin_ids: set[UUID], chain: list[tuple[(str | None), (str | None), int]]
+) -> set[UUID] {
+    if not chain {
+        return origin_ids;
+    }
+    import from jaclang.jac0core.archetype { NodeAnchor }
+    # Group current frontier by (topology_index, node_ids).
+    # Start with all origins on `self`.
+    frontier: list[tuple[TopologyIndex, set[UUID]]] = [(self, origin_ids)];
+    for (hop_idx, hop) in enumerate(chain) {
+        is_last = hop_idx == len(chain) - 1;
+        next_frontier: list[tuple[TopologyIndex, set[UUID]]] = [];
+        result_ids: set[UUID] = set();
+        for (idx, ids) in frontier {
+            hop_result = idx.resolve_chain(ids, [hop]);
+            if not hop_result {
+                continue;
+            }
+            if is_last {
+                result_ids |= hop_result;
+            } else {
+                # Split into local vs foreign for next hop.
+                cross_root_map = idx.get_cross_root_ids(hop_result);
+                local_ids = hop_result - {
+                    uid for ids in cross_root_map.values() for uid in ids
+                };
+                if local_ids {
+                    next_frontier.append((idx, local_ids));
+                }
+                for (foreign_root_id, foreign_node_ids) in cross_root_map.items() {
+                    try {
+                        root_anchor = mem.get(foreign_root_id);
+                        if not isinstance(root_anchor, NodeAnchor) {
+                            continue;
+                        }
+                        foreign_idx = root_anchor.get_topology_index();
+                        if foreign_idx is not None and len(foreign_idx) > 0 {
+                            next_frontier.append((foreign_idx, foreign_node_ids));
+                        }
+                    } except Exception {
+                        continue;
+                    }
+                }
+            }
+        }
+        if is_last {
+            return result_ids;
+        }
+        frontier = next_frontier;
+        if not frontier {
+            return set();
+        }
+    }
+    return set();
+}
+
+
 """Serialize to compact binary format (version 2)."""
 impl TopologyIndex.encode -> bytes {
     num_types = len(self.type_table);

--- a/jac/jaclang/runtimelib/impl/topology_index.impl.jac
+++ b/jac/jaclang/runtimelib/impl/topology_index.impl.jac
@@ -493,14 +493,20 @@ impl TopologyIndex.get_cross_root_ids(node_ids: set[UUID]) -> dict[UUID, set[UUI
     return result;
 }
 
-"""Resolve a chain across root boundaries hop by hop (iterative)."""
+"""Resolve a chain across root boundaries hop by hop (iterative).
+
+Returns None when any foreign root fails to load — the partial result
+would silently omit nodes, so the caller must fall back to the
+complete (but slower) edge-walk path."""
 impl TopologyIndex.resolve_chain_cross_root(
     mem: any, origin_ids: set[UUID], chain: list[tuple[(str | None), (str | None), int]]
-) -> set[UUID] {
+) -> (set[UUID] | None) {
     if not chain {
         return origin_ids;
     }
+    import logging;
     import from jaclang.jac0core.archetype { NodeAnchor }
+    _logger = logging.getLogger(__name__);
     # Group current frontier by (topology_index, node_ids).
     # Start with all origins on `self`.
     frontier: list[tuple[TopologyIndex, set[UUID]]] = [(self, origin_ids)];
@@ -528,14 +534,25 @@ impl TopologyIndex.resolve_chain_cross_root(
                     try {
                         root_anchor = mem.get(foreign_root_id);
                         if not isinstance(root_anchor, NodeAnchor) {
-                            continue;
+                            _logger.warning(
+                                "cross-root resolve: root %s is not a NodeAnchor, "
+                                "falling back to edge walk",
+                                foreign_root_id
+                            );
+                            return None;
                         }
                         foreign_idx = root_anchor.get_topology_index();
                         if foreign_idx is not None and len(foreign_idx) > 0 {
                             next_frontier.append((foreign_idx, foreign_node_ids));
                         }
-                    } except Exception {
-                        continue;
+                    } except Exception as exc {
+                        _logger.warning(
+                            "cross-root resolve: failed to load root %s (%s), "
+                            "falling back to edge walk",
+                            foreign_root_id,
+                            exc
+                        );
+                        return None;
                     }
                 }
             }

--- a/jac/jaclang/runtimelib/topology_index.jac
+++ b/jac/jaclang/runtimelib/topology_index.jac
@@ -79,6 +79,22 @@ obj TopologyIndex {
     ) -> list[UUID];
 
     def get_cross_root_ids(node_ids: set[UUID]) -> dict[UUID, set[UUID]];
+    """Resolve a chain across root boundaries.
+
+    Walks the chain hop by hop. After each intermediate hop, foreign nodes
+    (owned by other roots) are grouped by owner root. For each foreign root,
+    its topology index is loaded via `mem` and the remaining hops are resolved
+    there. Results from all roots are unioned.
+
+    `mem` must support `.get(uuid)` returning a NodeAnchor with
+    `.get_topology_index()`.
+    """
+    def resolve_chain_cross_root(
+        mem: any,
+        origin_ids: set[UUID],
+        chain: list[tuple[(str | None), (str | None), int]]
+    ) -> set[UUID];
+
     def encode -> bytes;
     static def decode(data: bytes) -> TopologyIndex;
     def __len__ -> int;

--- a/jac/jaclang/runtimelib/topology_index.jac
+++ b/jac/jaclang/runtimelib/topology_index.jac
@@ -93,7 +93,7 @@ obj TopologyIndex {
         mem: any,
         origin_ids: set[UUID],
         chain: list[tuple[(str | None), (str | None), int]]
-    ) -> set[UUID];
+    ) -> (set[UUID] | None);
 
     def encode -> bytes;
     static def decode(data: bytes) -> TopologyIndex;


### PR DESCRIPTION
## Summary
- Add `resolve_chain_cross_root` to `TopologyIndex`: iterative hop-by-hop resolver that crosses user boundaries by loading foreign roots' topology indices
- Wire into `plan_chain` so multi-hop queries stay on the fast path (topology index → materialize) instead of falling back to the edge-walk path
- Gated by `[run] cross_root_resolve = true` in jac.toml (default: false)

## Problem
When a multi-hop query like `[->:Follow:->[?:Profile]-->[?:Tweet]]` crosses user boundaries, the planner detects foreign nodes at intermediate hops and bails (`bail_on_intermediate_foreign`). The entire query falls back to `edges_to_nodes`, which triggers thousands of unnecessary edge anchor fetches from MongoDB.

In a benchmark with 5000 users (200 tweets each, 50 follows each), `load_feed` without cross-root resolution fetches ~10,200 Post edges and ~8,450 Follow edges from L3 — none of which are needed on the fast path.

## How it works
`resolve_chain_cross_root` walks the chain hop by hop:
1. Resolve the current hop within the current root's index
2. Classify results into local vs foreign nodes (`get_cross_root_ids`)
3. For each foreign root, load its topology index and continue the next hop there
4. Union all results

The planner uses this for multi-hop chains when `cross_root_resolve` is enabled, keeping the query on the index-only path across root boundaries.

## Security note
The resolver decodes foreign users' topology indices, exposing graph structure (node types, connectivity) internally to the planner. Actual data remains access-controlled — `_materialize_ids` filters results by permission before returning to walker code. Gated off by default.

## Test plan
- [ ] Run existing test suite
- [ ] Verify default (`cross_root_resolve = false`) produces identical behavior to main
- [ ] Enable `cross_root_resolve = true` and verify multi-hop cross-user queries return correct results
- [ ] Benchmark with LittleX5 dataset to measure edge fetch reduction