### PR TITLE
Multistage Visit Routing

### DIFF
--- a/jac/jaclang/byllm/examples/visit_routing_multistage/README.md
+++ b/jac/jaclang/byllm/examples/visit_routing_multistage/README.md
@@ -82,8 +82,7 @@ carries a long `case_notes` field with a fraud flag,
 same for both modes — "escalate if you see the fraud flag" — so the only
 variable is whether the router can see it.
 
-Expected output (the litellm "Provider List" lines are harmless `MockLLM`
-chatter):
+Expected output:
 
 ```
 === MULTISTAGE: field rendered untruncated, router sees the flag ===

--- a/jac/jaclang/byllm/examples/visit_routing_multistage/README.md
+++ b/jac/jaclang/byllm/examples/visit_routing_multistage/README.md
@@ -1,0 +1,126 @@
+# Multistage Visit Routing
+
+`visit ... by llm(...)` lets a byllm model choose which node(s) a walker visits
+next. This example documents the **multistage** routing mode and the change that
+makes it render walker/node context **untruncated**, and ships a self-contained
+demo (`demo.jac`) that shows the difference — no API key required.
+
+## Background: how single-stage routing works
+
+When you write `visit [-->] by llm(...)`, byllm builds a prompt describing the
+walker, the current node, and each candidate node, then asks the model to pick.
+Every field value in that description is rendered through an internal
+`_safe_repr` helper that **caps each value at 120 characters** — keeping the
+first ~57 and last ~57 characters and replacing the middle with `...`.
+
+That cap keeps routing prompts small, but it is a blind, middle-dropping
+truncation. Anything in the *middle* of a long field — a walker's accumulated
+conversation history, a case note, a long refined goal — is deleted before the
+model ever sees it. The routing decision is made on partial context.
+
+## Multistage routing
+
+Enable it by passing `multistage=True`:
+
+```jac
+visit [-->] by llm(
+    select   = 1,
+    intent   = "Move to Research once the initiative is understood; otherwise ask a follow-up.",
+    multistage = True,
+);
+```
+
+Instead of one constrained call that must commit to a choice immediately,
+multistage splits the decision into a short pipeline:
+
+1. **Condense** — the caller's `intent` / `incl_info` are compressed once into a
+   brief and cached, so a multi-hop traversal pays that cost a single time
+   rather than re-sending the full context on every hop. (Skipped for short
+   intents, where condensing would cost more than it saves.)
+2. **Reason** — the routing decision is made in a **free-text** reasoning call
+   that ends in a `CHOICE: <handle>` line. This call has room for full context
+   and actual reasoning tokens, which small models handle far more reliably than
+   forced constrained decoding.
+3. **Extract** — the structured choice is read off the `CHOICE:` line for free;
+   only a malformed line triggers a short fallback extraction call.
+
+### What changed: untruncated context in multistage
+
+Because the multistage **reason** call is free-text and built to hold full
+context, it renders walker/node field values **without the 120-char cap**. The
+single-stage path is unchanged and still truncates.
+
+Concretely, the render helpers now take a `limit` argument
+(`jaclang/byllm/visit_routing.jac`): single-stage calls them with the default
+`limit=120`; multistage calls them with `limit=None` (no truncation).
+
+Result: information buried in the middle of a long field reaches the multistage
+router but is invisible to the single-stage router.
+
+## Parameters
+
+Pass these as keyword arguments to `by llm(...)` on a `visit`:
+
+| Parameter    | Meaning |
+|--------------|---------|
+| `select`     | How many candidates to choose. `1` = exactly one; an `int` = up to N; a `(min, max)` tuple = a range. Defaults to "all". |
+| `intent`     | Natural-language goal describing when to pick which node. |
+| `incl_info`  | A `dict` of extra key/value context. Rendered verbatim (never truncated) in both modes. |
+| `multistage` | `True` enables the condense → reason → extract pipeline and untruncated field rendering. |
+
+Include `[here]` in the candidate set (`visit ([-->] + [here]) by llm(...)`) when
+you want the router to be able to *stay* on the current node and loop.
+
+> **Note:** the keyword is `multistage`. A misspelling such as `mutlistage` is
+> silently forwarded to the model as an API parameter rather than enabling the
+> feature, so double-check the spelling.
+
+## Running the demo
+
+```bash
+cd jaclang/byllm/examples/visit_routing_multistage
+jac run demo.jac
+```
+
+The demo drives one identical graph and walker through both modes. The walker
+carries a long `case_notes` field with a fraud flag,
+`INTERNAL_FRAUD_FLAG_ESCALATE`, buried in the middle. The routing rule is the
+same for both modes — "escalate if you see the fraud flag" — so the only
+variable is whether the router can see it.
+
+Expected output (the litellm "Provider List" lines are harmless `MockLLM`
+chatter):
+
+```
+=== MULTISTAGE: field rendered untruncated, router sees the flag ===
+  [router LLM | multistage ] fraud flag visible in prompt: True
+  --> LANDED: EscalationDesk (fraud / tier-2 queue)
+
+=== SINGLE-STAGE: field truncated at 120 chars, flag is hidden ===
+  [router LLM | single-stage] fraud flag visible in prompt: False
+  --> LANDED: BillingDesk (default billing queue)
+```
+
+Multistage sees the flag and escalates; single-stage never sees it and falls
+through to the default queue.
+
+## When to use multistage
+
+- **Long walker/node state that matters for routing** — accumulated
+  conversation history, case notes, refined goals. Middle-of-field detail
+  survives only under multistage.
+- **Small / local models** — the free-text reason stage is more reliable than
+  one-shot constrained decoding.
+- **Deep traversals with a stable `intent`** — condensation is computed once and
+  cached across hops.
+
+Single-stage remains the lighter-weight default when routing context is short
+and fits comfortably under the 120-char per-field cap.
+
+## Files
+
+```
+visit_routing_multistage/
+├── demo.jac    # Runnable MockLLM demo comparing both modes
+└── README.md   # This file
+```

--- a/jac/jaclang/byllm/examples/visit_routing_multistage/README.md
+++ b/jac/jaclang/byllm/examples/visit_routing_multistage/README.md
@@ -1,4 +1,5 @@
 # Multistage Visit Routing
+
 `visit ... by llm(...)` lets a byllm model choose which node(s) a walker visits
 next. This example documents the **multistage** routing mode and the change that
 makes it render walker/node context **untruncated**, and ships a self-contained
@@ -77,7 +78,7 @@ jac run demo.jac
 ```
 
 The demo drives one identical graph and walker through both modes. The walker
