### PR TITLE
fix(compiler): accept subscripted/generic types in lambda param annotations

### DIFF
--- a/jac/jaclang/jac0core/parser/impl/parser.impl.jac
+++ b/jac/jaclang/jac0core/parser/impl/parser.impl.jac
@@ -3121,41 +3121,30 @@ impl Parser.parse_lambda_param -> ParamVar | None {
         return None;
     }
     type_tag: SubTag | None = None;
-    # Heuristic to distinguish type annotation from lambda body colon:
-    # Type annotation COLON is followed by a type and then COMMA, EQ, COLON, RETURN_HINT, or LBRACE
+    # An un-parenthesized lambda reuses `:` for both the param annotation and
+    # the body separator: `name : <type> : <body>`. Unlike `def`/`has` params
+    # (whose colon is unambiguous), disambiguate by parsing the candidate type
+    # with parse_bitwise_or — the precedence rung that covers type syntax
+    # (names, dotted, subscripts like `list[int]`/`dict[str, int]`, `|` unions)
+    # but stops below comparison and other operators. A real type lands on a
+    # param/body delimiter (`:` `,` `=` `->` `{`); a body like `len(s) > 1,`
+    # stops at `>` and `-x` at `-`, so the trailing-token check rejects them and
+    # the colon falls through to the body.
     if self.check(TokenKind.COLON) {
-        next_tok = self.peek();
-        is_type_annotation = False;
-        if next_tok.kind in [
-            TokenKind.NAME,
-            TokenKind.TYP_STRING,
-            TokenKind.TYP_INT,
-            TokenKind.TYP_FLOAT,
-            TokenKind.TYP_LIST,
-            TokenKind.TYP_TUPLE,
-            TokenKind.TYP_SET,
-            TokenKind.TYP_DICT,
-            TokenKind.TYP_BOOL,
-            TokenKind.TYP_BYTES,
-            TokenKind.TYP_ANY,
-            TokenKind.TYP_TYPE
-        ] {
-            after_type = self.peek(2);
-            if after_type.kind in [
-                TokenKind.COMMA,
-                TokenKind.EQ,
-                TokenKind.COLON,
-                TokenKind.RETURN_HINT,
-                TokenKind.LBRACE
-            ] {
-                is_type_annotation = True;
-            }
-        }
-        if is_type_annotation {
-            self.advance();  # consume COLON
-            lam_colon = self.make_uni_token(self.previous());
-            te = self.parse_pipe();
+        save_pos = self.pos;
+        self.advance();  # consume COLON
+        lam_colon = self.make_uni_token(self.previous());
+        te = self.parse_bitwise_or();
+        if self.check_any(
+            TokenKind.COMMA,
+            TokenKind.EQ,
+            TokenKind.COLON,
+            TokenKind.RETURN_HINT,
+            TokenKind.LBRACE
+        ) {
             type_tag = SubTag(tag=te, kid=[lam_colon, te]);
+        } else {
+            self.pos = save_pos;  # not a type — the colon belongs to the body
         }
     }
     default_val: Expr | None = None;

--- a/jac/tests/language/fixtures/lambda_arg_annotation.jac
+++ b/jac/tests/language/fixtures/lambda_arg_annotation.jac
@@ -9,3 +9,12 @@ with entry {
     f = lambda  x: any: "even" if x % 2 == 0 else "odd";
     print(f(7));
 }
+
+with entry {
+    g = lambda d: list[int] : d[0];
+    print(g([10, 20]));
+    h = lambda d: dict[str, int] : d["n"];
+    print(h({"n": 42}));
+    k = lambda v: int | str : v;
+    print(k(7));
+}

--- a/jac/tests/language/test_cli.jac
+++ b/jac/tests/language/test_cli.jac
@@ -675,6 +675,9 @@ test "lambda arg annotation" {
     assert "x = lambda a, b: b + a" in stdout_value;
     assert "y = lambda: 567" in stdout_value;
     assert "f = lambda x: 'even' if x % 2 == 0 else 'odd'" in stdout_value;
+    assert "g = lambda d: d[0]" in stdout_value;
+    assert "h = lambda d: d['n']" in stdout_value;
+    assert "k = lambda v: v" in stdout_value;
 }
 
 test "lambda self" {


### PR DESCRIPTION
Fixes #6773.

## Problem

Jac's lambda syntax supports an explicit parameter type annotation (`lambda <name>: <type> : <body>`), but the annotation slot only accepted a **bare type name**. Any subscripted/generic type (`X[...]`) there was a parse error:

```jac
f1 = lambda d: dict : d["n"];            # OK
f2 = lambda d: list[int] : d[0];         # E0002 "Missing ';'" + E0004
f3 = lambda d: dict[str, int] : d["n"];  # same parse failure
```

This was inconsistent with `def f(d: dict[str, int])` and `has x: dict[str, int]`, which accept the full type-expression grammar.

## Root cause

`parse_lambda_param` disambiguated the param-annotation colon from the lambda body colon with a **fixed two-token lookahead**: it required `peek()` to be a type-name token *and* `peek(2)` to be a delimiter (`,` `=` `:` `->` `{`). For `list[int]`, the token after `list` is `[` — not a delimiter — so the annotation was never recognized, the colon fell through to the body, and the trailing body colon was left dangling.

## Fix

Replace the lookahead with **parse-and-backtrack**: consume the colon, parse the candidate type with `parse_bitwise_or` (the precedence rung that covers names, dotted paths, subscripts like `list[int]`/`dict[str, int]`, and `|` unions, but stops below comparison/arithmetic), then accept it as the annotation only if the parser lands on a real delimiter — otherwise reset `pos` so the colon belongs to the body.

This keeps non-annotation colons working: `lambda d: d[0]`, `lambda s: len(s) > 1`, and `lambda x: -x` still parse with the colon as the body separator.

## Acceptance (from the issue)

- [x] `lambda d: list[int] : d[0]` and `lambda d: dict[str, int] : d["n"]` parse without error
- [x] Existing bare-type lambdas still parse
- [x] No regression in parser/checker test suites

## Tests

Extended `tests/language/fixtures/lambda_arg_annotation.jac` with subscripted, generic, and union annotations, plus matching `jac2py` assertions in `tests/language/test_cli.jac` (annotations are stripped in the Python output; bodies preserved). Verified the repro cases parse, check, and run; confirmed identical pre-existing (unrelated) failures before/after — zero regressions.