### PR TITLE
fix(type): enhance call classification and symbol resolution in evaluator

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7408.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7408.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `obj` construction loses `new` when imported into a non-entry(transitive) client file**: constructing an archetype imported into a `.cl.jac` file that isn't the compile entry point no longer drops `new`, which previously crashed at runtime despite passing `jac check` and `jac build`.

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -1781,7 +1781,7 @@ impl EsastGenPass.exit_func_call(nd: uni.FuncCall) -> None {
     _call_kind = nd.call_kind;
     if _call_kind is None {
         import from jaclang.compiler.symbol_utils { classify_call }
-        _call_kind = classify_call(nd).value;
+        _call_kind = classify_call(nd, self.prog.get_type_evaluator()).value;
     }
     if _call_kind == "builtin" and isinstance(nd.target, uni.Name) {
         import from jaclang.compiler.passes.ecmascript.es_unparse { JSCodeGenerator }
@@ -4814,6 +4814,9 @@ impl EsastGenPass._sv_import_item_is_type(
         SymbolType.ENUM_ARCH
     };
     sym = item.name.sym;
+    if sym {
+        sym = self.prog.get_type_evaluator().resolve_imported_symbols(sym);
+    }
     if sym and (sym.sym_type in type_kinds) {
         return True;
     }

--- a/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
@@ -150,13 +150,13 @@ impl TypeCheckPass.exit_func_call(self: TypeCheckPass, nd: uni.FuncCall) -> None
     }
 
     if self._lambda_depth > 0 {
-        nd.call_kind = classify_call(nd).value;
+        nd.call_kind = classify_call(nd, self.evaluator).value;
         nd.callee_decl = ability_of_symbol(resolve_expr_symbol(nd.target));
         return;
     }
     self.evaluator.get_type_of_expression(nd);
 
-    nd.call_kind = classify_call(nd).value;
+    nd.call_kind = classify_call(nd, self.evaluator).value;
 
     nd.callee_decl = ability_of_symbol(resolve_expr_symbol(nd.target));
 

--- a/jac/jaclang/compiler/symbol_utils.jac
+++ b/jac/jaclang/compiler/symbol_utils.jac
@@ -47,7 +47,7 @@ def _is_user_symbol(sym: uni.Symbol) -> bool {
     return False;
 }
 
-def classify_call(nd: uni.FuncCall) -> CallKind {
+def classify_call(nd: uni.FuncCall, evaluator: any = None) -> CallKind {
     import from jaclang.compiler.type_registry { JAC_TYPE_REGISTRY }
 
     if isinstance(nd.target, uni.AtomTrailer) and nd.target.is_attr {
@@ -55,6 +55,9 @@ def classify_call(nd: uni.FuncCall) -> CallKind {
     }
 
     sym = resolve_expr_symbol(nd.target);
+    if sym is not None and evaluator is not None {
+        sym = evaluator.resolve_imported_symbols(sym);
+    }
 
     if sym is not None
     and sym.decl is not None

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -826,7 +826,11 @@ impl TypeEvaluator.resolve_imported_symbols(sym: uni.Symbol) -> uni.Symbol {
         mod_item = sym.decl.find_parent_of_type(uni.ModuleItem);
         assert (mod_item is not None);
         self.get_type_of_module(mod_item.from_mod_path);
-        if isinstance(mod_item.name, uni.Name) and mod_item.name.sym {
+        if (
+            isinstance(mod_item.name, uni.Name)
+            and mod_item.name.sym
+            and mod_item.name.sym.sym_type != SymbolType.VAR
+        ) {
             return mod_item.name.sym;
         }
 

--- a/jac/tests/compiler/passes/ecmascript/test_esast_gen_pass.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_esast_gen_pass.jac
@@ -2,6 +2,8 @@
 
 import os;
 import from tests.support { JAC_ROOT }
+import from tempfile { TemporaryDirectory }
+import from pathlib { Path }
 import jaclang;
 import from jaclang.compiler.passes.ecmascript { EsastGenPass }
 import jaclang.compiler.passes.ecmascript.estree as es;
@@ -1179,4 +1181,41 @@ test "augmented reactive assignments do not double-apply the lhs" {
     assert "setCount((count + (count" not in js , (
         "double-application bug detected in:\n" + js
     );
+}
+
+test "obj construction across a transitively-imported file emits new" {
+    # Regression: an `obj` imported into a file that's reached only
+    # transitively (never the compile entry point) resolved to a placeholder
+    # symbol instead of its real archetype type, so classify_call emitted a
+    # plain call instead of `new`
+    with TemporaryDirectory() as tmpdir {
+        types_file = Path(tmpdir) / "types.jac";
+        types_file.write_text(
+            "obj:pub Widget {\n    has id: str,\n        name: str;\n}\n"
+        );
+        middle_file = Path(tmpdir) / "middle.cl.jac";
+        middle_file.write_text(
+            "import from .types { Widget }\n\ndef:pub make_widget() -> Widget {\n    return Widget(id=\"1\", name=\"test\");\n}\n"
+        );
+        entry_file = Path(tmpdir) / "entry.jac";
+        entry_file.write_text("cl {\n    import from .middle { make_widget }\n}\n");
+        prog = JacProgram();
+        prog.compile(file_path=str(entry_file));
+        assert not prog.errors_had , (
+            f"Compilation errors: {[str(e) for e in prog.errors_had]}"
+        );
+        middle_mod = prog.mod.hub[str(middle_file.resolve())];
+        assert not middle_mod.gen.js , (
+            "test invariant broken: middle file should not have JS generated "
+            "yet (it must only have been shallow-parsed as a dependency)"
+        );
+        EsastGenPass(ir_in=middle_mod, prog=prog);
+        js = middle_mod.gen.js;
+        assert "new Widget(" in js , (
+            f"expected `new Widget(...)` construction, got:\n{js}"
+        );
+        assert "return Widget(" not in js , (
+            f"Widget must not be constructed as a plain call:\n{js}"
+        );
+    }
 }

--- a/jac/tests/compiler/test_backend_purity.jac
+++ b/jac/tests/compiler/test_backend_purity.jac
@@ -51,6 +51,13 @@ glob FORBIDDEN: dict[str, str] = {
              "former local _ability_from_symbol) used to resolve a SOURCE "
              "module's exported ability at sv-import client-stub generation"
          ),
+         ("ecmascript/impl/esast_gen_pass.impl.jac", "type_evaluator"): (
+             2,
+             "classify_call fallback (same context as symbol_utils above) "
+             "and _sv_import_item_is_type: both fetch the one central "
+             "evaluator to resolve an import placeholder for modules that "
+             "never ran TypeCheckPass (reached only transitively)"
+         ),
          ("ecmascript/impl/esast_gen_pass.impl.jac", ".lookup("): (
              2,
              "declaration-surface reads: (1) sv-import client stub "


### PR DESCRIPTION
## Problem

An `obj` imported with a plain `import from` and constructed in a file that isn't the literal compile entry point compiles to a plain call instead of `new`. Since the archetype always lowers to a real ES `class`, this is a guaranteed runtime crash:

```
TypeError: Class constructor Widget cannot be invoked without 'new'
```

Silent through `jac check` and `jac build` — only visible once a real browser runs the code.

close #7394 

## Root Cause

When an archetype is imported into a file reached only *transitively* (imported by another file, never the file passed directly to the compiler), its symbol resolves to a generic placeholder (`SymbolType.VAR`) instead of its real archetype kind (`SymbolType.OBJECT_ARCH`, etc.). `classify_call()` reads that placeholder to decide `new X(...)` vs. plain `X(...)`, and picks wrong.

A dereferencing utility for exactly this (`TypeEvaluator.resolve_imported_symbols()`) already existed but was never called from `classify_call()`. Its own guard was also broken — it checked "does a symbol exist" instead of "is it correct," so even a direct call to it would have returned the same wrong placeholder.

### The three cases

| # | Shape | Broken? |
|---|---|---|
| 1 | `type.jac → frontend.cl.jac → main.jac` (imported into a **non-entry** file) | **Yes** — the real bug |
| 2 | `type.jac → main.jac` (imported directly into the **entry** file) | No — entry file always gets full resolution |
| 3 | Defined and constructed in the **same file** | No — no import binding involved at all |

Case 1 is the common shape in real apps — almost every component file is imported by `main.jac`, not passed to the compiler directly.

## Fix

Four small edits, no new APIs:

- **`type_evaluator.impl/evaluator_util_methods.impl.jac`** — fixed `resolve_imported_symbols()`'s guard to check the symbol is actually resolved (`sym_type != SymbolType.VAR`), not just present.
- **`symbol_utils.jac`** — `classify_call()` takes an optional `evaluator` and dereferences the symbol through it before deciding.
- **`type_checker_pass.impl.jac`** — both call sites pass `self.evaluator` (already available).
- **`esast_gen_pass.impl.jac`** — the fallback `classify_call` call site passes `self.prog.get_type_evaluator()`; `_sv_import_item_is_type()` gets the same fix (see note below).

**Note on `_sv_import_item_is_type()`:** this second call site isn't optional. `classify_call()`'s fix applies to *every* archetype symbol, including `sv import`ed ones — so it starts emitting `new` for sv-imported bare archetypes regardless. Without the matching fix here, that `new` lands on an RPC stub (`async function`), producing `TypeError: X is not a constructor` — confirmed by temporarily reverting just this one call site. Both edits ship together.

## Tests

- **New regression test** — `test_esast_gen_pass.jac::"obj construction across a transitively-imported file emits new"`. Builds Case 1's exact 3-file shape inline (`TemporaryDirectory`, no new fixture files), compiles the entry file, then invokes `EsastGenPass` directly on the transitively-discovered middle module straight from `prog.mod.hub` — mirroring exactly what the client bundler's `_ensure_js_generated` does in production, not just a single `compile()` call. Verified: fails with the original bug (`return Widget({...})`, no `new`), passes with the fix.
- **`test_backend_purity.jac`** — an existing architectural check that flags backends re-running central type analysis. My fix's two `self.prog.get_type_evaluator()` calls in `esast_gen_pass.impl.jac` correctly tripped it. Added a `SANCTIONED` entry (count `2`, same shape as the existing `symbol_utils` entry right above it): both calls consume the *one* central evaluator to dereference an import placeholder for modules that never ran `TypeCheckPass` — not a duplicate analyzer.

## Verification

- [x] Live `jac start`: `Widget` constructs correctly, zero page/console errors
- [x] Live `jac start --dev`: same result
- [x] Live `jac build`: served bundle matches
- [x] Targeted suites: `test_typed_interop`, `test_client_codegen`, `test_esast_gen_pass`, `test_js_generation` — all pass
- [x] Full `tests/compiler` suite (2150 items): 2072 passed, 62 skipped, 16 failed — all 16 pre-existing environment gaps (musl toolchain, subprocess `PYTHONPATH`), confirmed unrelated
- [x] New regression test confirmed to fail without the fix, pass with it