-carries a long `case_notes` field with a fraud flag, 
+carries a long `case_notes` field with a fraud flag,
 `INTERNAL_FRAUD_FLAG_ESCALATE`, buried in the middle. The routing rule is the
 same for both modes — "escalate if you see the fraud flag" — so the only
 variable is whether the router can see it.

--- a/jac/jaclang/byllm/examples/visit_routing_multistage/README.md
+++ b/jac/jaclang/byllm/examples/visit_routing_multistage/README.md
@@ -1,11 +1,10 @@
 # Multistage Visit Routing
-
 `visit ... by llm(...)` lets a byllm model choose which node(s) a walker visits
 next. This example documents the **multistage** routing mode and the change that
 makes it render walker/node context **untruncated**, and ships a self-contained
 demo (`demo.jac`) that shows the difference — no API key required.
 
-## Background: how single-stage routing works
+## how current single-stage routing works
 
 When you write `visit [-->] by llm(...)`, byllm builds a prompt describing the
 walker, the current node, and each candidate node, then asks the model to pick.
@@ -59,21 +58,16 @@ router but is invisible to the single-stage router.
 
 ## Parameters
 
-Pass these as keyword arguments to `by llm(...)` on a `visit`:
+Added these 2 keyword arguments to `by llm(...)` on a `visit`:
 
 | Parameter    | Meaning |
-|--------------|---------|
-| `select`     | How many candidates to choose. `1` = exactly one; an `int` = up to N; a `(min, max)` tuple = a range. Defaults to "all". |
-| `intent`     | Natural-language goal describing when to pick which node. |
 | `incl_info`  | A `dict` of extra key/value context. Rendered verbatim (never truncated) in both modes. |
 | `multistage` | `True` enables the condense → reason → extract pipeline and untruncated field rendering. |
 
 Include `[here]` in the candidate set (`visit ([-->] + [here]) by llm(...)`) when
 you want the router to be able to *stay* on the current node and loop.
 
-> **Note:** the keyword is `multistage`. A misspelling such as `mutlistage` is
-> silently forwarded to the model as an API parameter rather than enabling the
-> feature, so double-check the spelling.
+> **Note:** the keyword is `multistage`. A misspelling such as `mutlistage` is silently forwarded to the model as an API parameter rather than enabling the feature, so double-check the spelling.
 
 ## Running the demo
 
@@ -83,7 +77,7 @@ jac run demo.jac
 ```
 
 The demo drives one identical graph and walker through both modes. The walker
-carries a long `case_notes` field with a fraud flag,
+carries a long `case_notes` field with a fraud flag, 
 `INTERNAL_FRAUD_FLAG_ESCALATE`, buried in the middle. The routing rule is the
 same for both modes — "escalate if you see the fraud flag" — so the only
 variable is whether the router can see it.
@@ -117,10 +111,12 @@ through to the default queue.
 Single-stage remains the lighter-weight default when routing context is short
 and fits comfortably under the 120-char per-field cap.
 
-## Files
+## Files edited
 
 ```
 visit_routing_multistage/
 ├── demo.jac    # Runnable MockLLM demo comparing both modes
 └── README.md   # This file
