### PR TITLE
fix(scale): complete the microservice destroy path via the base teardown

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7284.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7284.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: microservice destroy no longer leaks resources**: `KubernetesMicroserviceTarget.destroy` now delegates the shared teardown (monitoring, databases, PVCs, namespace) to the base target after its label-based fleet cleanup, and `--component` destroys pass through instead of being ignored.

--- a/jac/jaclang/scale/deploy/target/kubernetes/microservice/target.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/microservice/target.jac
@@ -798,10 +798,6 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
             }
         }
 
-        # Shared teardown (monitoring, ingress controller, databases, PVCs,
-        # deletion wait, namespace): without it a direct microservice destroy
-        # leaked the bundle PVC and the namespace. The fleet is already gone,
-        # so the bundle PVC releases without waiting on pod finalizers.
         super.destroy(app_name);
     }
 }

--- a/jac/jaclang/scale/deploy/target/kubernetes/microservice/target.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/microservice/target.jac
@@ -700,6 +700,10 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
     }
 
     def destroy(app_name: str, component: str = "") {
+        if component {
+            super.destroy(app_name, component);
+            return;
+        }
         if self.logger {
             self.logger.info(
                 f"Destroying microservice topology in namespace "
@@ -794,16 +798,10 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
             }
         }
 
-        try {
-            monitoring = MonitoringDeployer(self.k8s_config, self.logger);
-            monitoring.destroy(app_name, namespace, apps_v1, core_v1);
-        } except Exception as e {
-            if self.logger {
-                self.logger.info(
-                    f"Observability stack destroy reported a non-fatal error: {e}",
-                    {"app_name": app_name}
-                );
-            }
-        }
+        # Shared teardown (monitoring, ingress controller, databases, PVCs,
+        # deletion wait, namespace): without it a direct microservice destroy
+        # leaked the bundle PVC and the namespace. The fleet is already gone,
+        # so the bundle PVC releases without waiting on pod finalizers.
+        super.destroy(app_name);
     }
 }

