### PR TITLE
fix(scale): delete the managed fleet before the bundle PVC on destroy

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7283.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7283.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `jac destroy` no longer hangs on the bundle PVC**: the teardown now deletes the label-managed microservice/gateway deployments before the RWX bundle PVC they mount, so the `pvc-protection` finalizer releases on its own instead of wedging "Waiting for all resources to be deleted" until the pods are deleted by hand.

--- a/jac/jaclang/scale/deploy/target/kubernetes/kubernetes_target.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/kubernetes_target.jac
@@ -1424,9 +1424,27 @@ obj KubernetesTarget(DeploymentTarget) {
         self._destroy_dashboard(app_name, namespace, apps_v1, core_v1);
     }
 
+    def _destroy_managed_workloads(namespace: str, apps_v1: any) {
+        # Microservice-mode deployments are label-managed, not app_name-named.
+        # They must go before the bundle PVC they mount, or the pvc-protection
+        # finalizer holds the PVC (and the whole teardown) until the namespace
+        # cascade finally kills the pods.
+        try {
+            apps_v1.delete_collection_namespaced_deployment(
+                namespace=namespace,
+                label_selector="managed=jac-scale,jac-scale.role in (microservice,gateway)"
+            );
+        } except ApiException as e {
+            if e.status != 404 {
+                raise;
+            }
+        }
+    }
+
     def _destroy_application(
         app_name: str, namespace: str, apps_v1: any, core_v1: any
     ) {
+        self._destroy_managed_workloads(namespace, apps_v1);
         autoscaler = AutoscalerFactory.create(
             self.k8s_config.autoscaler_engine, self.k8s_config.to_dict(), self.logger
         );

--- a/jac/jaclang/scale/deploy/target/kubernetes/kubernetes_target.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/kubernetes_target.jac
@@ -1425,10 +1425,6 @@ obj KubernetesTarget(DeploymentTarget) {
     }
 
     def _destroy_managed_workloads(namespace: str, apps_v1: any) {
-        # Microservice-mode deployments are label-managed, not app_name-named.
-        # They must go before the bundle PVC they mount, or the pvc-protection
-        # finalizer holds the PVC (and the whole teardown) until the namespace
-        # cascade finally kills the pods.
         try {
             apps_v1.delete_collection_namespaced_deployment(
                 namespace=namespace,

--- a/jac/jaclang/scale/scripts/k8s_microservice_real_e2e.sh
+++ b/jac/jaclang/scale/scripts/k8s_microservice_real_e2e.sh
@@ -590,6 +590,40 @@ else
         "200|404|405|000" "${FIRST_SVC}-deployment" "" "5"
 fi
 
+_t "destroy start"
+echo "=== destroy: teardown must complete without manual pod deletion ==="
+# Same dispatch as `jac destroy` (default target): the base KubernetesTarget
+# must delete the label-managed fleet before the bundle PVC, or pvc-protection
+# wedges the teardown until someone deletes the pods by hand.
+if [ -n "${PORT_FORWARD_PID:-}" ]; then
+    kill "${PORT_FORWARD_PID}" 2>/dev/null || true
+    PORT_FORWARD_PID=""
+fi
+if [ -n "${LOKI_PORT_FORWARD_PID:-}" ]; then
+    kill "${LOKI_PORT_FORWARD_PID}" 2>/dev/null || true
+    LOKI_PORT_FORWARD_PID=""
+fi
+cd "${PROJECT_DIR}"
+timeout 420 jac - <<PYEOF
+from jaclang.scale.deploy.target.kubernetes.kubernetes_target import KubernetesTarget
+from jaclang.scale.deploy.target.kubernetes.kubernetes_config import KubernetesConfig
+
+KubernetesTarget(
+    config=KubernetesConfig(app_name="jac-e2e", namespace="${NAMESPACE}")
+).destroy("jac-e2e")
+PYEOF
+
+if kubectl get deploy -n "${NAMESPACE}" -l managed=jac-scale -o name 2>/dev/null | grep -q .; then
+    echo "FAIL: label-managed deployments survived destroy" >&2
+    exit 1
+fi
+if ! timeout 300 bash -c 'until ! kubectl get namespace "$1" >/dev/null 2>&1; do sleep 5; done' _ "${NAMESPACE}"; then
+    echo "FAIL: namespace '${NAMESPACE}' still present 300s after destroy" >&2
+    kubectl get pvc,pods -n "${NAMESPACE}" 2>/dev/null || true
+    exit 1
+fi
+echo "  destroy released the bundle PVC and deleted the namespace"
+
 _t "ALL DONE"
 print_timing_report
 echo "=== K8s microservice REAL e2e PASSED ==="

--- a/jac/jaclang/scale/scripts/k8s_microservice_real_e2e.sh
+++ b/jac/jaclang/scale/scripts/k8s_microservice_real_e2e.sh
@@ -592,9 +592,6 @@ fi
 
 _t "destroy start"
 echo "=== destroy: teardown must complete without manual pod deletion ==="
-# Same dispatch as `jac destroy` (default target): the base KubernetesTarget
-# must delete the label-managed fleet before the bundle PVC, or pvc-protection
-# wedges the teardown until someone deletes the pods by hand.
 if [ -n "${PORT_FORWARD_PID:-}" ]; then
     kill "${PORT_FORWARD_PID}" 2>/dev/null || true
     PORT_FORWARD_PID=""

--- a/jac/jaclang/scale/tests/deploy/test_destroy_ordering.jac
+++ b/jac/jaclang/scale/tests/deploy/test_destroy_ordering.jac
@@ -1,0 +1,73 @@
+import unittest.mock;
+import from kubernetes.client.exceptions { ApiException }
+import from jaclang.scale.deploy.target.kubernetes.kubernetes_target {
+    KubernetesTarget
+}
+import from jaclang.scale.deploy.target.kubernetes.kubernetes_config {
+    KubernetesConfig
+}
+
+glob MS_SELECTOR: str = (
+         "managed=jac-scale,jac-scale.role in (microservice,gateway)"
+     );
+
+
+def _target -> KubernetesTarget {
+    return KubernetesTarget(config=KubernetesConfig(namespace="jac-test"));
+}
+
+
+def _run_destroy_application(mgr: unittest.mock.MagicMock) {
+    with unittest.mock.patch(
+        "jaclang.scale.deploy.target.kubernetes.kubernetes_target.AutoscalerFactory"
+    ) {
+        with unittest.mock.patch(
+            "kubernetes.client.NetworkingV1Api", return_value=unittest.mock.MagicMock()
+        ) {
+            _target()._destroy_application("shop", "jac-test", mgr.apps, mgr.core);
+        }
+    }
+}
+
+
+test "label-managed workloads are deleted before the bundle PVC" {
+    # Microservice deployments are label-managed, not app_name-named; deleting
+    # the PVC first leaves it Terminating on pvc-protection until the pods die.
+    mgr = unittest.mock.MagicMock();
+    _run_destroy_application(mgr);
+
+    calls = [str(c[0]) for c in mgr.mock_calls];
+    workloads = calls.index("apps.delete_collection_namespaced_deployment");
+    pvc = calls.index("core.delete_namespaced_persistent_volume_claim");
+    assert workloads < pvc;
+
+    kwargs = mgr.apps.delete_collection_namespaced_deployment.call_args.kwargs;
+    assert kwargs["label_selector"] == MS_SELECTOR;
+    assert kwargs["namespace"] == "jac-test";
+}
+
+
+test "a cluster with no managed workloads (404) does not abort the teardown" {
+    mgr = unittest.mock.MagicMock();
+    mgr.apps.delete_collection_namespaced_deployment.side_effect = ApiException(
+        status=404
+    );
+    _run_destroy_application(mgr);
+    mgr.core.delete_namespaced_persistent_volume_claim.assert_called();
+}
+
+
+test "non-404 errors deleting managed workloads do abort" {
+    mgr = unittest.mock.MagicMock();
+    mgr.apps.delete_collection_namespaced_deployment.side_effect = ApiException(
+        status=500
+    );
+    caught = False;
+    try {
+        _run_destroy_application(mgr);
+    } except ApiException {
+        caught = True;
+    }
+    assert caught;
+    mgr.core.delete_namespaced_persistent_volume_claim.assert_not_called();
+}

--- a/jac/jaclang/scale/tests/deploy/test_destroy_ordering.jac
+++ b/jac/jaclang/scale/tests/deploy/test_destroy_ordering.jac
@@ -31,8 +31,6 @@ def _run_destroy_application(mgr: unittest.mock.MagicMock) {
 
 
 test "label-managed workloads are deleted before the bundle PVC" {
-    # Microservice deployments are label-managed, not app_name-named; deleting
-    # the PVC first leaves it Terminating on pvc-protection until the pods die.
     mgr = unittest.mock.MagicMock();
     _run_destroy_application(mgr);
 


### PR DESCRIPTION
## Summary

Fixes the teardown hang reported in the "Related (separate bug)" section of #7250. `jac destroy` dispatches to the base `KubernetesTarget` by default, whose `_destroy_application` only deletes a deployment literally named `app_name`. Microservice-mode deployments (`gateway-deployment-*`, `<svc>-deployment-*`) are label-managed, so they were never deleted; the RWX bundle PVC their pods mount was deleted anyway and sat Terminating on the `pvc-protection` finalizer, wedging "Waiting for all resources to be deleted" until someone deleted the deployments by hand.

- `_destroy_application` now deletes the label-managed workloads (`managed=jac-scale,jac-scale.role in (microservice,gateway)`) before any PVC delete, so the PVC releases as soon as the pods drain. This covers both the full `destroy()` and `--component application`.
- The real-cluster e2e (`k8s_microservice_real_e2e.sh`) gains a destroy phase: after the functional checks it runs the same base-target teardown and fails unless the managed deployments, the bundle PVC and the namespace are all gone within the timeout, with no manual pod deletion.

A companion PR completes the `KubernetesMicroserviceTarget.destroy` path (it currently leaks PVCs and the namespace when called directly).

## Tests

New `jac test jac/jaclang/scale/tests/deploy/test_destroy_ordering.jac` (3 passed):
- managed-workload deletion happens strictly before the bundle PVC delete, with the exact label selector
- a 404 (no managed workloads, plain single-service app) does not abort the teardown
- non-404 API errors still abort

Plus the new e2e destroy phase (runs on a real cluster via the existing script).