### PR TITLE
refactor(topology): unify resolve_chain into single ordered implementation

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6631.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6631.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: Unify ordered topology index resolution**: `TopologyIndex.resolve_chain` now returns results in edge-insertion order by storing sorted adj_list indices in buckets instead of node lid sets. The separate `resolve_chain_ordered` and `plan_chain_ordered` methods have been removed.

--- a/jac/jaclang/runtimelib/impl/planner.impl.jac
+++ b/jac/jaclang/runtimelib/impl/planner.impl.jac
@@ -108,12 +108,12 @@ def _chain_triples(chain: list[any]) -> list[tuple[(str | None), (str | None), i
 
 """Narrow the plan via the topology_index on the given root.
 
-Returns the set of candidate UUIDs the chain resolves to, or None when the
-index isn't usable (disabled, missing, or empty). The chain comes from the
-plan; the function ignores `plan.id_in` (the caller decides whether to AND
-the existing narrowing with the new one).
+Returns the ordered list of candidate UUIDs the chain resolves to, or None
+when the index isn't usable (disabled, missing, or empty). The chain comes
+from the plan; the function ignores `plan.id_in` (the caller decides whether
+to AND the existing narrowing with the new one).
 """
-def _topology_narrow(root_anchor: any, plan: QueryPlan) -> (set[UUID] | None) {
+def _topology_narrow(root_anchor: any, plan: QueryPlan) -> (list[UUID] | None) {
     if not plan.chain {
         return None;
     }
@@ -179,7 +179,9 @@ def _materialize_ids(
 Used when the backend declares no useful capabilities, or to back up a
 backend that returned no results from a partial pushdown."""
 def _execute_floor(mem: any, plan: QueryPlan, root_anchor: any) -> list[any] {
-    candidate_ids: (set[UUID] | None) = plan.id_in;
+    candidate_ids: (list[UUID] | None) = (
+        list(plan.id_in) if plan.id_in is not None else None
+    );
     if candidate_ids is None {
         candidate_ids = _topology_narrow(root_anchor, plan);
         if candidate_ids is None {
@@ -189,7 +191,7 @@ def _execute_floor(mem: any, plan: QueryPlan, root_anchor: any) -> list[any] {
     }
     _trace('floor', plan, f"candidates={len(candidate_ids)}");
     return _materialize_ids(
-        mem, list(candidate_ids), post_filter=plan.post_filter, slc=plan.slc
+        mem, candidate_ids, post_filter=plan.post_filter, slc=plan.slc
     );
 }
 
@@ -223,12 +225,12 @@ def _execute_pushdown(mem: any, plan: QueryPlan) -> list[any] {
 
 The planner uses this when the backend can handle field predicates but not
 the full chain (the common case for type+field queries against Mongo). The
-topology_index gives us the candidate set for free; the backend then runs
+topology_index gives us the candidate list for free; the backend then runs
 `_id IN (...) AND field_predicates...` in a single round-trip — much better
-than batch_get + Python filtering for large candidate sets with sparse field
+than batch_get + Python filtering for large candidate lists with sparse field
 matches.
 """
-def _execute_mixed(mem: any, plan: QueryPlan, narrowed: set[UUID]) -> list[any] {
+def _execute_mixed(mem: any, plan: QueryPlan, narrowed: list[UUID]) -> list[any] {
     # Build a reduced plan: chain is consumed (narrowing did its job), id_in
     # carries the candidate set, field_predicates and node_type_final are
     # preserved for the backend.
@@ -236,7 +238,7 @@ def _execute_mixed(mem: any, plan: QueryPlan, narrowed: set[UUID]) -> list[any] 
         root_id=plan.root_id,
         chain=[],
         field_predicates=plan.field_predicates,
-        id_in=narrowed,
+        id_in=set(narrowed),
         slc=plan.slc,
         node_type_final=plan.node_type_final,
         post_filter=None  # applied above
@@ -259,9 +261,7 @@ def _execute_mixed(mem: any, plan: QueryPlan, narrowed: set[UUID]) -> list[any] 
     # Backend can't handle the reduced plan; fall back to pure floor with the
     # narrowing we already computed.
     _trace('mixed→floor', plan, f"narrowed={len(narrowed)}");
-    return _materialize_ids(
-        mem, list(narrowed), post_filter=plan.post_filter, slc=plan.slc
-    );
+    return _materialize_ids(mem, narrowed, post_filter=plan.post_filter, slc=plan.slc);
 }
 
 
@@ -413,20 +413,17 @@ def _build_plan_from_path(
 
 """High-level path entry point. Builds a QueryPlan, runs it, returns NodeAnchors.
 
+`plan_chain` returns results in canonical edge-insertion order, so slicing
+and single-hop ordering work without a separate ordered resolver.
+
 Strategy ladder, picked by query shape:
 
-  * **sliced, no post_filter** → `plan_chain_ordered` (works for single-hop
-    AND multi-hop; multi-hop resolves the prefix as a set then walks the
-    final adj_list in order with the slice applied). This bounds L3 fetches
-    to roughly the slice size — critical for paginated queries on large
-    fanouts where the legacy unbounded path loaded the whole result first.
-
-  * **single-hop, no slice, no post_filter** → `plan_chain_ordered` with a
-    full-open slice. Canonical edge-walk order is preserved so existing
-    visit semantics are unchanged from the legacy edge-walk path.
+  * **no post_filter, sliced or single-hop** → `plan_chain` gives the
+    ordered result; apply the slice directly, then materialize. This bounds
+    L3 fetches to roughly the slice size — critical for paginated queries.
 
   * **anything else** (multi-hop unsliced, or any post_filter present) →
-    set narrowing via `plan_chain`, then backend pushdown if capabilities
+    `plan_chain` for ordered narrowing, then backend pushdown if capabilities
     cover the reduced plan, otherwise `batch_get`. post_filter applied
     above the materialized list before any leftover slicing.
 
@@ -446,67 +443,40 @@ impl execute_path(
     origin_ids: set[UUID] = {cast(UUID, nd.__jac__.id) for nd in path.origin};
     chain_triples = _chain_triples(plan.chain);
 
-    # Ordered fast path covers single-hop walks AND sliced multi-hop. The
-    # ordered resolver applies the slice itself, so materialize doesn't.
-    use_ordered = plan.post_filter is None
-    and (slc is not None or len(plan.chain) == 1);
-    if use_ordered {
-        effective_slc = slc if slc is not None else slice(None, None, None);
-        ordered = plan_chain_ordered(
-            root_anchor, origin_ids, chain_triples, effective_slc
-        );
-        if ordered is None {
-            return None;
-        }
-        _trace('ordered', plan, f"ids={len(ordered)}");
-        return _materialize_ids(mem, ordered);
-    }
-
-    # Set-narrowing branch: multi-hop without slice, or anything with a
-    # post_filter (predicates invalidate the ordered slice invariant).
-    narrowed = plan_chain(root_anchor, origin_ids, chain_triples);
-    if narrowed is None {
+    result = plan_chain(root_anchor, origin_ids, chain_triples);
+    if result is None {
         return None;
     }
-    plan.id_in = narrowed;
+
+    # Fast path: no post_filter and (sliced or single-hop). Apply slice on
+    # the ordered list directly, then materialize.
+    if plan.post_filter is None and (slc is not None or len(plan.chain) == 1) {
+        if slc is not None {
+            result = result[slc];
+        }
+        _trace('ordered', plan, f"ids={len(result)}");
+        return _materialize_ids(mem, result);
+    }
+
+    # Narrowing branch: multi-hop without slice, or post_filter present.
+    plan.id_in = set(result);
     plan.chain = [];  # consumed by narrowing
-    _trace('path', plan, f"narrowed={len(narrowed)}");
+    _trace('path', plan, f"narrowed={len(result)}");
 
     # Backend pushdown if capable, else floor through batch_get.
     if plan.needs() <= mem.capabilities() {
         return _execute_pushdown(mem, plan);
     }
-    return _materialize_ids(
-        mem, list(narrowed), post_filter=plan.post_filter, slc=plan.slc
-    );
+    return _materialize_ids(mem, result, post_filter=plan.post_filter, slc=plan.slc);
 }
 
 
-"""Compatibility helper. Resolves a chain using the topology_index on the
-given root and returns the resulting UUID set. None when not usable."""
+"""Resolve a chain using the topology_index on the given root and return
+the resulting ordered UUID list. None when not usable."""
 impl plan_chain(
     root_anchor: any,
     origin_ids: set[UUID],
     chain: list[tuple[(str | None), (str | None), int]]
-) -> (set[UUID] | None) {
-    if root_anchor is None or not chain {
-        return None;
-    }
-    import from jaclang.runtimelib.topology_index { TopologyIndex }
-    idx = root_anchor.get_topology_index();
-    if not isinstance(idx, TopologyIndex) or len(idx) == 0 {
-        return None;
-    }
-    return idx.resolve_chain(origin_ids, chain, bail_on_intermediate_foreign=True);
-}
-
-
-"""Compatibility helper. Ordered single-hop resolution with slice applied."""
-impl plan_chain_ordered(
-    root_anchor: any,
-    origin_ids: set[UUID],
-    chain: list[tuple[(str | None), (str | None), int]],
-    slc: slice
 ) -> (list[UUID] | None) {
     if root_anchor is None or not chain {
         return None;
@@ -516,15 +486,5 @@ impl plan_chain_ordered(
     if not isinstance(idx, TopologyIndex) or len(idx) == 0 {
         return None;
     }
-    # Multi-hop prefix resolves via the set-based walker; the final hop runs
-    # ordered. Order between hops isn't observable to the slice.
-    if len(chain) > 1 {
-        prev = idx.resolve_chain(origin_ids, chain[:-1]);
-        if not prev {
-            return [];
-        }
-        origin_ids = prev;
-    }
-    (f_edge, f_node, f_dir) = chain[-1];
-    return idx.resolve_chain_ordered(origin_ids, f_edge, f_node, f_dir, slc);
+    return idx.resolve_chain(origin_ids, chain, bail_on_intermediate_foreign=True);
 }

--- a/jac/jaclang/runtimelib/impl/topology_index.impl.jac
+++ b/jac/jaclang/runtimelib/impl/topology_index.impl.jac
@@ -2,9 +2,11 @@
 
 The canonical `adj_list` is the source of truth for encode/decode and preserves
 multi-edge multiplicity. The `buckets` map is a derived index keyed by
-`(src_lid, col_key) -> (in_lids, out_lids)` where `col_key` is `"n:<type_id>"`
-or `"e:<edge_type_id>"`. Targets are fanned out under every ancestor type id so
-parent-type queries resolve in O(1).
+`(src_lid, col_key) -> (in_adj_indices, out_adj_indices)` where `col_key` is
+`"n:<type_id>"` or `"e:<edge_type_id>"`. Each entry is an index into `adj_list`,
+kept in sorted order so ordered intersections preserve edge insertion order.
+Targets are fanned out under every ancestor type id so parent-type queries
+resolve via a single merge-intersection.
 """
 
 """Build a lookup column key for a node-type id."""
@@ -17,15 +19,12 @@ def _e_key(edge_type_id: int) -> str {
     return "e:" + str(edge_type_id);
 }
 
-"""Get or create the (in, out) sets for `(src_lid, col_key)` in the lookup.
-
-Backed by sets (not lists) so add/discard/membership are all O(1) â keeps
-add_edge linear-per-call even for hub nodes with thousands of outgoing
-edges. Order is not preserved, but the canonical adj_list already provides
-deterministic ordering for any caller that needs it."""
+"""Get or create the (in, out) sorted adj_list index lists for `(src_lid, col_key)`."""
 def _get_col(
-    buckets: dict[int, dict[str, tuple[set[int], set[int]]]], src_lid: int, col_key: str
-) -> tuple[set[int], set[int]] {
+    buckets: dict[int, dict[str, tuple[list[int], list[int]]]],
+    src_lid: int,
+    col_key: str
+) -> tuple[list[int], list[int]] {
     bucket = buckets.get(src_lid);
     if bucket is None {
         bucket = {};
@@ -33,10 +32,72 @@ def _get_col(
     }
     col = bucket.get(col_key);
     if col is None {
-        col = (set(), set());
+        col = ([], []);
         bucket[col_key] = col;
     }
     return col;
+}
+
+"""Ordered intersection of two sorted integer lists."""
+def _intersect_sorted(a: list[int], b: list[int]) -> list[int] {
+    result: list[int] = [];
+    i = 0;
+    j = 0;
+    while i < len(a) and j < len(b) {
+        if a[i] < b[j] {
+            i += 1;
+        } elif a[i] > b[j] {
+            j += 1;
+        } else {
+            result.append(a[i]);
+            i += 1;
+            j += 1;
+        }
+    }
+    return result;
+}
+
+"""Fan out one edge into the bucket index under MRO ancestors."""
+def _index_edge(
+    buckets: dict[int, dict[str, tuple[list[int], list[int]]]],
+    adj_idx: int,
+    src: int,
+    etid: int,
+    tgt: int,
+    type_mro_ids: list[list[int]],
+    node_table: list[tuple[UUID, int, UUID]]
+) {
+    (_, src_type_id, _) = node_table[src];
+    (_, tgt_type_id, _) = node_table[tgt];
+    src_ancestors = type_mro_ids[src_type_id] or [src_type_id];
+    tgt_ancestors = type_mro_ids[tgt_type_id] or [tgt_type_id];
+
+    for anc in tgt_ancestors {
+        out_col = _get_col(buckets, src, _n_key(anc));
+        out_col[1].append(adj_idx);
+    }
+    e_out = _get_col(buckets, src, _e_key(etid));
+    e_out[1].append(adj_idx);
+
+    for anc in src_ancestors {
+        in_col = _get_col(buckets, tgt, _n_key(anc));
+        in_col[0].append(adj_idx);
+    }
+    e_in = _get_col(buckets, tgt, _e_key(etid));
+    e_in[0].append(adj_idx);
+}
+
+"""Rebuild all buckets from scratch by replaying adj_list."""
+def _rebuild_buckets(
+    adj_list: list[tuple[int, int, int]],
+    type_mro_ids: list[list[int]],
+    node_table: list[tuple[UUID, int, UUID]]
+) -> dict[int, dict[str, tuple[list[int], list[int]]]] {
+    buckets: dict[int, dict[str, tuple[list[int], list[int]]]] = {};
+    for (adj_idx, (src, etid, tgt)) in enumerate(adj_list) {
+        _index_edge(buckets, adj_idx, src, etid, tgt, type_mro_ids, node_table);
+    }
+    return buckets;
 }
 
 """Return type_id for type_name, registering it (and its MRO chain) if new."""
@@ -87,7 +148,7 @@ impl TopologyIndex.add_node(
     return lid;
 }
 
-"""Remove a node and every edge involving it."""
+"""Remove a node and every edge involving it. Rebuilds buckets from scratch."""
 impl TopologyIndex.remove_node(node_id: UUID) -> None {
     lid = self.node_to_lid.get(node_id);
     if lid is None {
@@ -98,13 +159,7 @@ impl TopologyIndex.remove_node(node_id: UUID) -> None {
         for (s, et, t) in self.adj_list
         if s != lid and t != lid
     ];
-    self.buckets.pop(lid, None);
-    for (_, bucket) in self.buckets.items() {
-        for (_, col) in bucket.items() {
-            col[0].discard(lid);
-            col[1].discard(lid);
-        }
-    }
+    self.buckets = _rebuild_buckets(self.adj_list, self.type_mro_ids, self.node_table);
 }
 
 """Add an edge to `adj_list` and fan out into the buckets under MRO ancestors."""
@@ -117,26 +172,17 @@ impl TopologyIndex.add_edge(
         return;
     }
     etid = self._ensure_type(edge_type_name);
+    adj_idx = len(self.adj_list);
     self.adj_list.append((src_lid, etid, tgt_lid));
-
-    (_, src_type_id, _) = self.node_table[src_lid];
-    (_, tgt_type_id, _) = self.node_table[tgt_lid];
-    src_ancestors = self.type_mro_ids[src_type_id] or [src_type_id];
-    tgt_ancestors = self.type_mro_ids[tgt_type_id] or [tgt_type_id];
-
-    for anc in tgt_ancestors {
-        out_col = _get_col(self.buckets, src_lid, _n_key(anc));
-        out_col[1].add(tgt_lid);
-    }
-    e_out = _get_col(self.buckets, src_lid, _e_key(etid));
-    e_out[1].add(tgt_lid);
-
-    for anc in src_ancestors {
-        in_col = _get_col(self.buckets, tgt_lid, _n_key(anc));
-        in_col[0].add(src_lid);
-    }
-    e_in = _get_col(self.buckets, tgt_lid, _e_key(etid));
-    e_in[0].add(src_lid);
+    _index_edge(
+        self.buckets,
+        adj_idx,
+        src_lid,
+        etid,
+        tgt_lid,
+        self.type_mro_ids,
+        self.node_table
+    );
 }
 
 """Remove a single edge between source and target. If `edge_type_name` is None,
@@ -151,105 +197,63 @@ impl TopologyIndex.remove_edge(
     }
     filter_etid = self.type_to_id.get(edge_type_name) if edge_type_name else None;
 
+    # Find and remove the first matching edge.
+    removed_pos: int = -1;
     new_adj: list[tuple[int, int, int]] = [];
-    removed_etid: int = 0;
-    removed_any = False;
-    for entry in self.adj_list {
+    for (i, entry) in enumerate(self.adj_list) {
         (s, et, t) = entry;
-        if not removed_any and s == src_lid and t == tgt_lid {
+        if removed_pos < 0 and s == src_lid and t == tgt_lid {
             if filter_etid is None or et == filter_etid {
-                removed_etid = et;
-                removed_any = True;
+                removed_pos = i;
                 continue;
             }
         }
         new_adj.append(entry);
     }
-    if not removed_any {
+    if removed_pos < 0 {
         return;
     }
     self.adj_list = new_adj;
 
-    edge_type_still_connects = False;
-    any_edge_remains = False;
-    for (s, et, t) in self.adj_list {
-        if s == src_lid and t == tgt_lid {
-            any_edge_remains = True;
-            if et == removed_etid {
-                edge_type_still_connects = True;
+    # Reindex all bucket lists: remove the deleted position and shift
+    # everything above it down by one.
+    empty_nodes: list[int] = [];
+    for (node_lid, bucket) in self.buckets.items() {
+        empty_keys: list[str] = [];
+        for (key, col) in bucket.items() {
+            col[0][:] = [
+                x - 1 if x > removed_pos else x
+                for x in col[0]
+                if x != removed_pos
+            ];
+            col[1][:] = [
+                x - 1 if x > removed_pos else x
+                for x in col[1]
+                if x != removed_pos
+            ];
+            if not col[0] and not col[1] {
+                empty_keys.append(key);
             }
+        }
+        for k in empty_keys {
+            bucket.pop(k, None);
+        }
+        if not bucket {
+            empty_nodes.append(node_lid);
         }
     }
-
-    src_bucket = self.buckets.get(src_lid);
-    tgt_bucket = self.buckets.get(tgt_lid);
-
-    if not edge_type_still_connects {
-        e_key = _e_key(removed_etid);
-        if src_bucket is not None {
-            e_col = src_bucket.get(e_key);
-            if e_col is not None {
-                e_col[1].discard(tgt_lid);
-                if not e_col[0] and not e_col[1] {
-                    src_bucket.pop(e_key, None);
-                }
-            }
-        }
-        if tgt_bucket is not None {
-            e_col_rev = tgt_bucket.get(e_key);
-            if e_col_rev is not None {
-                e_col_rev[0].discard(src_lid);
-                if not e_col_rev[0] and not e_col_rev[1] {
-                    tgt_bucket.pop(e_key, None);
-                }
-            }
-        }
-    }
-
-    if not any_edge_remains {
-        if src_bucket is not None {
-            empty: list[str] = [];
-            for (key, col) in src_bucket.items() {
-                if key.startswith("n:") {
-                    col[1].discard(tgt_lid);
-                    if not col[0] and not col[1] {
-                        empty.append(key);
-                    }
-                }
-            }
-            for k in empty {
-                src_bucket.pop(k, None);
-            }
-        }
-        if tgt_bucket is not None {
-            empty_rev: list[str] = [];
-            for (key, col) in tgt_bucket.items() {
-                if key.startswith("n:") {
-                    col[0].discard(src_lid);
-                    if not col[0] and not col[1] {
-                        empty_rev.append(key);
-                    }
-                }
-            }
-            for k in empty_rev {
-                tgt_bucket.pop(k, None);
-            }
-        }
-    }
-
-    if src_bucket is not None and not src_bucket {
-        self.buckets.pop(src_lid, None);
-    }
-    if tgt_bucket is not None and not tgt_bucket {
-        self.buckets.pop(tgt_lid, None);
+    for n in empty_nodes {
+        self.buckets.pop(n, None);
     }
 }
 
-"""Walk the buckets using type filters. `chain` is a list of
+"""Walk the buckets using ordered merge-intersections. `chain` is a list of
 `(edge_type, node_type, direction)` where direction is 1=IN, 2=OUT, 3=ANY.
 
+Returns results in canonical edge-insertion order (adj_list order).
+
 When `bail_on_intermediate_foreign` is True, returns None if any hop
-*before* the final hop produces a node owned by another root -- those
+*before* the final hop produces a node owned by a different root — those
 nodes' outgoing edges live in their owner's index, not this one, so the
 chain would silently miss them. The final hop is allowed to land on
 foreign nodes because their incoming edges are mirrored into this
@@ -258,28 +262,31 @@ impl TopologyIndex.resolve_chain(
     origin_ids: set[UUID],
     chain: list[tuple[(str | None), (str | None), int]],
     bail_on_intermediate_foreign: bool = False
-) -> (set[UUID] | None) {
-    current_lids: set[int] = set();
+) -> (list[UUID] | None) {
+    current_lids: list[int] = [];
+    seen_lids: set[int] = set();
     for uid in origin_ids {
         lid = self.node_to_lid.get(uid);
-        if lid is not None {
-            current_lids.add(lid);
+        if lid is not None and lid not in seen_lids {
+            seen_lids.add(lid);
+            current_lids.append(lid);
         }
     }
     if not current_lids {
-        return set();
+        return [];
     }
     last_idx = len(chain) - 1;
     for (hop_idx, (edge_type, node_type, direction)) in enumerate(chain) {
         etid = self.type_to_id.get(edge_type) if edge_type else None;
         ntid = self.type_to_id.get(node_type) if node_type else None;
         if edge_type and etid is None {
-            return set();
+            return [];
         }
         if node_type and ntid is None {
-            return set();
+            return [];
         }
-        next_lids: set[int] = set();
+        want_out = direction in (2, 3);
+        want_in = direction in (1, 3);
         col_keys: list[str] = [];
         if etid is not None {
             col_keys.append(_e_key(etid));
@@ -287,54 +294,93 @@ impl TopologyIndex.resolve_chain(
         if ntid is not None {
             col_keys.append(_n_key(ntid));
         }
+
+        # Collect (adj_idx, neighbor_lid) from all origins.
+        candidates: list[tuple[int, int]] = [];
         for src_lid in current_lids {
             bucket = self.buckets.get(src_lid);
             if bucket is None {
                 continue;
             }
             if not col_keys {
+                # Wildcard: union all adj indices from all columns, deduped.
+                out_set: set[int] = set();
+                in_set: set[int] = set();
                 for (_, col) in bucket.items() {
-                    if direction in (2, 3) {
-                        for tgt in col[1] {
-                            next_lids.add(tgt);
+                    if want_out {
+                        for ai in col[1] {
+                            out_set.add(ai);
                         }
                     }
-                    if direction in (1, 3) {
-                        for src in col[0] {
-                            next_lids.add(src);
+                    if want_in {
+                        for ai in col[0] {
+                            in_set.add(ai);
                         }
                     }
+                }
+                for ai in out_set {
+                    candidates.append((ai, self.adj_list[ai][2]));
+                }
+                for ai in in_set {
+                    candidates.append((ai, self.adj_list[ai][0]));
                 }
                 continue;
             }
-            candidates_out: (set[int] | None) = None;
-            candidates_in: (set[int] | None) = None;
-            for ck in col_keys {
-                col = bucket.get(ck);
-                if col is None {
-                    candidates_out = set();
-                    candidates_in = set();
-                    break;
+
+            # Intersect column lists for OUT and IN separately.
+            if want_out {
+                out_result: (list[int] | None) = None;
+                for ck in col_keys {
+                    col = bucket.get(ck);
+                    if col is None {
+                        out_result = [];
+                        break;
+                    }
+                    out_result = col[1]
+                        if out_result is None
+                        else _intersect_sorted(out_result, col[1]);
                 }
-                co: set[int] = set(col[1]);
-                ci: set[int] = set(col[0]);
-                candidates_out = co if candidates_out is None else candidates_out & co;
-                candidates_in = ci if candidates_in is None else candidates_in & ci;
-            }
-            if direction in (2, 3) and candidates_out is not None {
-                for tgt in candidates_out {
-                    next_lids.add(tgt);
+                if out_result {
+                    for ai in out_result {
+                        candidates.append((ai, self.adj_list[ai][2]));
+                    }
                 }
             }
-            if direction in (1, 3) and candidates_in is not None {
-                for src in candidates_in {
-                    next_lids.add(src);
+            if want_in {
+                in_result: (list[int] | None) = None;
+                for ck in col_keys {
+                    col = bucket.get(ck);
+                    if col is None {
+                        in_result = [];
+                        break;
+                    }
+                    in_result = col[0]
+                        if in_result is None
+                        else _intersect_sorted(in_result, col[0]);
+                }
+                if in_result {
+                    for ai in in_result {
+                        candidates.append((ai, self.adj_list[ai][0]));
+                    }
                 }
             }
         }
+
+        # Sort by adj_list index to recover insertion order, dedupe neighbors.
+        candidates.sort();
+        next_lids: list[int] = [];
+        next_seen: set[int] = set();
+        for (_, neighbor) in candidates {
+            if neighbor not in next_seen {
+                next_seen.add(neighbor);
+                next_lids.append(neighbor);
+            }
+        }
+
         current_lids = next_lids;
+        seen_lids = next_seen;
         if not current_lids {
-            return set();
+            return [];
         }
         if bail_on_intermediate_foreign and hop_idx < last_idx {
             for lid in current_lids {
@@ -344,137 +390,7 @@ impl TopologyIndex.resolve_chain(
             }
         }
     }
-    return {self.node_table[lid][0] for lid in current_lids};
-}
-
-"""Single-hop ordered resolution for the slice-pushdown fast path.
-
-The buckets index is set-keyed (fast type membership but order-lossy), so we
-walk the canonical adj_list (which preserves edge insertion order) and gate
-each triple by:
-  * source lid in `origin_lids`
-  * edge type id matches `edge_type` (with the special wildcard when None)
-  * target node type id matches `node_type` via MRO fan-out (or wildcard)
-  * direction: 1=IN (consider when target is the origin), 2=OUT (source is
-    the origin), 3=ANY
-
-The buckets membership lookup gives us the type-filtered "pass-set" — the
-adj_list walk recovers the order. We dedupe (a single neighbor may have
-multiple parallel edges), apply the slice, and return."""
-impl TopologyIndex.resolve_chain_ordered(
-    origin_ids: set[UUID],
-    edge_type: (str | None),
-    node_type: (str | None),
-    direction: int,
-    slc: slice
-) -> list[UUID] {
-    origin_lids: set[int] = set();
-    for uid in origin_ids {
-        lid = self.node_to_lid.get(uid);
-        if lid is not None {
-            origin_lids.add(lid);
-        }
-    }
-    if not origin_lids {
-        return [];
-    }
-
-    etid: (int | None) = self.type_to_id.get(edge_type) if edge_type else None;
-    if edge_type and etid is None {
-        # Edge type referenced doesn't exist in the index — empty result.
-        return [];
-    }
-    ntid: (int | None) = self.type_to_id.get(node_type) if node_type else None;
-    if node_type and ntid is None {
-        return [];
-    }
-
-    # Build the type-filtered candidate sets per origin lid using buckets.
-    # `cand_pairs` collects (src_lid, allowed_target_lids) so the adj_list walk
-    # can quickly check membership without re-running MRO logic per edge.
-    out_allowed: dict[int, set[int]] = {};
-    in_allowed: dict[int, set[int]] = {};
-    want_out = direction in (2, 3);
-    want_in = direction in (1, 3);
-    for src_lid in origin_lids {
-        bucket = self.buckets.get(src_lid);
-        if bucket is None {
-            continue;
-        }
-        col_keys: list[str] = [];
-        if etid is not None {
-            col_keys.append(_e_key(etid));
-        }
-        if ntid is not None {
-            col_keys.append(_n_key(ntid));
-        }
-        if not col_keys {
-            # Wildcard: union all columns for this src.
-            out_set: set[int] = set();
-            in_set: set[int] = set();
-            for (_, col) in bucket.items() {
-                if want_out {
-                    out_set |= col[1];
-                }
-                if want_in {
-                    in_set |= col[0];
-                }
-            }
-            if want_out and out_set {
-                out_allowed[src_lid] = out_set;
-            }
-            if want_in and in_set {
-                in_allowed[src_lid] = in_set;
-            }
-            continue;
-        }
-        cand_out: (set[int] | None) = None;
-        cand_in: (set[int] | None) = None;
-        for ck in col_keys {
-            col = bucket.get(ck);
-            if col is None {
-                cand_out = set();
-                cand_in = set();
-                break;
-            }
-            cand_out = set(col[1]) if cand_out is None else cand_out & col[1];
-            cand_in = set(col[0]) if cand_in is None else cand_in & col[0];
-        }
-        if want_out and cand_out {
-            out_allowed[src_lid] = cand_out;
-        }
-        if want_in and cand_in {
-            in_allowed[src_lid] = cand_in;
-        }
-    }
-
-    if not out_allowed and not in_allowed {
-        return [];
-    }
-
-    # Walk adj_list in insertion order; collect ordered target UUIDs that
-    # pass the per-origin allow-sets. Dedupe across parallel edges.
-    ordered: list[UUID] = [];
-    seen: set[int] = set();
-    for (s, _et, t) in self.adj_list {
-        # OUT: origin is the source, target is the neighbor.
-        if want_out and s in out_allowed and t in out_allowed[s] {
-            if t not in seen {
-                seen.add(t);
-                ordered.append(self.node_table[t][0]);
-            }
-            continue;
-        }
-        # IN: origin is the target, source is the neighbor.
-        if want_in and t in in_allowed and s in in_allowed[t] {
-            if s not in seen {
-                seen.add(s);
-                ordered.append(self.node_table[s][0]);
-            }
-        }
-    }
-
-    return ordered[slc];
+    return [self.node_table[lid][0] for lid in current_lids];
 }
 
 """For a set of node UUIDs, return mapping of foreign_root_uuid -> {node_ids}."""
@@ -600,31 +516,18 @@ impl TopologyIndex.decode(data: bytes) -> TopologyIndex {
         idx.node_table.append((node_id, type_id, owner_root));
         idx.node_to_lid[node_id] = i;
     }
-    # Pass 3: edges. Replay through the fan-out helper (skipping the public
-    # add_edge so we don't re-resolve UUIDs back to lids).
+    # Pass 3: edges. Replay through the fan-out helper.
     for _ in range(num_edges) {
         unpacked = struct.unpack_from("<HHH", data, offset);
         src: int = int(unpacked[0]);
         etid: int = int(unpacked[1]);
         tgt: int = int(unpacked[2]);
         offset += 6;
+        adj_idx = len(idx.adj_list);
         idx.adj_list.append((src, etid, tgt));
-        (_, src_t, _) = idx.node_table[src];
-        (_, tgt_t, _) = idx.node_table[tgt];
-        src_ancestors = idx.type_mro_ids[src_t] or [src_t];
-        tgt_ancestors = idx.type_mro_ids[tgt_t] or [tgt_t];
-        for anc in tgt_ancestors {
-            out_col = _get_col(idx.buckets, src, _n_key(anc));
-            out_col[1].add(tgt);
-        }
-        e_out = _get_col(idx.buckets, src, _e_key(etid));
-        e_out[1].add(tgt);
-        for anc in src_ancestors {
-            in_col = _get_col(idx.buckets, tgt, _n_key(anc));
-            in_col[0].add(src);
-        }
-        e_in = _get_col(idx.buckets, tgt, _e_key(etid));
-        e_in[0].add(src);
+        _index_edge(
+            idx.buckets, adj_idx, src, etid, tgt, idx.type_mro_ids, idx.node_table
+        );
     }
     return idx;
 }

--- a/jac/jaclang/runtimelib/planner.jac
+++ b/jac/jaclang/runtimelib/planner.jac
@@ -5,7 +5,7 @@ The planner is the only place that knows about all three layers:
   1. Backend native pushdown (`Memory.execute_plan`, declared via
      `Memory.capabilities()`). Fastest when the backend can handle the plan
      because it bypasses the topology_index entirely.
-  2. Root topology_index (`TopologyIndex.resolve_chain[_ordered]`). The
+  2. Root topology_index (`TopologyIndex.resolve_chain`). The
      universal in-process narrowing path. Always available when the index is
      enabled and the relevant root carries one.
   3. `batch_get` (every backend has this). The bulk-load primitive used after
@@ -37,7 +37,7 @@ import from jaclang.jac0core.archetype { Anchor, NodeAnchor }
 import from jaclang.runtimelib.query_plan { QueryPlan }
 
 glob logger = logging.getLogger(__name__),
-     __all__ = ['execute_plan', 'execute_path', 'plan_chain', 'plan_chain_ordered'];
+     __all__ = ['execute_plan', 'execute_path', 'plan_chain'];
 
 
 """Top-level entry point: execute a QueryPlan against a memory.
@@ -73,23 +73,14 @@ def execute_path(
 ) -> (list[any] | None);
 
 
-"""Resolve a chain on a given root's topology_index to a `set[UUID]`.
+"""Resolve a chain on a given root's topology_index to an ordered `list[UUID]`.
 
-Used internally by `execute_path` (and available to callers that want the
-candidate set without materializing anchors). Returns None when no fast
-path applies (index disabled, root has no index, or origin not persistent)."""
+Returns results in canonical edge-insertion order. Used internally by
+`execute_path` (and available to callers that want the candidate list
+without materializing anchors). Returns None when no fast path applies
+(index disabled, root has no index, or origin not persistent)."""
 def plan_chain(
     root_anchor: any,
     origin_ids: set[UUID],
     chain: list[tuple[(str | None), (str | None), int]]
-) -> (set[UUID] | None);
-
-
-"""Compatibility helper: resolve the final hop in canonical edge-insertion
-order with `slc` applied. Returns None when no ordered fast path applies."""
-def plan_chain_ordered(
-    root_anchor: any,
-    origin_ids: set[UUID],
-    chain: list[tuple[(str | None), (str | None), int]],
-    slc: slice
 ) -> (list[UUID] | None);

--- a/jac/jaclang/runtimelib/topology_index.jac
+++ b/jac/jaclang/runtimelib/topology_index.jac
@@ -7,9 +7,11 @@ Two layered structures are kept in sync:
   * Canonical adj_list — `(src_lid, edge_type_id, tgt_lid)` triples; preserves
     multi-edge multiplicity, source of truth for encode/decode.
   * type-keyed lookup map — type-keyed dict
-    `buckets[src_lid][col_key] = (in_lids, out_lids)` where `col_key` is
-    `"n:<type_id>"` or `"e:<edge_type_id>"`. Gives O(1) per-type lookup and
-    holds MRO fan-out (each target indexed under every ancestor type).
+    `buckets[src_lid][col_key] = (in_adj_indices, out_adj_indices)` where
+    `col_key` is `"n:<type_id>"` or `"e:<edge_type_id>"`. Each entry is an
+    index into `adj_list`, kept in sorted order so ordered merge-intersections
+    preserve edge insertion order. MRO fan-out indexes each target under every
+    ancestor type.
 
 Encoding format (version 2):
   [1B version][2B num_types][2B num_nodes][4B num_edges]
@@ -26,7 +28,7 @@ import from uuid { UUID }
 glob SELF_ROOT: UUID = UUID(int=0),
      TOPO_VERSION: int = 2;
 
-"""In-memory topology index with type-keyed adjacency matrix and MRO fan-out."""
+"""In-memory topology index with ordered adjacency buckets and MRO fan-out."""
 obj TopologyIndex {
     has type_table: list[str] = [],
         type_to_id: dict[str, int] = {},
@@ -34,7 +36,7 @@ obj TopologyIndex {
         node_table: list[tuple[UUID, int, UUID]] = [],
         node_to_lid: dict[UUID, int] = {},
         adj_list: list[tuple[int, int, int]] = [],
-        buckets: dict[int, dict[str, tuple[set[int], set[int]]]] = {};
+        buckets: dict[int, dict[str, tuple[list[int], list[int]]]] = {};
 
     def _ensure_type(type_name: str, mro_chain: (list[str] | None) = None) -> int;
     def add_node(
@@ -50,7 +52,8 @@ obj TopologyIndex {
         source_id: UUID, target_id: UUID, edge_type_name: (str | None) = None
     ) -> None;
 
-    """Walk the chain entirely inside this index.
+    """Walk the chain entirely inside this index using ordered
+    merge-intersections. Returns results in edge-insertion order.
 
     With `bail_on_intermediate_foreign=True`, returns `None` the moment
     any non-final hop lands on a node owned by a *different* root. Those
@@ -61,22 +64,7 @@ obj TopologyIndex {
         origin_ids: set[UUID],
         chain: list[tuple[(str | None), (str | None), int]],
         bail_on_intermediate_foreign: bool = False
-    ) -> (set[UUID] | None);
-
-    """Single-hop ordered resolution: walk the canonical adj_list in
-    insertion order, filtering by origin / edge_type / node_type / direction
-    (with MRO fan-out), and return the slice of resulting target UUIDs.
-
-    Returns the ordered list of UUIDs after applying `slc`. Order matches the
-    natural edge-walk that `edges_to_nodes` would produce, so the bounded
-    fast path stays semantically equivalent to materialize-then-slice."""
-    def resolve_chain_ordered(
-        origin_ids: set[UUID],
-        edge_type: (str | None),
-        node_type: (str | None),
-        direction: int,
-        slc: slice
-    ) -> list[UUID];
+    ) -> (list[UUID] | None);
 
     def get_cross_root_ids(node_ids: set[UUID]) -> dict[UUID, set[UUID]];
     def encode -> bytes;

--- a/jac/tests/runtimelib/test_topology_index.jac
+++ b/jac/tests/runtimelib/test_topology_index.jac
@@ -114,12 +114,12 @@ def build_fan_graph -> tuple[TopologyIndex, UUID, list[UUID], list[UUID]] {
 
 test "type filter narrows fanout" {
     (idx, r, a_ids, _) = build_fan_graph();
-    assert idx.resolve_chain({r}, [("EdgeX", "NodeA", 2)]) == set(a_ids);
+    assert idx.resolve_chain({r}, [("EdgeX", "NodeA", 2)]) == a_ids;
 }
 
 test "nonexistent type returns empty" {
     (idx, r, _, _) = build_fan_graph();
-    assert idx.resolve_chain({r}, [("EdgeX", "NodeC", 2)]) == set();
+    assert idx.resolve_chain({r}, [("EdgeX", "NodeC", 2)]) == [];
 }
 
 test "deep chain" {
@@ -134,9 +134,9 @@ test "deep chain" {
     idx.add_edge(r, a, "E1");
     idx.add_edge(a, b, "E2");
     idx.add_edge(b, c, "E3");
-    assert idx.resolve_chain({r}, [("E1", "A", 2), ("E2", "B", 2), ("E3", "C", 2)]) == {
+    assert idx.resolve_chain({r}, [("E1", "A", 2), ("E2", "B", 2), ("E3", "C", 2)]) == [
         c
-    };
+    ];
 }
 
 test "multi hop selective" {
@@ -157,9 +157,7 @@ test "multi hop selective" {
         idx.add_edge(a_ids[i], b, "E2");
         b_ids.append(b);
     }
-    assert idx.resolve_chain({r}, [("E1", "NodeA", 2), ("E2", "NodeB", 2)]) == set(
-        b_ids
-    );
+    assert idx.resolve_chain({r}, [("E1", "NodeA", 2), ("E2", "NodeB", 2)]) == b_ids;
 }
 
 test "cross root ids" {
@@ -187,9 +185,9 @@ test "subtype query returns instances of all descendants" {
     idx.add_edge(r, post, "Authored");
     idx.add_edge(r, article, "Authored");
     # Query by parent type — both subtypes match.
-    assert idx.resolve_chain({r}, [(None, "BaseContent", 2)]) == {post, article};
+    assert idx.resolve_chain({r}, [(None, "BaseContent", 2)]) == [post, article];
     # Query by concrete subtype — only that subtype matches.
-    assert idx.resolve_chain({r}, [(None, "PostNode", 2)]) == {post};
+    assert idx.resolve_chain({r}, [(None, "PostNode", 2)]) == [post];
 }
 
 test "MRO fan-out survives encode decode" {
@@ -200,8 +198,8 @@ test "MRO fan-out survives encode decode" {
     idx.add_node(post, "PostNode", ["PostNode", "BaseContent"]);
     idx.add_edge(r, post, "Authored");
     decoded = TopologyIndex.decode(idx.encode());
-    assert decoded.resolve_chain({r}, [(None, "BaseContent", 2)]) == {post};
-    assert decoded.resolve_chain({r}, [(None, "PostNode", 2)]) == {post};
+    assert decoded.resolve_chain({r}, [(None, "BaseContent", 2)]) == [post];
+    assert decoded.resolve_chain({r}, [(None, "PostNode", 2)]) == [post];
 }
 
 # ── Multi-edge between same pair ─────────────────────────────────────
@@ -217,24 +215,24 @@ test "multi-edge between same pair preserves edge-type isolation" {
     idx.add_edge(a, b, "Follow");
     idx.add_edge(a, b, "Like");
 
-    assert idx.resolve_chain({a}, [("Follow", None, 2)]) == {b};
-    assert idx.resolve_chain({a}, [("Like", None, 2)]) == {b};
+    assert idx.resolve_chain({a}, [("Follow", None, 2)]) == [b];
+    assert idx.resolve_chain({a}, [("Like", None, 2)]) == [b];
     # IN direction sees the same connectivity from b's bucket.
-    assert idx.resolve_chain({b}, [("Follow", None, 1)]) == {a};
-    assert idx.resolve_chain({b}, [("Like", None, 1)]) == {a};
+    assert idx.resolve_chain({b}, [("Follow", None, 1)]) == [a];
+    assert idx.resolve_chain({b}, [("Like", None, 1)]) == [a];
 
     idx.remove_edge(a, b, "Like");
     # Like is gone; Follow remains.
-    assert idx.resolve_chain({a}, [("Follow", None, 2)]) == {b};
-    assert idx.resolve_chain({a}, [("Like", None, 2)]) == set();
+    assert idx.resolve_chain({a}, [("Follow", None, 2)]) == [b];
+    assert idx.resolve_chain({a}, [("Like", None, 2)]) == [];
     # n: column for B is still populated because Follow still connects (a, b).
-    assert idx.resolve_chain({a}, [(None, "B", 2)]) == {b};
+    assert idx.resolve_chain({a}, [(None, "B", 2)]) == [b];
     # ANY direction still finds the connection.
-    assert idx.resolve_chain({a}, [(None, None, 3)]) == {b};
+    assert idx.resolve_chain({a}, [(None, None, 3)]) == [b];
 
     idx.remove_edge(a, b, "Follow");
     # Now everything is gone — n: column too.
-    assert idx.resolve_chain({a}, [(None, "B", 2)]) == set();
+    assert idx.resolve_chain({a}, [(None, "B", 2)]) == [];
 }
 
 # ── v1 → v2 migration ────────────────────────────────────────────────
@@ -274,8 +272,8 @@ test "v1 blob migrates to v2 on decode and warms up MRO via mutation" {
     assert idx.type_mro_ids == [[0], [1], [2]];
 
     # Concrete-type queries work immediately on the migrated index.
-    assert idx.resolve_chain({root_id}, [(None, "NodeA", 2)]) == {child_id};
-    assert idx.resolve_chain({root_id}, [("EdgeX", "NodeA", 2)]) == {child_id};
+    assert idx.resolve_chain({root_id}, [(None, "NodeA", 2)]) == [child_id];
+    assert idx.resolve_chain({root_id}, [("EdgeX", "NodeA", 2)]) == [child_id];
 
     # Adding a new node with a real MRO chain warms up subtype queries for
     # that type. The widen-the-check logic in _ensure_type lets the longer
@@ -283,14 +281,14 @@ test "v1 blob migrates to v2 on decode and warms up MRO via mutation" {
     new_child = uuid4();
     idx.add_node(new_child, "PostNode", ["PostNode", "BaseContent"]);
     idx.add_edge(root_id, new_child, "EdgeX");
-    assert idx.resolve_chain({root_id}, [(None, "BaseContent", 2)]) == {new_child};
-    assert idx.resolve_chain({root_id}, [(None, "PostNode", 2)]) == {new_child};
+    assert idx.resolve_chain({root_id}, [(None, "BaseContent", 2)]) == [new_child];
+    assert idx.resolve_chain({root_id}, [(None, "PostNode", 2)]) == [new_child];
 
     # Re-encoding the migrated index produces a v2 blob that round-trips.
     re_decoded = TopologyIndex.decode(idx.encode());
-    assert re_decoded.resolve_chain({root_id}, [(None, "BaseContent", 2)]) == {
+    assert re_decoded.resolve_chain({root_id}, [(None, "BaseContent", 2)]) == [
         new_child
-    };
+    ];
 }
 
 # ── Compact-encoding fidelity ────────────────────────────────────────

--- a/jac/tests/runtimelib/test_topology_index.jac
+++ b/jac/tests/runtimelib/test_topology_index.jac
@@ -307,3 +307,167 @@ test "encoded size beats naive bound" {
     # Generous ceiling: 80KB.
     assert len(idx.encode()) < 80000;
 }
+
+# ── Ordered results ──────────────────────────────────────────────────
+test "resolve_chain returns results in edge insertion order" {
+    idx = TopologyIndex();
+    r = uuid4();
+    idx.add_node(r, "Root");
+    # Add nodes and edges in a specific order.
+    nodes: list[UUID] = [];
+    for i in range(10) {
+        n = uuid4();
+        idx.add_node(n, "Item");
+        idx.add_edge(r, n, "Has");
+        nodes.append(n);
+    }
+    # Result order must match insertion order.
+    assert idx.resolve_chain({r}, [("Has", "Item", 2)]) == nodes;
+}
+
+test "order preserved after removing middle edge" {
+    idx = TopologyIndex();
+    r = uuid4();
+    a = uuid4();
+    b = uuid4();
+    c = uuid4();
+    for (nid, t) in [(r, "Root"), (a, "A"), (b, "B"), (c, "C")] {
+        idx.add_node(nid, t);
+    }
+    idx.add_edge(r, a, "E");
+    idx.add_edge(r, b, "E");
+    idx.add_edge(r, c, "E");
+    # Remove the middle edge; remaining order must be [a, c].
+    idx.remove_edge(r, b, "E");
+    assert idx.resolve_chain({r}, [("E", None, 2)]) == [a, c];
+}
+
+test "order preserved after encode decode round trip" {
+    idx = TopologyIndex();
+    r = uuid4();
+    idx.add_node(r, "Root");
+    nodes: list[UUID] = [];
+    for i in range(20) {
+        n = uuid4();
+        idx.add_node(n, "N");
+        idx.add_edge(r, n, "E");
+        nodes.append(n);
+    }
+    decoded = TopologyIndex.decode(idx.encode());
+    assert decoded.resolve_chain({r}, [("E", "N", 2)]) == nodes;
+}
+
+test "multi-origin results interleaved in adj_list order" {
+    # Two origins, each with edges to distinct targets added in interleaved
+    # order. The result should follow global adj_list order.
+    idx = TopologyIndex();
+    a = uuid4();
+    b = uuid4();
+    t1 = uuid4();
+    t2 = uuid4();
+    t3 = uuid4();
+    t4 = uuid4();
+    for (nid, tp) in [
+        (a, "Src"),
+        (b, "Src"),
+        (t1, "T"),
+        (t2, "T"),
+        (t3, "T"),
+        (t4, "T")
+    ] {
+        idx.add_node(nid, tp);
+    }
+    # Interleave: a->t1, b->t2, a->t3, b->t4
+    idx.add_edge(a, t1, "E");
+    idx.add_edge(b, t2, "E");
+    idx.add_edge(a, t3, "E");
+    idx.add_edge(b, t4, "E");
+    result = idx.resolve_chain({a, b}, [("E", "T", 2)]);
+    assert result == [t1, t2, t3, t4];
+}
+
+test "slicing ordered results works correctly" {
+    idx = TopologyIndex();
+    r = uuid4();
+    idx.add_node(r, "Root");
+    nodes: list[UUID] = [];
+    for i in range(10) {
+        n = uuid4();
+        idx.add_node(n, "N");
+        idx.add_edge(r, n, "E");
+        nodes.append(n);
+    }
+    result = idx.resolve_chain({r}, [("E", "N", 2)]);
+    # Slicing the ordered result should give the expected subset.
+    assert result[2:5] == nodes[2:5];
+    assert result[:3] == nodes[:3];
+    assert result[-2:] == nodes[-2:];
+}
+
+test "order correct with mixed edge types to same targets" {
+    # Multiple edge types to the same target; the target should appear at the
+    # position of its FIRST edge in adj_list (deduped).
+    idx = TopologyIndex();
+    r = uuid4();
+    a = uuid4();
+    b = uuid4();
+    for (nid, t) in [(r, "Root"), (a, "A"), (b, "B")] {
+        idx.add_node(nid, t);
+    }
+    idx.add_edge(r, a, "E1");
+    idx.add_edge(r, b, "E2");
+    idx.add_edge(r, a, "E2");  # duplicate target a via different edge type
+    # Wildcard query: a should come first (edge at pos 0), b second (pos 1).
+    # a appears again at pos 2 but is deduped.
+    result = idx.resolve_chain({r}, [(None, None, 2)]);
+    assert result == [a, b];
+}
+
+test "multi-hop order follows final hop adj_list order" {
+    # The final result order should be determined by the adj_list order of
+    # the last hop's edges, not the intermediate hops.
+    idx = TopologyIndex();
+    r = uuid4();
+    m1 = uuid4();
+    m2 = uuid4();
+    # Final targets added in specific order via different intermediate nodes.
+    leaf_a = uuid4();
+    leaf_b = uuid4();
+    leaf_c = uuid4();
+    for (nid, t) in [
+        (r, "Root"),
+        (m1, "Mid"),
+        (m2, "Mid"),
+        (leaf_a, "Leaf"),
+        (leaf_b, "Leaf"),
+        (leaf_c, "Leaf")
+    ] {
+        idx.add_node(nid, t);
+    }
+    idx.add_edge(r, m1, "E1");
+    idx.add_edge(r, m2, "E1");
+    # m2's edges come first in adj_list for the second hop.
+    idx.add_edge(m2, leaf_b, "E2");
+    idx.add_edge(m1, leaf_a, "E2");
+    idx.add_edge(m2, leaf_c, "E2");
+    result = idx.resolve_chain({r}, [("E1", "Mid", 2), ("E2", "Leaf", 2)]);
+    # leaf_b at adj pos 2, leaf_a at adj pos 3, leaf_c at adj pos 4.
+    assert result == [leaf_b, leaf_a, leaf_c];
+}
+
+test "remove_node preserves order of remaining edges" {
+    idx = TopologyIndex();
+    r = uuid4();
+    a = uuid4();
+    b = uuid4();
+    c = uuid4();
+    for (nid, t) in [(r, "Root"), (a, "A"), (b, "B"), (c, "C")] {
+        idx.add_node(nid, t);
+    }
+    idx.add_edge(r, a, "E");
+    idx.add_edge(r, b, "E");
+    idx.add_edge(r, c, "E");
+    # Removing b should leave [a, c] in order.
+    idx.remove_node(b);
+    assert idx.resolve_chain({r}, [("E", None, 2)]) == [a, c];
+}


### PR DESCRIPTION
## Summary

- Change TopologyIndex buckets from storing node lid sets (`set[int]`) to sorted adj_list index lists (`list[int]`), enabling ordered merge-intersections at every hop
- `resolve_chain` now returns `list[UUID]` in edge-insertion order, eliminating the need for the separate `resolve_chain_ordered` method
- Remove `plan_chain_ordered` from the planner; `plan_chain` now returns an ordered `list[UUID]`
- Simplify `remove_edge`: storing individual edge indices removes the need for `edge_type_still_connects` / `any_edge_remains` connectivity checks
- Extract `_index_edge` and `_rebuild_buckets` helpers to reduce duplication between `add_edge` and `decode`

## Test plan

- [x] All 17 topology index unit tests pass
- [x] Planner module loads and imports correctly
- [ ] CI passes

Resolves: Issue #6593