+
+
 ```

--- a/jac/jaclang/byllm/tests/fixtures/routing_multistage.jac
+++ b/jac/jaclang/byllm/tests/fixtures/routing_multistage.jac
@@ -1,0 +1,81 @@
+"""Multistage visit routing: condense -> reason -> extract pipeline.
+
+`by llm(multistage=True)` must dispatch through `route_visit_multistage`:
+a long `intent` is condensed in one dedicated call, the routing decision is
+made in a free-text reasoning call, and a well-formed trailing 'CHOICE:' line
+short-circuits the structured extraction call entirely. The mock tags each
+stage by its system prompt and counts how often each fires; a second hop with
+the identical intent must hit the condensation cache instead of a new call.
+"""
+
+import from jaclang.byllm.lib { MockLLM }
+import from jaclang.byllm.types { CompletionResult }
+import from jaclang.byllm.mtir { MTRuntime }
+
+glob stage_calls: dict = {"condense": 0, "reason": 0, "extract": 0};
+
+glob LONG_GOAL: str = (
+    "Route the walker to the agent best suited for billing questions. " * 20
+);
+
+obj StageMock(MockLLM) {
+    """Answers each pipeline stage, keyed off its system prompt."""
+    override def dispatch_no_streaming(mt_run: MTRuntime) -> CompletionResult {
+        sys_txt = str(getattr(mt_run.messages[0], "content", ""));
+        if "compress task context" in sys_txt {
+            stage_calls["condense"] += 1;
+            return CompletionResult(
+                output="Send the walker to the billing agent.",
+                tool_calls=[],
+                usage={}
+            );
+        }
+        if "Extract the routing decision" in sys_txt {
+            stage_calls["extract"] += 1;
+            return CompletionResult(output=[0], tool_calls=[], usage={});
+        }
+        stage_calls["reason"] += 1;
+        user_txt = str(getattr(mt_run.messages[-1], "content", ""));
+        pick = "none";
+        if "Agent_beta)" in user_txt {
+            pick = "Agent_beta";
+        } elif "Agent)" in user_txt {
+            pick = "Agent";
+        }
+        return CompletionResult(
+            output=f"Beta handles billing questions.\nCHOICE: {pick}",
+            tool_calls=[],
+            usage={}
+        );
+    }
+}
+
+glob llm: StageMock = StageMock(model_name="mockllm", config={"outputs": []});
+
+node Desk {}
+
+node Agent {
+    has tag: str = "x";
+
+    can serve with router entry {
+        print("VISITED:" + self.tag);
+        visit [-->] by llm(select=1, multistage=True, intent=LONG_GOAL);
+    }
+}
+
+walker router {
+    can route with Desk entry {
+        visit [-->] by llm(select=1, multistage=True, intent=LONG_GOAL);
+    }
+}
+
+with entry {
+    desk = root ++> Desk();
+    desk ++> Agent(tag="alpha");
+    beta = desk ++> Agent(tag="beta");
+    beta ++> Agent(tag="gamma");
+    router() spawn desk;
+    print("CONDENSE:" + str(stage_calls["condense"]));
+    print("REASON:" + str(stage_calls["reason"]));
+    print("EXTRACT:" + str(stage_calls["extract"]));
+}

--- a/jac/jaclang/byllm/tests/test_visit_routing.jac
+++ b/jac/jaclang/byllm/tests/test_visit_routing.jac
@@ -72,6 +72,28 @@ test "candidate nodes with identical field values are distinct visit targets" {
 }
 
 
+test "multistage routing condenses context once and skips extraction on a parseable choice line" {
+    captured_output = io.StringIO();
+    old_stdout = sys.stdout;
+    sys.stdout = captured_output;
+    try {
+        jac_import("routing_multistage", base_path=FIXTURE_DIR + "/");
+    } finally {
+        sys.stdout = old_stdout;
+    }
+    stdout_value = captured_output.getvalue();
+
+    assert "VISITED:beta" in stdout_value;
+    assert "VISITED:gamma" in stdout_value;
+    assert "VISITED:alpha" not in stdout_value;
+    # Two hops share the same long intent: condensed once, cached on hop two.
+    assert "CONDENSE:1" in stdout_value;
+    assert "REASON:2" in stdout_value;
+    # The trailing 'CHOICE:' line short-circuits the structured extraction call.
+    assert "EXTRACT:0" in stdout_value;
+}
+
+
 test "routing dispatches the LLM call through the call_llm plugin hook" {
     captured_output = io.StringIO();
     old_stdout = sys.stdout;

--- a/jac/jaclang/byllm/visit_routing.jac
+++ b/jac/jaclang/byllm/visit_routing.jac
@@ -542,7 +542,7 @@ def route_visit(candidates: list, model: object) -> list {
 
     call_params = model?.call_params or {};
     if call_params.get("multistage") is True {
-        if call_params.get("verbose") is True{
+        if call_params.get("verbose") is True {
             print("\033[31m Visit by enabled multistage routing \033[0m");
         }
         return route_visit_multistage(candidates, model);

--- a/jac/jaclang/byllm/visit_routing.jac
+++ b/jac/jaclang/byllm/visit_routing.jac
@@ -21,13 +21,13 @@ def _class_info(arch: object) -> object {
 }
 
 
-def _safe_repr(value: object, limit: int = 120) -> str {
+def _safe_repr(value: object, limit: int | None = 120) -> str {
     try {
         text = repr(value);
     } except Exception {
         text = f"<{type(value).__name__}>";
     }
-    if len(text) <= limit {
+    if limit is None or len(text) <= limit {
         return text;
     }
     keep = (limit - 5) // 2;
@@ -35,7 +35,7 @@ def _safe_repr(value: object, limit: int = 120) -> str {
 }
 
 
-def _describe_arch(arch: object) -> str {
+def _describe_arch(arch: object, limit: int | None = 120) -> str {
     if arch is None {
         return "(none)";
     }
@@ -56,7 +56,7 @@ def _describe_arch(arch: object) -> str {
             if f.name.startswith("_") {
                 continue;
             }
-            val = _safe_repr(getattr(arch, f.name));
+            val = _safe_repr(getattr(arch, f.name), limit);
             label = f"{f.name} ({fsem[f.name]})" if f.name in fsem else f.name;
             parts.append(f"{label}={val}");
         }
@@ -293,10 +293,10 @@ def _build_recs(candidates: list, here_anchor: object) -> list {
 }
 
 
-def _render_candidates(recs: list, wkr: object) -> str {
+def _render_candidates(recs: list, wkr: object, limit: int | None = 120) -> str {
     lines: list = [];
     for r in recs {
-        node_txt = _describe_arch(r["node"]);
+        node_txt = _describe_arch(r["node"], limit);
         runs = _node_run_desc(r["node"], wkr);
         if runs {
             node_txt = node_txt + f" [runs: {runs}]";
@@ -304,7 +304,7 @@ def _render_candidates(recs: list, wkr: object) -> str {
         if r["edge"] is None {
             lines.append(f"{r['handle']}) {node_txt}");
         } else {
-            edge_txt = _describe_arch(r["edge"]);
+            edge_txt = _describe_arch(r["edge"], limit);
             if r["dir"] == "in" {
                 arrow = f"<--({edge_txt})--";
             } elif r["dir"] == "undir" {
@@ -468,7 +468,9 @@ def route_visit_multistage(candidates: list, model: object) -> list {
     (wkr, here_anchor) = _route_context();
     recs = _build_recs(candidates, here_anchor);
     handles = [r["handle"] for r in recs];
-    candidates_block = _render_candidates(recs, wkr);
+    # Multistage reasons over full context in free text, so field values are
+    # rendered untruncated (limit=None); the single-stage path keeps the cap.
+    candidates_block = _render_candidates(recs, wkr, None);
     directive = _select_directive(select);
 
     brief = _condense_context(intent, incl_info, model, api_params);
@@ -481,10 +483,10 @@ def route_visit_multistage(candidates: list, model: object) -> list {
         user_parts.append(f"Task brief:\n{brief}");
     }
     if wkr is not None {
-        user_parts.append(f"Walker:\n{_describe_arch(wkr)}");
+        user_parts.append(f"Walker:\n{_describe_arch(wkr, None)}");
     }
     if here_anchor is not None {
-        user_parts.append(f"Current node:\n{_describe_arch(here_anchor.archetype)}");
+        user_parts.append(f"Current node:\n{_describe_arch(here_anchor.archetype, None)}");
     }
     user_parts.append(f"Candidates (choose by handle):\n{candidates_block}");
 

--- a/jac/jaclang/byllm/visit_routing.jac
+++ b/jac/jaclang/byllm/visit_routing.jac
@@ -3,6 +3,13 @@ import re;
 import from dataclasses { fields, is_dataclass }
 import from jaclang.byllm._optdeps.loguru { logger }
 
+# Condensed-context cache for multistage routing: intent/incl_info are
+# re-sent verbatim on every hop, so one condensation serves a whole traversal.
+glob _CTX_BRIEF_CACHE: dict = {},
+     _CTX_BRIEF_CACHE_MAX: int = 32,
+     # Below this size, condensing costs more tokens than it saves.
+     _CONDENSE_MIN_CHARS: int = 400;
+
 
 def _class_info(arch: object) -> object {
     import from jaclang.jac0core.mtp { fetch_mtir }
@@ -241,26 +248,37 @@ def _resolve_choice(item: object, by_handle: dict, recs: list) -> object {
 }
 
 
-def route_visit(candidates: list, model: object) -> list {
-    import from jaclang.byllm.mtir { MTRuntime }
-    import from jaclang.byllm.types { Message, MessageRole }
-    import from jaclang.jac0core.runtime { JacRuntime as Jac }
-
-    if not candidates {
-        return [];
-    }
-
-    call_params = model?.call_params or {};
+def _normalize_select(call_params: dict) -> object {
     select = call_params.get("select", "all");
-
     if isinstance(select, int) and not isinstance(select, bool) and (select < 1) {
         select = "all";
     }
-    intent = call_params.get("intent");
-    incl_info = call_params.get("incl_info");
+    return select;
+}
 
-    (wkr, here_anchor) = _route_context();
 
+def _select_directive(select: object) -> str {
+    if select == 1 {
+        return " Choose exactly one.";
+    } elif isinstance(select, int) and not isinstance(select, bool) {
+        return f" Choose exactly {select}.";
+    } elif isinstance(select, tuple) and len(select) == 2 {
+        return f" Choose between {select[0]} and {select[1]} (inclusive).";
+    }
+    return "";
+}
+
+
+def _routing_api_params(call_params: dict) -> dict {
+    return {
+        k: v
+        for (k, v) in call_params.items()
+        if k not in ("select", "intent", "incl_info", "multistage")
+    };
+}
+
+
+def _build_recs(candidates: list, here_anchor: object) -> list {
     recs: list = [];
     for item in candidates {
         (edge_arch, node_arch, direction) = _candidate_for(item, here_anchor);
@@ -271,7 +289,11 @@ def route_visit(candidates: list, model: object) -> list {
     for (i, handle) in enumerate(_make_handles(recs)) {
         recs[i]["handle"] = handle;
     }
+    return recs;
+}
 
+
+def _render_candidates(recs: list, wkr: object) -> str {
     lines: list = [];
     for r in recs {
         node_txt = _describe_arch(r["node"]);
@@ -293,7 +315,242 @@ def route_visit(candidates: list, model: object) -> list {
             lines.append(f"{r['handle']}) here {arrow} {node_txt}");
         }
     }
-    candidates_block = "\n".join(lines);
+    return "\n".join(lines);
+}
+
+
+def _collect_chosen(selected: list, recs: list) -> list {
+    by_handle = {r["handle"]: r["node"] for r in recs};
+    chosen: list = [];
+    seen_ids: set = set();
+    for item in selected {
+        picked = _resolve_choice(item, by_handle, recs);
+        if picked is not None and id(picked) not in seen_ids {
+            seen_ids.add(id(picked));
+            chosen.append(picked);
+        }
+    }
+    return chosen;
+}
+
+
+def _trim_selection(chosen: list, select: object, n_cands: int) -> list {
+    if select == 1 {
+        chosen = chosen[:1];
+    } elif isinstance(select, int) and not isinstance(select, bool) {
+        chosen = chosen[:select];
+    } elif isinstance(select, tuple) and len(select) == 2 {
+        chosen = chosen[:select[1]];
+        if len(chosen) < select[0] {
+            logger.warning(
+                f"visit-by routing: requested at least {select[0]} node(s) (select={select}) but the model selected {len(
+                    chosen
+                )} from {n_cands} candidate(s)."
+            );
+        }
+    }
+    return chosen;
+}
+
+
+"""Stage 1 of multistage routing: condense the caller-supplied context.
+
+`intent`/`incl_info` are re-sent verbatim on every hop, so their token cost
+scales as context x traversal depth. This compresses them once into a short
+brief and caches the result keyed on the raw text, so subsequent hops (which
+carry the identical context) pay nothing. Short context is passed through
+untouched -- condensing it would cost more than it saves.
+"""
+def _condense_context(
+    intent: object, incl_info: object, model: object, api_params: dict
+) -> str {
+    import from jaclang.byllm.mtir { MTRuntime }
+    import from jaclang.byllm.types { Message, MessageRole }
+    import from jaclang.jac0core.runtime { JacRuntime as Jac }
+
+    parts: list = [];
+    if intent {
+        parts.append(f"Goal: {intent}");
+    }
+    if incl_info and isinstance(incl_info, dict) {
+        parts.append("\n".join([f"{k} = {v}" for (k, v) in incl_info.items()]));
+    }
+    raw_ctx = "\n\n".join(parts);
+    if not raw_ctx or len(raw_ctx) <= _CONDENSE_MIN_CHARS {
+        return raw_ctx;
+    }
+    cached = _CTX_BRIEF_CACHE.get(raw_ctx);
+    if cached is not None {
+        return cached;
+    }
+    sys_txt = (
+        "You compress task context for a graph-routing agent. Rewrite the " + "context below as a brief of at most 120 words, keeping every " + "detail that could matter for choosing which node a walker visits " + "next. Output plain text only."
+    );
+    mt_run = MTRuntime(
+        messages=[
+            Message(role=MessageRole.SYSTEM, content=sys_txt),
+            Message(role=MessageRole.USER, content=raw_ctx)
+        ],
+        resp_type=str,
+        stream=False,
+        tools=[],
+        call_params=api_params,
+        mtir=None
+    );
+    brief = str(Jac.call_llm(model, mt_run));
+    if len(_CTX_BRIEF_CACHE) >= _CTX_BRIEF_CACHE_MAX {
+        _CTX_BRIEF_CACHE.clear();
+    }
+    _CTX_BRIEF_CACHE[raw_ctx] = brief;
+    return brief;
+}
+
+
+"""Parse the trailing 'CHOICE: <handle>[, <handle>...]' line of the reasoning.
+
+Returns the handle list when every token is a valid handle, [] when the model
+explicitly chose nothing, and None when no well-formed choice line is found
+(the caller then falls back to the structured extraction call).
+"""
+def _parse_choice_line(reasoning: str, handles: list) -> list | None {
+    valid = set(handles);
+    for line in reversed(reasoning.strip().splitlines()) {
+        m = re.search(r"choice\s*:\s*(.+)$", line.strip(), re.IGNORECASE);
+        if m is None {
+            continue;
+        }
+        toks = [t.strip().strip("'\"`*.") for t in m.group(1).split(",")];
+        toks = [
+            t
+            for t in toks
+            if t
+        ];
+        if len(toks) == 1 and toks[0].lower() in ("none", "(none)", "nothing") {
+            return [];
+        }
+        if toks and all((t in valid) for t in toks) {
+            return toks;
+        }
+        return None;
+    }
+    return None;
+}
+
+
+"""Multistage visit routing: condense -> reason -> extract.
+
+Decouples the single routing call into stages so each LLM call has a short,
+single-purpose prompt that small models handle reliably: (1) the unbounded
+caller context (intent/incl_info) is condensed once and cached across hops
+instead of being re-paid per hop; (2) the routing decision is made in free
+text, leaving room for reasoning tokens instead of forcing constrained
+decoding to commit immediately; (3) the structured choice is extracted last --
+for free when the reasoning ends in a well-formed 'CHOICE:' line, otherwise
+via one short schema-constrained call. Enabled with `by llm(multistage=True)`.
+"""
+def route_visit_multistage(candidates: list, model: object) -> list {
+    import from jaclang.byllm.mtir { MTRuntime }
+    import from jaclang.byllm.types { Message, MessageRole }
+    import from jaclang.jac0core.runtime { JacRuntime as Jac }
+
+    if not candidates {
+        return [];
+    }
+
+    call_params = model?.call_params or {};
+    select = _normalize_select(call_params);
+    intent = call_params.get("intent");
+    incl_info = call_params.get("incl_info");
+    api_params = _routing_api_params(call_params);
+    # The intermediate stages are internal decision calls; never stream them.
+    api_params.pop("stream", None);
+
+    (wkr, here_anchor) = _route_context();
+    recs = _build_recs(candidates, here_anchor);
+    handles = [r["handle"] for r in recs];
+    candidates_block = _render_candidates(recs, wkr);
+    directive = _select_directive(select);
+
+    brief = _condense_context(intent, incl_info, model, api_params);
+
+    reason_sys = (
+        "You are routing a graph walker. Reason briefly about which " + "candidate node(s) the walker should visit next." + directive + " End your reply with one final line of the form " + "'CHOICE: <handle>' (comma-separated for several handles, or " + "'CHOICE: none' to visit nothing). Use only listed handles."
+    );
+    user_parts: list = [];
+    if brief {
+        user_parts.append(f"Task brief:\n{brief}");
+    }
+    if wkr is not None {
+        user_parts.append(f"Walker:\n{_describe_arch(wkr)}");
+    }
+    if here_anchor is not None {
+        user_parts.append(f"Current node:\n{_describe_arch(here_anchor.archetype)}");
+    }
+    user_parts.append(f"Candidates (choose by handle):\n{candidates_block}");
+
+    reason_run = MTRuntime(
+        messages=[
+            Message(role=MessageRole.SYSTEM, content=reason_sys),
+            Message(role=MessageRole.USER, content="\n\n".join(user_parts))
+        ],
+        resp_type=str,
+        stream=False,
+        tools=[],
+        call_params=api_params,
+        mtir=None
+    );
+    reasoning = str(Jac.call_llm(model, reason_run));
+
+    selected = _parse_choice_line(reasoning, handles);
+    if selected is None {
+        Choice = enum.Enum("RouteChoice", {h: h for h in handles}) if handles else None;
+        resp_type = list[Choice] if Choice is not None else list;
+        extract_sys = (
+            "Extract the routing decision from the reasoning below. " + "Return only valid candidate handles." + directive
+        );
+        extract_user = (
+            f"Valid handles: {', '.join(handles)}\n\nReasoning:\n{reasoning}"
+        );
+        extract_run = MTRuntime(
+            messages=[
+                Message(role=MessageRole.SYSTEM, content=extract_sys),
+                Message(role=MessageRole.USER, content=extract_user)
+            ],
+            resp_type=resp_type,
+            stream=False,
+            tools=[],
+            call_params=api_params,
+            mtir=None
+        );
+        raw = Jac.call_llm(model, extract_run);
+        selected = raw if isinstance(raw, list) else [raw];
+    }
+
+    chosen = _collect_chosen(selected, recs);
+    return _trim_selection(chosen, select, len(recs));
+}
+
+
+def route_visit(candidates: list, model: object) -> list {
+    import from jaclang.byllm.mtir { MTRuntime }
+    import from jaclang.byllm.types { Message, MessageRole }
+    import from jaclang.jac0core.runtime { JacRuntime as Jac }
+
+    if not candidates {
+        return [];
+    }
+
+    call_params = model?.call_params or {};
+    if call_params.get("multistage") is not None {
+        return route_visit_multistage(candidates, model);
+    }
+    select = _normalize_select(call_params);
+    intent = call_params.get("intent");
+    incl_info = call_params.get("incl_info");
+
+    (wkr, here_anchor) = _route_context();
+    recs = _build_recs(candidates, here_anchor);
+    candidates_block = _render_candidates(recs, wkr);
 
     user_parts: list = [];
     if intent {
@@ -311,64 +568,29 @@ def route_visit(candidates: list, model: object) -> list {
     }
 
     sys_txt = "You are routing a graph walker. Choose which candidate node(s) the " + "walker should visit next, by handle. Return only valid handles.";
-    if select == 1 {
-        sys_txt += " Choose exactly one.";
-    } elif isinstance(select, int) and not isinstance(select, bool) {
-        sys_txt += f" Choose exactly {select}.";
-    } elif isinstance(select, tuple) and len(select) == 2 {
-        sys_txt += f" Choose between {select[0]} and {select[1]} (inclusive).";
-    }
+    sys_txt += _select_directive(select);
 
     handles = [r["handle"] for r in recs];
 
     Choice = enum.Enum("RouteChoice", {h: h for h in handles}) if handles else None;
     resp_type = list[Choice] if Choice is not None else list;
 
-    api_params = {
-        k: v
-        for (k, v) in call_params.items()
-        if k not in ("select", "intent", "incl_info")
-    };
+    api_params = _routing_api_params(call_params);
     mt_run = MTRuntime(
         messages=[
             Message(role=MessageRole.SYSTEM, content=sys_txt),
-            Message(role=MessageRole.USER, content="\n\n".join(user_parts)),
-
+            Message(role=MessageRole.USER, content="\n\n".join(user_parts))
         ],
         resp_type=resp_type,
         stream=bool(call_params.get("stream", False)),
         tools=[],
         call_params=api_params,
-        mtir=None,
+        mtir=None
     );
 
     raw = Jac.call_llm(model, mt_run);
 
     selected = raw if isinstance(raw, list) else [raw];
-    by_handle = {r["handle"]: r["node"] for r in recs};
-    chosen: list = [];
-    seen_ids: set = set();
-    for item in selected {
-        picked = _resolve_choice(item, by_handle, recs);
-        if picked is not None and id(picked) not in seen_ids {
-            seen_ids.add(id(picked));
-            chosen.append(picked);
-        }
-    }
-
-    if select == 1 {
-        chosen = chosen[:1];
-    } elif isinstance(select, int) and not isinstance(select, bool) {
-        chosen = chosen[:select];
-    } elif isinstance(select, tuple) and len(select) == 2 {
-        chosen = chosen[:select[1]];
-        if len(chosen) < select[0] {
-            logger.warning(
-                f"visit-by routing: requested at least {select[0]} node(s) (select={select}) but the model selected {len(
-                    chosen
-                )} from {len(recs)} candidate(s)."
-            );
-        }
-    }
-    return chosen;
+    chosen = _collect_chosen(selected, recs);
+    return _trim_selection(chosen, select, len(recs));
 }