--- a/jac/jaclang/scale/tests/microservices/test_ms_destroy.jac
+++ b/jac/jaclang/scale/tests/microservices/test_ms_destroy.jac
@@ -1,0 +1,74 @@
+import unittest.mock;
+import from types { SimpleNamespace }
+import from jaclang.scale.deploy.target.kubernetes.kubernetes_target {
+    KubernetesTarget
+}
+import from jaclang.scale.deploy.target.kubernetes.microservice.target {
+    KubernetesMicroserviceTarget
+}
+import from jaclang.scale.deploy.target.kubernetes.kubernetes_config {
+    KubernetesConfig
+}
+
+
+def _destroy(mgr: unittest.mock.MagicMock, component: str = "") {
+    mgr.core.list_namespaced_service.return_value = SimpleNamespace(items=[]);
+    target = KubernetesMicroserviceTarget(
+        config=KubernetesConfig(namespace="jac-test")
+    );
+    with unittest.mock.patch.object(
+        KubernetesMicroserviceTarget, "_load_kube_config", unittest.mock.MagicMock()
+    ) {
+        with unittest.mock.patch.object(KubernetesTarget, "destroy", mgr.base) {
+            with unittest.mock.patch(
+                "jaclang.scale.deploy.target.kubernetes.microservice.target.AutoscalerFactory"
+            ) {
+                with unittest.mock.patch(
+                    "kubernetes.client.AppsV1Api", return_value=mgr.apps
+                ) {
+                    with unittest.mock.patch(
+                        "kubernetes.client.CoreV1Api", return_value=mgr.core
+                    ) {
+                        with unittest.mock.patch(
+                            "kubernetes.client.PolicyV1Api", return_value=mgr.policy
+                        ) {
+                            with unittest.mock.patch(
+                                "kubernetes.client.NetworkingV1Api",
+                                return_value=mgr.net
+                            ) {
+                                target.destroy("shop", component);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+test "microservice destroy hands shared teardown to the base target" {
+    # Without the base pass the bundle PVC and the namespace leak: nothing in
+    # the label-based cleanup deletes them.
+    mgr = unittest.mock.MagicMock();
+    _destroy(mgr);
+    mgr.base.assert_called_once_with("shop");
+}
+
+
+test "the fleet is deleted before the base teardown removes the PVCs" {
+    mgr = unittest.mock.MagicMock();
+    _destroy(mgr);
+    calls = [str(c[0]) for c in mgr.mock_calls];
+    fleet = calls.index("apps.delete_collection_namespaced_deployment");
+    base = calls.index("base");
+    assert fleet < base;
+}
+
+
+test "component destroy passes straight through to the base target" {
+    mgr = unittest.mock.MagicMock();
+    _destroy(mgr, component="database");
+    mgr.base.assert_called_once_with("shop", "database");
+    mgr.apps.delete_collection_namespaced_deployment.assert_not_called();
+}

--- a/jac/jaclang/scale/tests/microservices/test_ms_destroy.jac
+++ b/jac/jaclang/scale/tests/microservices/test_ms_destroy.jac
@@ -1,3 +1,4 @@
+import contextlib;
 import unittest.mock;
 import from types { SimpleNamespace }
 import from jaclang.scale.deploy.target.kubernetes.kubernetes_target {
@@ -11,45 +12,49 @@ import from jaclang.scale.deploy.target.kubernetes.kubernetes_config {
 }
 
 
+def _mocked_cluster(mgr: unittest.mock.MagicMock) -> contextlib.ExitStack {
+    stack = contextlib.ExitStack();
+    stack.enter_context(
+        unittest.mock.patch.object(
+            KubernetesMicroserviceTarget, "_load_kube_config", unittest.mock.MagicMock()
+        )
+    );
+    stack.enter_context(
+        unittest.mock.patch.object(KubernetesTarget, "destroy", mgr.base)
+    );
+    stack.enter_context(
+        unittest.mock.patch(
+            "jaclang.scale.deploy.target.kubernetes.microservice.target.AutoscalerFactory"
+        )
+    );
+    stack.enter_context(
+        unittest.mock.patch("kubernetes.client.AppsV1Api", return_value=mgr.apps)
+    );
+    stack.enter_context(
+        unittest.mock.patch("kubernetes.client.CoreV1Api", return_value=mgr.core)
+    );
+    stack.enter_context(
+        unittest.mock.patch("kubernetes.client.PolicyV1Api", return_value=mgr.policy)
+    );
+    stack.enter_context(
+        unittest.mock.patch("kubernetes.client.NetworkingV1Api", return_value=mgr.net)
+    );
+    return stack;
+}
+
+
 def _destroy(mgr: unittest.mock.MagicMock, component: str = "") {
     mgr.core.list_namespaced_service.return_value = SimpleNamespace(items=[]);
     target = KubernetesMicroserviceTarget(
         config=KubernetesConfig(namespace="jac-test")
     );
-    with unittest.mock.patch.object(
-        KubernetesMicroserviceTarget, "_load_kube_config", unittest.mock.MagicMock()
-    ) {
-        with unittest.mock.patch.object(KubernetesTarget, "destroy", mgr.base) {
-            with unittest.mock.patch(
-                "jaclang.scale.deploy.target.kubernetes.microservice.target.AutoscalerFactory"
-            ) {
-                with unittest.mock.patch(
-                    "kubernetes.client.AppsV1Api", return_value=mgr.apps
-                ) {
-                    with unittest.mock.patch(
-                        "kubernetes.client.CoreV1Api", return_value=mgr.core
-                    ) {
-                        with unittest.mock.patch(
-                            "kubernetes.client.PolicyV1Api", return_value=mgr.policy
-                        ) {
-                            with unittest.mock.patch(
-                                "kubernetes.client.NetworkingV1Api",
-                                return_value=mgr.net
-                            ) {
-                                target.destroy("shop", component);
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    with _mocked_cluster(mgr) {
+        target.destroy("shop", component);
     }
 }
 
 
 test "microservice destroy hands shared teardown to the base target" {
-    # Without the base pass the bundle PVC and the namespace leak: nothing in
-    # the label-based cleanup deletes them.
     mgr = unittest.mock.MagicMock();
     _destroy(mgr);
     mgr.base.assert_called_once_with("shop");


### PR DESCRIPTION
## Summary

Companion to #7283 (found while validating the teardown bug in #7250). `KubernetesMicroserviceTarget.destroy` only deleted its label-managed resources (deployments, autoscalers, PDBs, ingresses, services, source config maps) plus monitoring, so calling it directly leaked the RWX bundle PVC, secrets, provisioned databases and the namespace itself. Its `component` parameter was also accepted and silently ignored.

- After the label-based cleanup (fleet first, so no pod finalizers pin the bundle PVC), destroy now delegates the shared teardown to `KubernetesTarget.destroy`: monitoring, ingress controller, databases, all app PVCs, the deletion wait and the namespace delete.
- `--component` destroys pass straight through to the base component dispatch instead of tearing down the whole fleet.
- The duplicated `MonitoringDeployer.destroy` call is gone (the base pass owns it).

Together with #7283 both destroy entry points (the `jac destroy` CLI default and the programmatic microservice target) now finish on their own, in the right order.

## Tests

New `jac test jac/jaclang/scale/tests/microservices/test_ms_destroy.jac` (3 passed):
- destroy hands shared teardown to the base target exactly once
- the fleet delete-collection strictly precedes the base pass (PVC ordering)
- `component=` destroys pass through without touching the fleet

The e2e destroy phase added in #7283 covers the real-cluster behavior.