### PR TITLE
fix(ci): repair main jac-check (syntax error in test_prim_equivalence + unformatted microservice tests)

### DIFF
--- a/jac/jaclang/compiler/tests/test_prim_equivalence.jac
+++ b/jac/jaclang/compiler/tests/test_prim_equivalence.jac
@@ -249,6 +249,7 @@ test "json bundled" {
 test "base64 bundled" {
     run_with_both(
         "prim_base64.jac", "base64_py", "base64_cl", "base64_na", require=["na"]
+    );
 }
 
 test "textwrap bundled" {

--- a/jac/jaclang/scale/tests/microservices/test_discovery.jac
+++ b/jac/jaclang/scale/tests/microservices/test_discovery.jac
@@ -258,9 +258,7 @@ test "discover_sv_service_files maps a subdir service to its real relative path"
     tmp = Path(tempfile.mkdtemp());
     (tmp / "jac.toml").write_text("[project]\nname = \"app\"\n");
     (tmp / "main.jac").write_text("with entry { print(1); }\n");
-    (tmp / "analytics.jac").write_text(
-        "to sv:\ndef:pub stats -> int { return 1; }\n"
-    );
+    (tmp / "analytics.jac").write_text("to sv:\ndef:pub stats -> int { return 1; }\n");
     sub = tmp / "littlex";
     sub.mkdir();
     (sub / "social_graph.jac").write_text(
@@ -273,9 +271,7 @@ test "discover_sv_service_files maps a subdir service to its real relative path"
         );
         assert files.get("social_graph") == os.path.join(
             "littlex", "social_graph.jac"
-        ) , (
-            f"subdir service must keep its relative path, got: {files}"
-        );
+        ) , (f"subdir service must keep its relative path, got: {files}");
     } finally {
         shutil.rmtree(str(tmp), ignore_errors=True);
     }
@@ -312,9 +308,7 @@ test "resolve_service_files falls back to <name>.jac for import-only routes" {
     (tmp / "jac.toml").write_text("[project]\nname = \"app\"\n");
     (tmp / "main.jac").write_text("sv import from remote_app { f }\n");
     try {
-        files = resolve_service_files(
-            str(tmp / "main.jac"), {"remote_app": "/remote"}
-        );
+        files = resolve_service_files(str(tmp / "main.jac"), {"remote_app": "/remote"});
         assert files == {"remote_app": "remote_app.jac"} , (
             f"import-only service must fall back to <name>.jac, got: {files}"
         );

--- a/jac/jaclang/scale/tests/microservices/test_gateway.jac
+++ b/jac/jaclang/scale/tests/microservices/test_gateway.jac
@@ -319,7 +319,7 @@ def _serve_fragment(payload: dict) -> tuple {
 
     body = json.dumps(payload).encode();
 
-    def _do_get(handler_self: any) -> None {
+    def _do_get(handler_self: any) {
         handler_self.send_response(200);
         handler_self.send_header("Content-Type", "application/json");
         handler_self.send_header("Content-Length", str(len(body)));
@@ -327,7 +327,7 @@ def _serve_fragment(payload: dict) -> tuple {
         handler_self.wfile.write(body);
     }
 
-    def _log_quiet(handler_self: any, fmt: str, *args: any) -> None {}
+    def _log_quiet(handler_self: any, fmt: str, *args: any) { }
 
     handler_cls = type(
         "_FragmentHandler",
@@ -401,11 +401,7 @@ test "/graph/data merges the graph fragments of every healthy service" {
 }
 
 test "/graph/data still answers when one service is down (partial merge)" {
-    frag_a = {
-        "version": "1.0",
-        "nodes": [{"id": "r", "label": "root"}],
-        "edges": []
-    };
+    frag_a = {"version": "1.0", "nodes": [{"id": "r", "label": "root"}], "edges": []};
     (srv_a, port_a) = _serve_fragment(frag_a);
 
     reg = ServiceRegistry();

--- a/jac/jaclang/scale/tests/microservices/test_orchestrator.jac
+++ b/jac/jaclang/scale/tests/microservices/test_orchestrator.jac
@@ -124,7 +124,7 @@ test "_wait_for_health does not burn the boot budget on a dead child" {
 
     orch = MicroserviceOrchestrator(ms_config={});
     with mock.patch.object(
-        pm, "check_health", side_effect=(lambda name: name == "alive")
+        pm, "check_health", side_effect=(lambda name : name == "alive")
     ) {
         start = time.time();
         orch._wait_for_health(pm, reg, 6);

--- a/jac/jaclang/scale/tests/microservices/test_process_manager.jac
+++ b/jac/jaclang/scale/tests/microservices/test_process_manager.jac
@@ -203,9 +203,7 @@ test "start service passes the registry's subdir file path to jac start" {
     reg = ServiceRegistry();
     reg.register(
         ServiceEntry(
-            name="social_graph",
-            file="littlex/social_graph.jac",
-            prefix="/social_graph"
+            name="social_graph", file="littlex/social_graph.jac", prefix="/social_graph"
         )
     );
     pm = ServiceProcessManager(registry=reg);
@@ -279,9 +277,11 @@ test "check all health reports a dead process once, not every poll" {
         pm.check_all_health();
         pm.check_all_health();
         exit_reports = [
-            c for c in (
-                list(fake_log.warning.call_args_list)
-                + list(fake_log.error.call_args_list)
+            c
+            for c in (
+                list(fake_log.warning.call_args_list) + list(
+                    fake_log.error.call_args_list
+                )
             )
             if "exited" in str(c)
         ];


### PR DESCRIPTION
## Why

Main's `jac-check` job has failed on every CI run since the workflow consolidation (#7125), for two accumulated reasons:

1. **Parse error in `jac/jaclang/compiler/tests/test_prim_equivalence.jac`** — the `"base64 bundled"` test block landed in #7086 missing the closing `);` of its `run_with_both(` call (`line 252, col 1: Missing ',' / Unexpected token`). That commit's own main run was cancelled by the push-concurrency group (#7087 landed right behind it), so the breakage was never gated.

2. **Four unformatted files under `jac/jaclang/scale/tests/microservices/`** (`test_discovery`, `test_gateway`, `test_orchestrator`, `test_process_manager`) — flagged by the consolidated `jac format --check --lintfix` sweep since the first post-#7125 run.

## What

- Restore the missing `);` in the base64 test block.
- Run `jac format --lintfix` on the four microservice test files. The diff is stylistic only (re-wraps, plus a redundant `-> None` dropped by the lint fixer).

Verified locally that all five files now pass `jac format --check --lintfix`.
