### PR TITLE
fix(scale): disabling observability removes an existing stack, not just future ones

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7652.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7652.bugfix.md
@@ -1,0 +1,1 @@
+- **Scale: disabling observability now tears down an existing stack**: a microservice deploy with logs and tracing off previously only stopped re-deploying the Prometheus/Grafana/Loki/Tempo/Alloy stack, leaving one from an earlier observability-on deploy running until the namespace was deleted; it is now removed, so the toggle actually reclaims the pods.

--- a/jac/jaclang/scale/deploy/target/kubernetes/microservice/target.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/microservice/target.jac
@@ -540,14 +540,18 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
     def _deploy_observability(app_name: str) -> None {
         logs_cfg = self._read_microservices_logs_config();
         tracing_cfg = self._read_microservices_tracing_config();
-        if not logs_cfg.get("enabled", False)
-        and not tracing_cfg.get("enabled", False) {
-            return;
-        }
 
         self._load_kube_config();
         apps_v1 = client.AppsV1Api();
         core_v1 = client.CoreV1Api();
+
+        if not logs_cfg.get("enabled", False)
+        and not tracing_cfg.get("enabled", False) {
+            MonitoringDeployer(self.k8s_config, self.logger).destroy(
+                app_name, self.k8s_config.namespace, apps_v1, core_v1
+            );
+            return;
+        }
 
         provider = get_cluster_provider();
 

--- a/jac/jaclang/scale/tests/deploy/test_observability_gc.jac
+++ b/jac/jaclang/scale/tests/deploy/test_observability_gc.jac
@@ -1,0 +1,53 @@
+import kubernetes;
+import unittest.mock;
+import jaclang.scale.deploy.target.kubernetes.microservice.target as target_mod;
+import from jaclang.scale.deploy.target.kubernetes.microservice.target {
+    KubernetesMicroserviceTarget
+}
+import from jaclang.scale.deploy.target.kubernetes.kubernetes_config {
+    KubernetesConfig
+}
+
+
+def _target(logs: bool, tracing: bool) -> KubernetesMicroserviceTarget {
+    return KubernetesMicroserviceTarget(
+        config=KubernetesConfig(app_name="shop", namespace="shop-ns"),
+        microservices_config={
+            "logs": {"enabled": logs},
+            "tracing": {"enabled": tracing}
+        }
+    );
+}
+
+
+test "observability disabled tears down any stack a prior deploy left" {
+    t = _target(False, False);
+    with unittest.mock.patch.object(t, "_load_kube_config"), unittest.mock.patch.object(
+        kubernetes.client, "AppsV1Api"
+    ), unittest.mock.patch.object(kubernetes.client, "CoreV1Api"), unittest.mock.patch.object(
+        target_mod, "MonitoringDeployer"
+    ) as Deployer {
+        t._deploy_observability("shop");
+        Deployer.return_value.destroy.assert_called_once();
+        (app, ns) = Deployer.return_value.destroy.call_args[0][:2];
+        assert app == "shop";
+        assert ns == "shop-ns";
+        assert not Deployer.return_value.deploy.called;
+    }
+}
+
+
+test "observability enabled deploys the stack and does not destroy" {
+    t = _target(True, False);
+    with unittest.mock.patch.object(t, "_load_kube_config"), unittest.mock.patch.object(
+        kubernetes.client, "AppsV1Api"
+    ), unittest.mock.patch.object(kubernetes.client, "CoreV1Api"), unittest.mock.patch.object(
+        target_mod, "get_cluster_provider"
+    ), unittest.mock.patch.object(t, "_ensure_privileged_namespace"), unittest.mock.patch.object(
+        t, "_build_observability_config"
+    ), unittest.mock.patch.object(target_mod, "MonitoringDeployer") as Deployer {
+        t._deploy_observability("shop");
+        Deployer.return_value.deploy.assert_called_once();
+        assert not Deployer.return_value.destroy.called;
+    }
+}


### PR DESCRIPTION
## Problem

`_deploy_observability` returns early when `[scale.microservices].logs` and `.tracing` are both disabled. That stops the stack from being *re-deployed*, but it never removes a stack an earlier observability-on deploy left in the namespace. So turning observability off on an existing deployment doesn't reclaim anything - the Prometheus/Grafana/Loki/Tempo/Alloy pods keep running until the whole namespace is deleted.

On a shared cluster this compounds: each lingering stack is ~37 pods including per-node daemonsets, and several of them exhaust the nodes' pod capacity so new fleets fail to schedule.

## Fix

The disabled branch now calls the existing `MonitoringDeployer.destroy` for the app's namespace, tearing down Prometheus, Grafana, Loki, Tempo, Alloy, node-exporter, and kube-state-metrics (deployments, services, config maps, secrets, cluster roles/bindings). The enabled path is unchanged.

## Testing

`tests/deploy/test_observability_gc.jac` (new): observability disabled invokes `destroy` for the app namespace and does not deploy; observability enabled deploys and does not destroy. Both pass. No new type-check findings on the touched file.