### PR TITLE
fix(formatter): identity-based body membership for synthesized IR

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7331.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7331.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix(formatter): identity-based body membership for synthesized IR**: `DocIRGenPass` now uses `is_body_member` (node identity) instead of source-span `is_within` when placing formatter body blocks, fixing spurious blank lines in synthesized control-flow IR. `PyastBuildPass` also stamps real `lineno`/`col_offset` on `break`/`continue` tokens.

--- a/jac/jaclang/compiler/passes/main/impl/pyast_load_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/pyast_load_pass.impl.jac
@@ -1254,18 +1254,25 @@ impl PyastBuildPass.proc_dict(nd: py_ast.Dict) -> uni.DictVal {
 }
 
 impl PyastBuildPass.proc_continue(nd: py_ast.Continue) -> uni.CtrlStmt {
+    (ln, col) = self.ctrl_loc(nd);
     continue_tok = uni.Token(
         orig_src=self.orig_src,
         name=Tok.KW_CONTINUE,
         value='continue',
-        line=0,
-        end_line=0,
-        col_start=0,
-        col_end=0,
+        line=ln,
+        end_line=ln,
+        col_start=col,
+        col_end=col + 8,
         pos_start=0,
-        pos_end=0
+        pos_end=8
     );
     return uni.CtrlStmt(ctrl=continue_tok, kid=[continue_tok]);
+}
+
+impl PyastBuildPass.ctrl_loc(nd: object) -> tuple[int, int] {
+    ln = getattr(nd, "lineno", 0) or 0;
+    col = getattr(nd, "col_offset", 0) or 0;
+    return (ln, col);
 }
 
 impl PyastBuildPass.proc_constant(nd: py_ast.Constant) -> uni.Literal {
@@ -1382,16 +1389,17 @@ impl PyastBuildPass.proc_call(nd: py_ast.Call) -> uni.FuncCall {
 }
 
 impl PyastBuildPass.proc_break(nd: py_ast.Break) -> uni.CtrlStmt {
+    (ln, col) = self.ctrl_loc(nd);
     break_tok = uni.Token(
         orig_src=self.orig_src,
         name=Tok.KW_BREAK,
         value='break',
-        line=0,
-        end_line=0,
-        col_start=0,
-        col_end=0,
+        line=ln,
+        end_line=ln,
+        col_start=col,
+        col_end=col + 5,
         pos_start=0,
-        pos_end=0
+        pos_end=5
     );
     return uni.CtrlStmt(ctrl=break_tok, kid=[break_tok]);
 }

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.jac
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.jac
@@ -121,6 +121,7 @@ obj PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]) {
     def proc_arg(nd: py_ast.arg) -> uni.ParamVar;
     def proc_arguments(nd: py_ast.arguments) -> uni.FuncSignature;
     def operator(tok: Tok, value: str) -> uni.Token;
+    def ctrl_loc(nd: object) -> tuple[int, int];
     def proc_and(nd: py_ast.And) -> uni.Token;
     def proc_or(nd: py_ast.Or) -> uni.Token;
     def proc_add(nd: py_ast.Add) -> uni.Token;

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.jac
@@ -58,6 +58,7 @@ obj DocIRGenPass(UniPass) {
     ) -> None;
 
     def is_within(kid_node: uni.UniNode, block: Sequence[uni.UniNode]) -> bool;
+    def is_body_member(kid_node: uni.UniNode, block: Sequence[uni.UniNode]) -> bool;
     def trim_trailing_line(parts: list[doc.DocType]) -> None;
     def jsx_whitespace -> doc.DocType;
     def jsx_mixed_child_parts(children: Sequence[uni.UniNode]) -> list[doc.DocType];

--- a/jac/jaclang/compiler/passes/tool/impl/doc_ir_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/doc_ir_gen_pass.impl.jac
@@ -1271,7 +1271,7 @@ impl DocIRGenPass.exit_with_stmt(nd: uni.WithStmt) -> None {
     parts: list[doc.DocType] = [];
     body_parts: list[doc.DocType] = [self.hard_line()];
     for i in nd.kid {
-        if (isinstance(nd.body, Sequence) and self.is_within(i, nd.body)) {
+        if (isinstance(nd.body, Sequence) and self.is_body_member(i, nd.body)) {
             if (i == nd.body[0]) {
                 parts.append(self.indent(self.concat(body_parts), ast_node=nd));
                 parts.append(self.hard_line());
@@ -1668,7 +1668,9 @@ impl DocIRGenPass.exit_if_stmt(nd: uni.IfStmt) -> None {
             } elif (isinstance(i, uni.Token) and (i.name == Tok.RBRACE)) {
                 parts.append(self.line());
                 parts.append(i.gen.doc_ir);
-            } elif (isinstance(nd.body, Sequence) and self.is_within(i, nd.body)) {
+            } elif (
+                isinstance(nd.body, Sequence) and self.is_body_member(i, nd.body)
+            ) {
                 if not body_placed {
                     parts.append(
                         self.indent(
@@ -1689,7 +1691,7 @@ impl DocIRGenPass.exit_if_stmt(nd: uni.IfStmt) -> None {
     body_parts: list[doc.DocType] = [self.hard_line()];
     prev_body_item: (uni.UniNode | None) = None;
     for i in nd.kid {
-        if (isinstance(nd.body, Sequence) and self.is_within(i, nd.body)) {
+        if (isinstance(nd.body, Sequence) and self.is_body_member(i, nd.body)) {
             if (i == nd.body[0]) {
                 parts.append(self.indent(self.concat(body_parts), ast_node=nd));
                 parts.append(self.hard_line());
@@ -2221,6 +2223,20 @@ impl DocIRGenPass.is_within(
     return (first and last);
 }
 
+impl DocIRGenPass.is_body_member(
+    kid_node: uni.UniNode, block: Sequence[uni.UniNode]
+) -> bool {
+    if not block {
+        return False;
+    }
+    for member in block {
+        if kid_node is member {
+            return True;
+        }
+    }
+    return False;
+}
+
 impl DocIRGenPass.add_body_stmt_with_spacing(
     body_parts: list[doc.DocType], current: uni.UniNode, previous: (uni.UniNode | None)
 ) -> None {
@@ -2275,7 +2291,7 @@ impl DocIRGenPass.format_simple_stmt_with_body(
     body_parts: list[doc.DocType] = [self.hard_line()];
     prev_body_item: (uni.UniNode | None) = None;
     for i in nd.kid {
-        if (isinstance(body, Sequence) and self.is_within(i, body)) {
+        if (isinstance(body, Sequence) and self.is_body_member(i, body)) {
             if (body and (i == body[0])) {
                 parts.append(self.indent(self.concat(body_parts), ast_node=nd));
                 parts.append(self.hard_line());
@@ -2354,7 +2370,7 @@ impl DocIRGenPass._assign_else_doc_ir(
     parts: list[doc.DocType] = [];
     body_parts: list[doc.DocType] = [self.hard_line()];
     for i in nd.kid {
-        if (isinstance(body, Sequence) and self.is_within(i, body)) {
+        if (isinstance(body, Sequence) and self.is_body_member(i, body)) {
             if (i == body[0]) {
                 parts.append(self.indent(self.concat(body_parts), ast_node=nd));
                 parts.append(self.hard_line());


### PR DESCRIPTION
## Summary

- Add `DocIRGenPass.is_body_member` so formatter body-block membership uses node identity instead of source-span containment, fixing spurious blank lines in synthesized control-flow IR
- Stamp real `lineno`/`col_offset` on `break`/`continue` tokens in `PyastBuildPass` so c2jac-emitted control flow formats correctly

## Stacked PR

This is **PR 1a/3** in the c2jac split (replaces #7223).

- **1b**: `c2jac-1b` — P1 transpiler foundation
- **1c**: `c2jac-1c` — P2 idioms + pcpp preprocessing

## Test plan

- [ ] CI jac-check / formatter passes
- [ ] No behavior change for normal Jac sources; c2jac tests in 1b/1c exercise the synthesized-IR path


Made with [Cursor](https://cursor.com)