### PR TITLE
Add 'exclude' field to BuildConfig for improved directory management

### DIFF
--- a/jac/jaclang/cli/commands/impl/project.impl.jac
+++ b/jac/jaclang/cli/commands/impl/project.impl.jac
@@ -1400,7 +1400,9 @@ def _bundle_wheel(config: any, output: str) -> int {
     return 0;
 }
 
-def _seal_copy_ignore(_dir: str, items: list) -> list {
+def _seal_copy_ignore(
+    _dir: str, items: list, extra: (list[str] | None) = None
+) -> list {
     drop = [
         "__pycache__",
         "node_modules",
@@ -1414,6 +1416,9 @@ def _seal_copy_ignore(_dir: str, items: list) -> list {
         ".mypy_cache",
         ".pytest_cache"
     ];
+    if extra {
+        drop = drop + extra;
+    }
     return [
         it
         for it in items
@@ -1733,8 +1738,10 @@ def _make_sealed_image(
         } except ValueError { }
     }
 
+    seal_excludes = config.build.exclude or [];
+
     def copy_ignore(d: str, items: list) -> list {
-        skipped = _seal_copy_ignore(d, items);
+        skipped = _seal_copy_ignore(d, items, seal_excludes);
         if out_names and Path(d).resolve() == Path(proj_root).resolve() {
             skipped = list(
                 set(skipped) | {

--- a/jac/jaclang/cli/commands/impl/project.impl.jac
+++ b/jac/jaclang/cli/commands/impl/project.impl.jac
@@ -1738,7 +1738,7 @@ def _make_sealed_image(
         } except ValueError { }
     }
 
-    seal_excludes = config.build.exclude or [];
+    seal_excludes = config.build.exclude;
 
     def copy_ignore(d: str, items: list) -> list {
         skipped = _seal_copy_ignore(d, items, seal_excludes);

--- a/jac/jaclang/project/config.jac
+++ b/jac/jaclang/project/config.jac
@@ -53,6 +53,7 @@ obj NativeBuildConfig {
 obj BuildConfig {
     has typecheck: bool = False,
         dir: str = ".jac",
+        exclude: list[str] = [],
         native: NativeBuildConfig = NativeBuildConfig();
 }
 

--- a/jac/jaclang/project/impl/config.impl.jac
+++ b/jac/jaclang/project/impl/config.impl.jac
@@ -751,7 +751,8 @@ impl _parse_toml_data(
         build_data = data["build"];
         config.build = BuildConfig(
             typecheck=build_data.get("typecheck", False),
-            dir=build_data.get("dir", ".jac")
+            dir=build_data.get("dir", ".jac"),
+            exclude=build_data.get("exclude", [])
         );
     }
     if "test" in data {

--- a/jac/jaclang/scale/injector/bundle.jac
+++ b/jac/jaclang/scale/injector/bundle.jac
@@ -203,11 +203,13 @@ def open_det_tar(buf: io.BytesIO) -> tuple[tarfile.TarFile, any] {
 }
 
 
-def _precompile_app(base: Path, pod_binary: bytes) -> Path {
+def _precompile_app(
+    base: Path, pod_binary: bytes, extra_dirs: (set[str] | None) = None
+) -> Path {
     # Seal the app's modules with the pod binary into _precompiled/MANIFEST.json
     # so the deploy artifact is a valid .jab. The seal is mandatory: an
     # incomplete seal raises rather than shipping a cold-compile fallback.
-    xtra = _config_excludes(base);
+    xtra = _config_excludes(base) if extra_dirs is None else extra_dirs;
     stage_root = Path(tempfile.mkdtemp(prefix="jac-app-precompile-"));
     stage = stage_root / "app";
     try {
@@ -266,7 +268,7 @@ def pack_jab(project_dir: str, provisioned_database: str, pod_binary: bytes) -> 
     }
     base = Path(project_dir).resolve();
     xtra = _config_excludes(base);
-    staged = _precompile_app(base, pod_binary);
+    staged = _precompile_app(base, pod_binary, xtra);
     # staged is <stage_root>/app; the whole mkdtemp tree must be removed even if
     # a tar.add below raises, or a full project copy leaks in /tmp on every
     # failed deploy (accumulates on a retrying deploy driver).

--- a/jac/jaclang/scale/injector/bundle.jac
+++ b/jac/jaclang/scale/injector/bundle.jac
@@ -50,7 +50,17 @@ glob _EXCLUDE_SUFFIXES: tuple = (
      );
 
 
-def is_excluded(rel: Path) -> bool {
+def _config_excludes(base: Path) -> set[str] {
+    # User-declared [build] exclude dirs from jac.toml (never sealed or packed).
+    import from jaclang.project.config { get_config_for_path }
+    cfg = get_config_for_path(base);
+    if cfg is None {
+        return set();
+    }
+    return set([str(x) for x in cfg.build.exclude]);
+}
+
+def is_excluded(rel: Path, extra_dirs: (set[str] | None) = None) -> bool {
     parts = rel.parts;
     if (
         len(parts) >= 3
@@ -60,8 +70,9 @@ def is_excluded(rel: Path) -> bool {
     ) {
         return False;
     }
+    dirs = _EXCLUDE_DIRS if extra_dirs is None else (_EXCLUDE_DIRS | extra_dirs);
     for part in parts {
-        if part in _EXCLUDE_DIRS {
+        if part in dirs {
             return True;
         }
     }
@@ -196,11 +207,12 @@ def _precompile_app(base: Path, pod_binary: bytes) -> Path {
     # Seal the app's modules with the pod binary into _precompiled/MANIFEST.json
     # so the deploy artifact is a valid .jab. The seal is mandatory: an
     # incomplete seal raises rather than shipping a cold-compile fallback.
+    xtra = _config_excludes(base);
     stage_root = Path(tempfile.mkdtemp(prefix="jac-app-precompile-"));
     stage = stage_root / "app";
     try {
         for path in sorted(base.rglob("*")) {
-            if not path.is_file() or is_excluded(path.relative_to(base)) {
+            if not path.is_file() or is_excluded(path.relative_to(base), xtra) {
                 continue;
             }
             dest = stage / path.relative_to(base);
@@ -253,6 +265,7 @@ def pack_jab(project_dir: str, provisioned_database: str, pod_binary: bytes) -> 
         );
     }
     base = Path(project_dir).resolve();
+    xtra = _config_excludes(base);
     staged = _precompile_app(base, pod_binary);
     # staged is <stage_root>/app; the whole mkdtemp tree must be removed even if
     # a tar.add below raises, or a full project copy leaks in /tmp on every
@@ -267,7 +280,7 @@ def pack_jab(project_dir: str, provisioned_database: str, pod_binary: bytes) -> 
                         continue;
                     }
                     rel = path.relative_to(base);
-                    if is_excluded(rel) {
+                    if is_excluded(rel, xtra) {
                         continue;
                     }
                     tar.add(str(path), arcname=str(rel), filter=det_tar_member);


### PR DESCRIPTION
## **Description**

Introduce an 'exclude' field in the BuildConfig to allow users to specify directories that should be ignored during the build process. Update the parsing logic to accommodate this new field and modify the relevant functions to utilize the specified exclusions. This enhancement improves flexibility in managing build configurations.