--- a/jac/jaclang/byllm/visit_routing.jac
+++ b/jac/jaclang/byllm/visit_routing.jac
@@ -384,7 +384,7 @@ def _condense_context(
         return cached;
     }
     sys_txt = (
-        "You compress task context for a graph-routing agent. Rewrite the " + "context below as a brief of at most 120 words, keeping every " + "detail that could matter for choosing which node a walker visits " + "next. Output plain text only."
+        "You are a helper to compress task context for a graph-routing agent. Rewrite the " + "context below as a brief text, keeping every " + "detail that could matter for choosing which node a walker visits " + "next. Output plain text only."
     );
     mt_run = MTRuntime(
         messages=[
@@ -541,7 +541,10 @@ def route_visit(candidates: list, model: object) -> list {
     }
 
     call_params = model?.call_params or {};
-    if call_params.get("multistage") is not None {
+    if call_params.get("multistage") is True {
+        if call_params.get("verbose") is True{
+            print("\033[31m Visit by enabled multistage routing \033[0m");
+        }
         return route_visit_multistage(candidates, model);
     }
     select = _normalize_select(call_params);


### PR DESCRIPTION
# Multistage Visit Routing
`visit ... by llm(...)` lets a byllm model choose which node(s) a walker visits
next. This example documents the **multistage** routing mode and the change that
makes it render walker/node context **untruncated**, and 
demo (`demo.jac`) that shows the difference.

## how current single-stage routing works

When you write `visit [-->] by llm(...)`, byllm builds a prompt describing the
walker, the current node, and each candidate node, then asks the model to pick.
Every field value in that description is rendered through an internal
`_safe_repr` helper that **caps each value at 120 characters** — keeping the
first ~57 and last ~57 characters and replacing the middle with `...`.

That cap keeps routing prompts small, but it is a blind, middle-dropping
truncation. Anything in the *middle* of a long field — a walker's accumulated
conversation history, a case note, a long refined goal — is deleted before the
model ever sees it. The routing decision is made on partial context.

## Multistage routing

Enable it by passing `multistage=True`:

```jac
visit [-->] by llm(
    select   = 1,
    intent   = "Move to Research once the initiative is understood; otherwise ask a follow-up.",
    multistage = True,
);
```

Instead of one constrained call that must commit to a choice immediately,
multistage splits the decision into a short pipeline:

1. **Condense** — the caller's `intent` / `incl_info` are compressed once into a
   brief and cached, so a multi-hop traversal pays that cost a single time
   rather than re-sending the full context on every hop. (Skipped for short
   intents, where condensing would cost more than it saves.)
2. **Reason** — the routing decision is made in a **free-text** reasoning call
   that ends in a `CHOICE: <handle>` line. This call has room for full context
   and actual reasoning tokens, which small models handle far more reliably than
   forced constrained decoding.
3. **Extract** — the structured choice is read off the `CHOICE:` line for free;
   only a malformed line triggers a short fallback extraction call.

## Parameters

Added `multistage` keyword arguments to `by llm(...)` on a `visit`:
| `multistage` | `True` enables the condense → reason → extract pipeline and untruncated field rendering. |

Include `[here]` in the candidate set (`visit ([-->] + [here]) by llm(...)`) when
you want the router to be able to *stay* on the current node and loop.



## Running the demo

```bash
cd jaclang/byllm/examples/visit_routing_multistage
jac run demo.jac
```

The demo drives one identical graph and walker through both modes. The walker
carries a long `case_notes` field with a fraud flag, 
`INTERNAL_FRAUD_FLAG_ESCALATE`, buried in the middle. The routing rule is the
same for both modes — "escalate if you see the fraud flag" — so the only
variable is whether the router can see it.

Expected output:

```
=== MULTISTAGE: field rendered untruncated, router sees the flag ===
  [router LLM | multistage ] fraud flag visible in prompt: True
  --> LANDED: EscalationDesk (fraud / tier-2 queue)

=== SINGLE-STAGE: field truncated at 120 chars, flag is hidden ===
  [router LLM | single-stage] fraud flag visible in prompt: False
  --> LANDED: BillingDesk (default billing queue)
```

Multistage sees the flag and escalates; single-stage never sees it and falls
through to the default queue.

## When to use multistage

- **Long walker/node state that matters for routing** — accumulated
  conversation history, case notes, refined goals. Middle-of-field detail
  survives only under multistage.
- **Small / local models** — the free-text reason stage is more reliable than
  one-shot constrained decoding.
- **Deep traversals with a stable `intent`** — condensation is computed once and
  cached across hops.

Single-stage remains the lighter-weight default when routing context is short
and fits comfortably under the 120-char per-field cap.

## Files edited

```
visit_routing_multistage/
├── demo.jac    
└── README.md   
```
