### PR TITLE
refactor(assets): unify static asset serving into one resolver

### DIFF
--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -1691,11 +1691,11 @@ impl JacServe.send_css(handler: BaseHTTPRequestHandler, css_code: str) -> None {
     ResponseBuilder.send_css(handler, css_code);
 }
 
-impl JacServe.send_static_file(
-    handler: BaseHTTPRequestHandler, file_path: Path, content_type: (str | None) = None
+impl JacServe.send_asset(
+    handler: BaseHTTPRequestHandler, resolution: any, head_only: bool = False
 ) -> None {
     import from jaclang.runtimelib.client.serving { JacClient }
-    JacClient.send_static_file(handler, file_path, content_type);
+    JacClient.send_asset(handler, resolution, head_only);
 }
 
 impl JacLLM.get_mtir(

--- a/jac/jaclang/jac0core/runtime.jac
+++ b/jac/jaclang/jac0core/runtime.jac
@@ -469,10 +469,8 @@ class JacServe {
 
     static def send_javascript(handler: BaseHTTPRequestHandler, code: str) -> None;
     static def send_css(handler: BaseHTTPRequestHandler, css_code: str) -> None;
-    static def send_static_file(
-        handler: BaseHTTPRequestHandler,
-        file_path: Path,
-        content_type: (str | None) = None
+    static def send_asset(
+        handler: BaseHTTPRequestHandler, resolution: any, head_only: bool = False
     ) -> None;
 }
 

--- a/jac/jaclang/runtimelib/client/asset_processor.jac
+++ b/jac/jaclang/runtimelib/client/asset_processor.jac
@@ -2,31 +2,11 @@ import contextlib;
 import shutil;
 import from pathlib { Path }
 import from jaclang.project.config { get_config }
+import from jaclang.runtimelib.client.assets { ASSET_COPY_EXTENSIONS }
 
 class AssetProcessor {
     with entry {
-        ASSET_EXTENSIONS = {
-            '.css',
-            '.scss',
-            '.sass',
-            '.less',
-            '.svg',
-            '.png',
-            '.jpg',
-            '.jpeg',
-            '.gif',
-            '.webp',
-            '.ico',
-            '.woff',
-            '.woff2',
-            '.ttf',
-            '.eot',
-            '.otf',
-            '.mp4',
-            '.webm',
-            '.mp3',
-            '.wav'
-        };
+        ASSET_EXTENSIONS = ASSET_COPY_EXTENSIONS;
     }
 
     def copy_assets(

--- a/jac/jaclang/runtimelib/client/assets.jac
+++ b/jac/jaclang/runtimelib/client/assets.jac
@@ -1,0 +1,291 @@
+import re;
+import from enum { StrEnum }
+import from pathlib { Path }
+
+glob ASSET_MEDIA_TYPES: dict[str, str] = {
+         '.avif': 'image/avif',
+         '.css': 'text/css; charset=utf-8',
+         '.eot': 'application/vnd.ms-fontobject',
+         '.gif': 'image/gif',
+         '.htm': 'text/html; charset=utf-8',
+         '.html': 'text/html; charset=utf-8',
+         '.ico': 'image/x-icon',
+         '.jpeg': 'image/jpeg',
+         '.jpg': 'image/jpeg',
+         '.js': 'text/javascript; charset=utf-8',
+         '.json': 'application/json; charset=utf-8',
+         '.map': 'application/json; charset=utf-8',
+         '.mjs': 'text/javascript; charset=utf-8',
+         '.mp3': 'audio/mpeg',
+         '.mp4': 'video/mp4',
+         '.otf': 'font/otf',
+         '.pdf': 'application/pdf',
+         '.png': 'image/png',
+         '.svg': 'image/svg+xml',
+         '.ttf': 'font/ttf',
+         '.txt': 'text/plain; charset=utf-8',
+         '.wasm': 'application/wasm',
+         '.wav': 'audio/wav',
+         '.webm': 'video/webm',
+         '.webp': 'image/webp',
+         '.woff': 'font/woff',
+         '.woff2': 'font/woff2',
+         '.xml': 'application/xml; charset=utf-8'
+     };
+
+glob SOURCE_ONLY_EXTENSIONS: set[str] = {
+         '.jac',
+         '.jsx',
+         '.less',
+         '.py',
+         '.pyc',
+         '.sass',
+         '.scss',
+         '.styl',
+         '.ts',
+         '.tsx'
+     };
+
+glob ASSET_COPY_EXTENSIONS: set[str] = set(ASSET_MEDIA_TYPES.keys()) | {
+         '.less',
+         '.sass',
+         '.scss',
+         '.styl'
+     };
+
+glob RESERVED_URL_PREFIXES: list[str] = [
+         'walker/',
+         'walkers',
+         'function/',
+         'functions',
+         'user/',
+         'protected',
+         'healthz',
+         'graph',
+         'docs',
+         '__build_status',
+         '__jac'
+     ];
+
+glob _HASHED_TOKEN_RE: str = r'[._-]([A-Za-z0-9_]{8,})(?:\.[A-Za-z0-9]+)+$',
+     _CACHE_BUST_KEYS: list[str] = ['hash', 'v', 'version'],
+     _HEX_DIGITS: str = '0123456789abcdefABCDEF';
+
+enum AssetOutcome(StrEnum) {
+    SERVED = 'served',
+    NOT_AN_ASSET = 'not_an_asset',
+    NOT_FOUND = 'not_found',
+    FORBIDDEN = 'forbidden'
+}
+
+enum AssetRootMode(StrEnum) {
+    BUILD_OUTPUT = 'build-output',
+    PUBLIC = 'public',
+    SOURCE_ASSET = 'source-asset'
+}
+
+obj AssetRoot {
+    has path: Path,
+        mode: str = AssetRootMode.SOURCE_ASSET.value,
+        flatten: bool = False;
+}
+
+obj AssetPolicy {
+    has roots: list[AssetRoot] = [],
+        extensions: set[str] = set(),
+        reserved_prefixes: list[str] = [],
+        dev: bool = False,
+        immutable_max_age: int = 31536000;
+
+    static def from_config(
+        base_path: (Path | None) = None, dev: bool = False
+    ) -> AssetPolicy;
+}
+
+obj AssetResolution {
+    has outcome: str,
+        status: int = 200,
+        path: (Path | None) = None,
+        media_type: str = 'text/plain; charset=utf-8',
+        cache_control: str = 'no-cache',
+        etag: str = '',
+        last_modified: str = '',
+        message: str = '';
+
+    def is_served -> bool {
+        return self.outcome == AssetOutcome.SERVED.value;
+    }
+
+    def headers -> dict[str, str];
+    def read_bytes -> bytes;
+    def is_fresh(
+        if_none_match: (str | None) = None, if_modified_since: (str | None) = None
+    ) -> bool;
+}
+
+obj AssetResolver {
+    has policy: AssetPolicy;
+
+    static def build(
+        dev: bool = False, base_path: (Path | None) = None
+    ) -> AssetResolver;
+
+    def resolve(url_path: str, query: str = "") -> AssetResolution;
+    def _locate(rel: str) -> (Path | None);
+    def _describe(file_path: Path, cache_bust: bool) -> AssetResolution;
+}
+
+def parse_byte_range(
+    range_header: (str | None), size: int
+) -> (tuple[(int, int)] | None) {
+    if not range_header or size <= 0 {
+        return None;
+    }
+    text = range_header.strip();
+    if not text.startswith('bytes=') or (',' in text) {
+        return None;
+    }
+    spec = text[6:].strip();
+    if '-' not in spec {
+        return None;
+    }
+    (raw_start, _, raw_end) = spec.partition('-');
+    try {
+        if not raw_start {
+            length = int(raw_end);
+            if length <= 0 {
+                return None;
+            }
+            start = max(0, size - length);
+            end = size - 1;
+        } else {
+            start = int(raw_start);
+            end = int(raw_end) if raw_end else (size - 1);
+        }
+    } except ValueError {
+        return None;
+    }
+    end = min(end, size - 1);
+    if start > end or start >= size {
+        return None;
+    }
+    return (start, end);
+}
+
+def _as_dict(value: any) -> dict[str, any] {
+    return value if isinstance(value, dict) else {};
+}
+
+def _as_list(value: any) -> list[any] {
+    return value if isinstance(value, list) else [];
+}
+
+def _as_ext_set(value: any) -> set[str] {
+    out: set[str] = set();
+    for item in _as_list(value) {
+        text = str(item).strip().lower();
+        if text {
+            out.add(text if text.startswith('.') else f".{text}");
+        }
+    }
+    return out;
+}
+
+def configured_extra_extensions -> set[str] {
+    import from jaclang.project.config { get_config }
+    config = get_config();
+    client_cfg = config.get_plugin_config('client') if config else None;
+    raw = _as_dict(client_cfg.get('assets') if client_cfg else None);
+    return _as_ext_set(_as_dict(raw.get('extensions')).get('add')) | _as_ext_set(
+        raw.get('custom_extensions')
+    );
+}
+
+def confined_path(root_dir: Path, rel: str) -> (Path | None) {
+    try {
+        candidate = (root_dir / rel).resolve();
+        anchor = root_dir.resolve();
+    } except (OSError, RuntimeError, ValueError) {
+        return None;
+    }
+    if candidate != anchor and not candidate.is_relative_to(anchor) {
+        return None;
+    }
+    return candidate;
+}
+
+def is_reserved_url(rel: str, prefixes: list[str]) -> bool {
+    for prefix in prefixes {
+        if prefix.endswith('/') {
+            if rel.startswith(prefix) {
+                return True;
+            }
+        } elif rel == prefix or rel.startswith(f"{prefix}/") {
+            return True;
+        }
+    }
+    return False;
+}
+
+def has_cache_bust(query: str) -> bool {
+    if not query {
+        return False;
+    }
+    import from urllib.parse { parse_qs }
+    keys = parse_qs(query, keep_blank_values=True).keys();
+    return any(key in _CACHE_BUST_KEYS for key in keys);
+}
+
+def asset_media_type(file_path: Path) -> str {
+    return ASSET_MEDIA_TYPES.get(file_path.suffix.lower(), 'application/octet-stream');
+}
+
+def is_content_hashed(name: str) -> bool {
+    hit = re.search(_HASHED_TOKEN_RE, name);
+    if hit is None {
+        return False;
+    }
+    token = hit.group(1);
+    if all(ch in _HEX_DIGITS for ch in token) {
+        return True;
+    }
+    return (
+        any(ch.isdigit() for ch in token)
+        and any(ch.islower() for ch in token)
+        and any(ch.isupper() for ch in token)
+    );
+}
+
+def resolve_project_root(base_path_dir: (Path | None) = None) -> Path {
+    import from jaclang.project.config { find_project_root }
+    import from jaclang.jac0core.runtime { JacRuntime as Jac }
+    if base_path_dir is None {
+        bp_dir = Jac.get_context().base_path_dir or Jac.get_base_path_dir();
+        base_path_dir = Path(bp_dir) if bp_dir else Path.cwd();
+    }
+    found = find_project_root(base_path_dir);
+    if found {
+        (project_root, _) = found;
+        return project_root;
+    }
+    return base_path_dir;
+}
+
+def default_asset_roots(base_path: Path) -> list[AssetRoot] {
+    return [
+        AssetRoot(
+            path=base_path / '.jac' / 'client' / 'dist',
+            mode=AssetRootMode.BUILD_OUTPUT.value,
+            flatten=True
+        ),
+        AssetRoot(
+            path=base_path / 'dist', mode=AssetRootMode.BUILD_OUTPUT.value, flatten=True
+        ),
+        AssetRoot(path=base_path / 'public', mode=AssetRootMode.PUBLIC.value),
+        AssetRoot(
+            path=base_path / 'assets',
+            mode=AssetRootMode.SOURCE_ASSET.value,
+            flatten=True
+        )
+    ];
+}

--- a/jac/jaclang/runtimelib/client/impl/asset_processor.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/asset_processor.impl.jac
@@ -37,9 +37,8 @@ impl AssetProcessor.copy_custom_asset_types(
             }
         }
     }
-    config = get_config();
-    assets_config = config.get_plugin_config("client").get("assets", {});
-    custom_asset_extensions = set(assets_config.get("custom_extensions", []));
+    import from jaclang.runtimelib.client.assets { configured_extra_extensions }
+    custom_asset_extensions = configured_extra_extensions();
     if custom_asset_extensions {
         copy_recursive(src_dir, dest_dir);
     }

--- a/jac/jaclang/runtimelib/client/impl/assets.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/assets.impl.jac
@@ -1,0 +1,203 @@
+import from email.utils { formatdate, parsedate_to_datetime }
+import from urllib.parse { unquote }
+
+impl AssetPolicy.from_config(
+    base_path: (Path | None) = None, dev: bool = False
+) -> AssetPolicy {
+    import from jaclang.cli.console { console }
+    import from jaclang.project.config { get_config }
+    base = base_path if base_path is not None else resolve_project_root();
+    config = get_config(base_path) if base_path is not None else get_config();
+    client_cfg = config.get_plugin_config('client') if config else None;
+    raw: dict[str, any] = _as_dict(client_cfg.get('assets') if client_cfg else None);
+    extensions: set[str] = set(ASSET_MEDIA_TYPES.keys()) | configured_extra_extensions();
+    extensions -= _as_ext_set(_as_dict(raw.get('extensions')).get('remove'));
+    if raw.get('custom_extensions') {
+        console.warning(
+            "[client.assets] custom_extensions is deprecated and is now additive; " + "use extensions.add = [...] instead. It no longer replaces the " + "built-in extension table."
+        );
+    }
+    roots: list[AssetRoot] = [];
+    for entry in _as_list(raw.get('roots')) {
+        spec: dict[str, any] = _as_dict(entry);
+        declared = str(spec.get('path', ''));
+        if not declared {
+            continue;
+        }
+        candidate = confined_path(base, declared);
+        if candidate is None {
+            console.warning(
+                f"[client.assets] ignoring root outside the project: {declared}"
+            );
+            continue;
+        }
+        roots.append(
+            AssetRoot(
+                path=candidate,
+                mode=str(spec.get('mode', AssetRootMode.SOURCE_ASSET.value)),
+                flatten=bool(spec.get('flatten', False))
+            )
+        );
+    }
+    if not roots {
+        roots = default_asset_roots(base);
+    }
+    reserved: list[str] = list(RESERVED_URL_PREFIXES);
+    cl_prefix: str = config.serve.cl_route_prefix if config else 'cl';
+    if cl_prefix {
+        reserved.append(f"{cl_prefix}/");
+    }
+    max_age: any = raw.get('immutable_max_age', 31536000);
+    return AssetPolicy(
+        roots=roots,
+        extensions=extensions,
+        reserved_prefixes=reserved,
+        dev=dev,
+        immutable_max_age=int(max_age) if isinstance(max_age, int) else 31536000
+    );
+}
+
+impl AssetResolution.headers -> dict[str, str] {
+    out = {'Cache-Control': self.cache_control};
+    if self.etag {
+        out['ETag'] = self.etag;
+    }
+    if self.last_modified {
+        out['Last-Modified'] = self.last_modified;
+    }
+    return out;
+}
+
+impl AssetResolver.build(
+    dev: bool = False, base_path: (Path | None) = None
+) -> AssetResolver {
+    return AssetResolver(policy=AssetPolicy.from_config(base_path, dev));
+}
+
+impl AssetResolver.resolve(url_path: str, query: str = "") -> AssetResolution {
+    rel = unquote(url_path).lstrip('/');
+    under_static = rel.startswith('static/');
+    if under_static {
+        rel = rel[7:];
+    } elif is_reserved_url(rel, self.policy.reserved_prefixes) {
+        return AssetResolution(outcome=AssetOutcome.NOT_AN_ASSET.value);
+    }
+    if not rel {
+        return AssetResolution(outcome=AssetOutcome.NOT_AN_ASSET.value);
+    }
+    segments = rel.split('/');
+    for segment in segments {
+        if not segment
+        or segment.startswith('.')
+        or ('\\' in segment)
+        or ('\x00' in segment) {
+            return AssetResolution(
+                outcome=AssetOutcome.FORBIDDEN.value, status=403, message='Forbidden'
+            );
+        }
+    }
+    suffix = Path(rel).suffix.lower();
+    if suffix in SOURCE_ONLY_EXTENSIONS {
+        return AssetResolution(
+            outcome=AssetOutcome.FORBIDDEN.value, status=403, message='Forbidden'
+        );
+    }
+    found = self._locate(rel);
+    if found is not None {
+        return self._describe(found, has_cache_bust(query));
+    }
+    if under_static or (suffix in self.policy.extensions) {
+        return AssetResolution(
+            outcome=AssetOutcome.NOT_FOUND.value,
+            status=404,
+            message=f"Asset not found: {rel}"
+        );
+    }
+    return AssetResolution(outcome=AssetOutcome.NOT_AN_ASSET.value);
+}
+
+impl AssetResolver._locate(rel: str) -> (Path | None) {
+    file_name = Path(rel).name;
+    for asset_root in self.policy.roots {
+        candidate = confined_path(asset_root.path, rel);
+        if candidate is not None and candidate.is_file() {
+            return candidate;
+        }
+        if asset_root.flatten and (file_name != rel) {
+            flat = confined_path(asset_root.path, file_name);
+            if flat is not None and flat.is_file() {
+                return flat;
+            }
+        }
+    }
+    return None;
+}
+
+impl AssetResolver._describe(file_path: Path, cache_bust: bool) -> AssetResolution {
+    try {
+        stat = file_path.stat();
+    } except OSError {
+        return AssetResolution(
+            outcome=AssetOutcome.NOT_FOUND.value, status=404, message='Asset not found'
+        );
+    }
+    immutable = cache_bust or is_content_hashed(file_path.name);
+    if immutable {
+        cache_control = f"public, max-age={self.policy.immutable_max_age}, immutable";
+    } elif self.policy.dev {
+        cache_control = 'no-store';
+    } else {
+        cache_control = 'no-cache';
+    }
+    return AssetResolution(
+        outcome=AssetOutcome.SERVED.value,
+        status=200,
+        path=file_path,
+        media_type=asset_media_type(file_path),
+        cache_control=cache_control,
+        etag=f'"{stat.st_mtime_ns:x}-{stat.st_size:x}"',
+        last_modified=formatdate(stat.st_mtime, usegmt=True)
+    );
+}
+
+impl AssetResolution.read_bytes -> bytes {
+    if self.path is None {
+        return b'';
+    }
+    return self.path.read_bytes();
+}
+
+impl AssetResolution.is_fresh(
+    if_none_match: (str | None) = None, if_modified_since: (str | None) = None
+) -> bool {
+    if not self.is_served() {
+        return False;
+    }
+    if if_none_match {
+        if if_none_match.strip() == '*' {
+            return True;
+        }
+        for raw_tag in if_none_match.split(',') {
+            tag = raw_tag.strip();
+            if tag.startswith('W/') {
+                tag = tag[2:];
+            }
+            if tag == self.etag {
+                return True;
+            }
+        }
+        return False;
+    }
+    if if_modified_since and self.path is not None {
+        try {
+            since = parsedate_to_datetime(if_modified_since);
+        } except (TypeError, ValueError) {
+            return False;
+        }
+        if since is None {
+            return False;
+        }
+        return int(self.path.stat().st_mtime) <= int(since.timestamp());
+    }
+    return False;
+}

--- a/jac/jaclang/runtimelib/client/impl/serving.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/serving.impl.jac
@@ -1,32 +1,67 @@
 import from jaclang.project.config { get_config }
 
-impl JacClient.send_static_file(
-    handler: BaseHTTPRequestHandler, file_path: Path, content_type: (str | None) = None
+impl JacClient.send_asset(
+    handler: BaseHTTPRequestHandler,
+    resolution: AssetResolution,
+    head_only: bool = False
 ) -> None {
+    import from jaclang.runtimelib.client.assets { parse_byte_range }
     import from jaclang.runtimelib.server { ResponseBuilder }
-    if (not file_path.exists() or not file_path.is_file()) {
-        ResponseBuilder.send_json(handler, 404, {'error': 'File not found'});
-        return;
-    }
-    try {
-        file_content = file_path.read_bytes();
-        if (content_type is None) {
-            (content_type, _) = mimetypes.guess_type(str(file_path));
-            if (content_type is None) {
-                content_type = 'application/octet-stream';
-            }
+
+    def emit(
+        status: int, body: bytes, extra: dict[(str, str)], with_body: bool = True
+    ) {
+        handler.send_response(status);
+        for (key, value) in extra.items() {
+            handler.send_header(key, value);
         }
-        handler.send_response(200);
-        handler.send_header('Content-Type', content_type);
-        handler.send_header('Content-Length', str(len(file_content)));
-        handler.send_header('Cache-Control', 'public, max-age=3600');
+        handler.send_header('Content-Length', str(len(body)));
         ResponseBuilder._add_cors_headers(handler);
         ResponseBuilder._add_custom_headers(handler);
         handler.end_headers();
-        handler.wfile.write(file_content);
-    } except Exception as exc {
-        ResponseBuilder.send_json(handler, 500, {'error': str(exc)});
+        if with_body and body {
+            handler.wfile.write(body);
+        }
     }
+    incoming: any = handler.headers;
+
+    def header_of(name: str) -> (str | None) {
+        raw: any = incoming.get(name) if incoming is not None else None;
+        return str(raw) if raw is not None else None;
+    }
+    if not resolution.is_served() {
+        message = (resolution.message or 'Not found').encode('utf-8');
+        emit(
+            resolution.status,
+            message,
+            {'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-store'},
+            not head_only
+        );
+        return;
+    }
+    headers = resolution.headers();
+    headers['Accept-Ranges'] = 'bytes';
+    if resolution.is_fresh(
+        header_of('If-None-Match'), header_of('If-Modified-Since')
+    ) {
+        emit(304, b'', headers, False);
+        return;
+    }
+    try {
+        payload = resolution.read_bytes();
+    } except OSError as exc {
+        ResponseBuilder.send_json(handler, 500, {'error': str(exc)});
+        return;
+    }
+    headers['Content-Type'] = resolution.media_type;
+    window = parse_byte_range(header_of('Range'), len(payload));
+    if window is not None {
+        (start, end) = window;
+        headers['Content-Range'] = f"bytes {start}-{end}/{len(payload)}";
+        emit(206, payload[start:end + 1], headers, not head_only);
+        return;
+    }
+    emit(200, payload, headers, not head_only);
 }
 
 impl JacClient.render_page(

--- a/jac/jaclang/runtimelib/client/plugin_config.jac
+++ b/jac/jaclang/runtimelib/client/plugin_config.jac
@@ -52,6 +52,45 @@ class JacClientPluginConfig {
                     "default": {},
                     "description": "TypeScript configuration overrides"
                 },
+                "assets": {
+                    "type": "dict",
+                    "default": {},
+                    "description": "Static asset serving. Applies identically to the local server and to jac-scale.",
+                    "nested": {
+                        "roots": {
+                            "type": "list",
+                            "default": [],
+                            "description": "Ordered directories assets are served from, each { path, mode = 'build-output' | 'public' | 'source-asset', flatten = false }. Paths are confined to the project. Empty means the built-in set: .jac/client/dist, dist, public, assets."
+                        },
+                        "extensions": {
+                            "type": "dict",
+                            "default": {},
+                            "description": "Adjust the servable extension table with 'add' and 'remove' lists. Both are deltas on the built-in table; neither replaces it.",
+                            "nested": {
+                                "add": {
+                                    "type": "list",
+                                    "default": [],
+                                    "description": "Extra extensions to treat as assets (e.g. ['.avif'])"
+                                },
+                                "remove": {
+                                    "type": "list",
+                                    "default": [],
+                                    "description": "Built-in extensions to stop serving"
+                                }
+                            }
+                        },
+                        "immutable_max_age": {
+                            "type": "int",
+                            "default": 31536000,
+                            "description": "max-age for content-hashed filenames. Unhashed files are always revalidated with an ETag instead."
+                        },
+                        "custom_extensions": {
+                            "type": "list",
+                            "default": [],
+                            "description": "Deprecated: use extensions.add. Kept readable for one release and now additive; it used to replace the built-in table, which silently 404'd fonts and images."
+                        }
+                    }
+                },
                 "configs": {
                     "type": "dict",
                     "default": {},

--- a/jac/jaclang/runtimelib/client/serving.jac
+++ b/jac/jaclang/runtimelib/client/serving.jac
@@ -1,13 +1,13 @@
 import hashlib;
 import html;
 import json;
-import mimetypes;
 import types;
 import from http.server { BaseHTTPRequestHandler }
 import from pathlib { Path }
 import from typing { Any, Literal, TypeAlias }
 import from jaclang.runtimelib.runtime { JacRuntime as Jac }
 import from jaclang.runtimelib.server { ModuleIntrospector }
+import from jaclang.runtimelib.client.assets { AssetResolution }
 
 glob JsonValue: TypeAlias = None | str | int | float | bool | list['JsonValue'] | dict[
          (str, 'JsonValue')
@@ -39,10 +39,10 @@ obj HeaderBuilder {
 }
 
 class JacClient {
-    static def send_static_file(
+    static def send_asset(
         handler: BaseHTTPRequestHandler,
-        file_path: Path,
-        content_type: (str | None) = None
+        resolution: AssetResolution,
+        head_only: bool = False
     ) -> None;
 
     static def render_page(

--- a/jac/jaclang/runtimelib/client/targets/impl/static_target.impl.jac
+++ b/jac/jaclang/runtimelib/client/targets/impl/static_target.impl.jac
@@ -93,10 +93,9 @@ class _DistRequestHandler(SimpleHTTPRequestHandler) {
     }
 
     def guess_type(self: _DistRequestHandler, path: str) -> str {
-        if str(path).endswith(".wasm") {
-            return "application/wasm";
-        }
-        return super.guess_type(path);
+        import from jaclang.runtimelib.client.assets { ASSET_MEDIA_TYPES }
+        known = ASSET_MEDIA_TYPES.get(Path(str(path)).suffix.lower());
+        return known or super.guess_type(path);
     }
 }
 

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -1937,131 +1937,15 @@ impl JacAPIServer.create_handler -> type[BaseHTTPRequestHandler] {
                 Jac.send_json(self, 200, get_build_status());
                 return;
             }
-            is_static_path = path.startswith('/static/');
             import from jaclang.project.config { get_config }
+            import from jaclang.runtimelib.client.assets { AssetOutcome }
 
             config = get_config();
-            client_cfg = config.get_plugin_config("client") if config else None;
-            assets_config = client_cfg.get("assets", {}) if client_cfg else {};
-            custom_asset_extensions = set(assets_config.get("custom_extensions", []));
             cl_route_prefix = config.serve.cl_route_prefix if config else "cl";
             cl_route_path = f"/{cl_route_prefix}/";
-            is_asset_file = (
-                not is_static_path
-                and (path != '/')
-                and not path.startswith(cl_route_path)
-                and not path.startswith('/function/')
-                and not path.startswith('/walker/')
-                and not path.startswith('/user/')
-                and not path.startswith('/functions')
-                and not path.startswith('/walkers')
-                and not path.startswith('/protected')
-                and (
-                    Path(path).suffix in (
-                        custom_asset_extensions
-                        or {
-                            '.png',
-                            '.jpg',
-                            '.jpeg',
-                            '.gif',
-                            '.webp',
-                            '.svg',
-                            '.ico',
-                            '.woff',
-                            '.woff2',
-                            '.ttf',
-                            '.otf',
-                            '.eot',
-                            '.mp4',
-                            '.webm',
-                            '.mp3',
-                            '.wav',
-                            '.css',
-                            '.js',
-                            '.json'
-                        }
-                    )
-                )
-            );
-            if (is_static_path or is_asset_file) {
-                try {
-                    import from jaclang.project.config { find_project_root }
-                    bp_dir = Jac.get_context().base_path_dir or Jac.get_base_path_dir();
-                    base_path_dir = Path(bp_dir) if bp_dir else Path.cwd();
-                    project_root_result = find_project_root(base_path_dir);
-                    if project_root_result {
-                        (base_path, _) = project_root_result;
-                    } else {
-                        base_path = base_path_dir;
-                    }
-                    if is_static_path {
-                        relative_path = path[8:];
-                    } else {
-                        relative_path = path[1:];
-                    }
-                    file_name = Path(relative_path).name;
-
-                    client_build_dist_file = base_path / '.jac' / 'client' / 'dist' / relative_path;
-                    client_build_dist_file_simple = base_path / '.jac' / 'client' / 'dist' / file_name;
-
-                    dist_file = base_path / 'dist' / relative_path;
-                    dist_file_simple = base_path / 'dist' / file_name;
-
-                    assets_file = base_path / 'assets' / relative_path;
-                    assets_file_simple = base_path / 'assets' / file_name;
-                    if path.endswith('.css') {
-                        if client_build_dist_file.exists() {
-                            css_content = client_build_dist_file.read_text(
-                                encoding='utf-8'
-                            );
-                            Jac.send_css(self, css_content);
-                            return;
-                        } elif client_build_dist_file_simple.exists() {
-                            css_content = client_build_dist_file_simple.read_text(
-                                encoding='utf-8'
-                            );
-                            Jac.send_css(self, css_content);
-                            return;
-                        } elif dist_file.exists() {
-                            css_content = dist_file.read_text(encoding='utf-8');
-                            Jac.send_css(self, css_content);
-                            return;
-                        } elif dist_file_simple.exists() {
-                            css_content = dist_file_simple.read_text(encoding='utf-8');
-                            Jac.send_css(self, css_content);
-                            return;
-                        } elif assets_file.exists() {
-                            css_content = assets_file.read_text(encoding='utf-8');
-                            Jac.send_css(self, css_content);
-                            return;
-                        } elif assets_file_simple.exists() {
-                            css_content = assets_file_simple.read_text(
-                                encoding='utf-8'
-                            );
-                            Jac.send_css(self, css_content);
-                            return;
-                        } else {
-                            Jac.send_json(self, 404, {'error': 'CSS file not found'});
-                            return;
-                        }
-                    }
-                    for candidate_file in [
-                        client_build_dist_file,
-                        client_build_dist_file_simple,
-                        dist_file,
-                        dist_file_simple,
-                        assets_file,
-                        assets_file_simple
-                    ] {
-                        if (candidate_file.exists() and candidate_file.is_file()) {
-                            Jac.send_static_file(self, candidate_file);
-                            return;
-                        }
-                    }
-                    Jac.send_json(self, 404, {'error': 'Static file not found'});
-                } except Exception as exc {
-                    Jac.send_json(self, 500, {'error': str(exc)});
-                }
+            asset = server.asset_resolver.resolve(path, parsed_path.query);
+            if asset.outcome != AssetOutcome.NOT_AN_ASSET.value {
+                Jac.send_asset(self, asset);
                 return;
             }
             if (path == '/') {
@@ -2390,6 +2274,13 @@ impl JacAPIServer.load_module(force_reload: bool = False) -> None {
 
 impl JacAPIServer.module.getter -> object {
     return self.introspector._module;
+}
+
+impl JacAPIServer.asset_resolver.getter -> AssetResolver {
+    if self._asset_resolver is None {
+        self._asset_resolver = AssetResolver.build(dev=True);
+    }
+    return self._asset_resolver;
 }
 
 impl JacAPIServer.get_functions -> dict[str, Callable[(..., Any)]] {

--- a/jac/jaclang/runtimelib/server.jac
+++ b/jac/jaclang/runtimelib/server.jac
@@ -20,6 +20,7 @@ import from typing {
     get_type_hints
 }
 import from urllib.parse { parse_qs, urlparse }
+import from jaclang.runtimelib.client.assets { AssetResolver }
 import from jaclang.runtimelib.client_bundle { ClientBundleError }
 import from jaclang.runtimelib.context { CallState, ExecutionContext }
 import from jaclang.runtimelib.transport { TransportResponse, HTTPTransport, Meta }
@@ -208,7 +209,8 @@ obj JacAPIServer {
         introspection_handler: IntrospectionHandler postinit,
         execution_handler: ExecutionHandler postinit,
         server: (HTTPServer | None) postinit,
-        scheduler: Scheduler postinit;
+        scheduler: Scheduler postinit,
+        _asset_resolver: (AssetResolver | None) = None;
 
     obj RestSpecs {
         has method: str = "",
@@ -222,6 +224,7 @@ obj JacAPIServer {
     def load_module(force_reload: bool = False) -> None;
 
     has module: object { getter; }
+    has asset_resolver: AssetResolver { getter; }
 
     def get_functions -> dict[str, Callable[(..., Any)]];
     def get_walkers -> dict[str, type[WalkerArchetype]];

--- a/jac/jaclang/scale/server/impl/serve.static.impl.jac
+++ b/jac/jaclang/scale/server/impl/serve.static.impl.jac
@@ -1,6 +1,5 @@
-import mimetypes;
 import from collections.abc { Callable }
-import from pathlib { Path }
+import from fastapi { Request }
 import from fastapi.responses { HTMLResponse, JSONResponse, Response }
 import from jaclang.scale.jserver.jserver {
     APIParameter,
@@ -10,80 +9,90 @@ import from jaclang.scale.jserver.jserver {
 }
 import from jaclang.jac0core.runtime { JacRuntime as Jac }
 import from jaclang.runtimelib.server { JsonValue }
+import from jaclang.runtimelib.client.assets { AssetResolution, AssetResolver }
 import from jaclang.cli.console { console }
 
-impl JacAPIServerStatic.serve_static_file(file_path: str) -> Response {
-    try {
-        import from jaclang.project.config { find_project_root }
-        base_path_dir = Path(bp_dir)
-            if (bp_dir := Jac.get_context().base_path_dir or Jac.get_base_path_dir())
-            else Path.cwd();
-        project_root_result = find_project_root(base_path_dir);
-        if project_root_result {
-            (base_path, _) = project_root_result;
-        } else {
-            base_path = base_path_dir;
-        }
-        file_name = Path(file_path).name;
-
-        client_build_dist_file = base_path / '.jac' / 'client' / 'dist' / file_path;
-        client_build_dist_file_simple = base_path / '.jac' / 'client' / 'dist' / file_name;
-
-        dist_file = base_path / 'dist' / file_path;
-        dist_file_simple = base_path / 'dist' / file_name;
-
-        assets_file = base_path / 'assets' / file_path;
-        assets_file_simple = base_path / 'assets' / file_name;
-        if file_name.endswith('.css') {
-            if client_build_dist_file.exists() {
-                css_content = client_build_dist_file.read_text(encoding='utf-8');
-                return Response(content=css_content, media_type='text/css');
-            } elif client_build_dist_file_simple.exists() {
-                css_content = client_build_dist_file_simple.read_text(encoding='utf-8');
-                return Response(content=css_content, media_type='text/css');
-            } elif dist_file.exists() {
-                css_content = dist_file.read_text(encoding='utf-8');
-                return Response(content=css_content, media_type='text/css');
-            } elif dist_file_simple.exists() {
-                css_content = dist_file_simple.read_text(encoding='utf-8');
-                return Response(content=css_content, media_type='text/css');
-            } elif assets_file.exists() {
-                css_content = assets_file.read_text(encoding='utf-8');
-                return Response(content=css_content, media_type='text/css');
-            } elif assets_file_simple.exists() {
-                css_content = assets_file_simple.read_text(encoding='utf-8');
-                return Response(content=css_content, media_type='text/css');
-            } else {
-                return Response(
-                    status_code=404,
-                    content='CSS file not found',
-                    media_type='text/plain'
-                );
-            }
-        }
-        for candidate_file in [
-            client_build_dist_file,
-            client_build_dist_file_simple,
-            dist_file,
-            dist_file_simple,
-            assets_file,
-            assets_file_simple
-        ] {
-            if (candidate_file.exists() and candidate_file.is_file()) {
-                file_content = candidate_file.read_bytes();
-                (content_type, _) = mimetypes.guess_type(str(candidate_file));
-                if (content_type is None) {
-                    content_type = 'application/octet-stream';
-                }
-                return Response(content=file_content, media_type=content_type);
-            }
-        }
+impl JacAPIServerStatic.asset_response(
+    resolution: AssetResolution, request: Request
+) -> Response {
+    import from jaclang.runtimelib.client.assets { parse_byte_range }
+    if not resolution.is_served() {
         return Response(
-            status_code=404, content='Static file not found', media_type='text/plain'
+            status_code=resolution.status,
+            content=resolution.message or 'Not found',
+            media_type='text/plain; charset=utf-8',
+            headers={'Cache-Control': 'no-store'}
         );
-    } except Exception as exc {
-        return Response(status_code=500);
     }
+    headers = resolution.headers();
+    headers['Accept-Ranges'] = 'bytes';
+    if resolution.is_fresh(
+        request.headers.get('if-none-match'), request.headers.get('if-modified-since')
+    ) {
+        return Response(status_code=304, headers=headers);
+    }
+    try {
+        payload = resolution.read_bytes();
+    } except OSError as exc {
+        console.print(f"Error reading asset {resolution.path}: {exc}");
+        return Response(
+            status_code=500, content='Internal server error', media_type='text/plain'
+        );
+    }
+    window = parse_byte_range(request.headers.get('range'), len(payload));
+    if window is not None {
+        (start, end) = window;
+        headers['Content-Range'] = f"bytes {start}-{end}/{len(payload)}";
+        return Response(
+            status_code=206,
+            content=payload[start:end + 1],
+            media_type=resolution.media_type,
+            headers=headers
+        );
+    }
+    return Response(content=payload, media_type=resolution.media_type, headers=headers);
+}
+
+impl JacAPIServerStatic.serve_asset(file_path: str, request: Request) -> Response {
+    import from jaclang.runtimelib.client.assets { AssetOutcome, is_reserved_url }
+    url_path = request.url.path;
+    resolution = self.asset_resolver().resolve(url_path, request.url.query);
+    if resolution.outcome != AssetOutcome.NOT_AN_ASSET.value {
+        return self.asset_response(resolution, request);
+    }
+    rel = url_path.lstrip('/');
+    if is_reserved_url(rel, self.asset_resolver().policy.reserved_prefixes) {
+        return Response(status_code=404, content='Not found', media_type='text/plain');
+    }
+    import from jaclang.project.config { get_config }
+    config = get_config();
+    configured_root = config.serve.base_route_app if config else "";
+    base_route_app = self.introspector.resolve_root_app(configured_root);
+    if not base_route_app {
+        return Response(status_code=404, content='Not found', media_type='text/plain');
+    }
+    try {
+        render_payload = self.introspector.render_page(
+            base_route_app, {}, Con.GUEST.value
+        );
+    } except ValueError {
+        return HTMLResponse(content="<h1>404 Not Found</h1>", status_code=404);
+    } except RuntimeError {
+        return HTMLResponse(
+            content="<h1>503 Service Unavailable</h1>", status_code=503
+        );
+    }
+    return HTMLResponse(
+        content=render_payload['html'],
+        status_code=self.introspector.spa_fallback_status(url_path)
+    );
+}
+
+impl JacAPIServerStatic.asset_resolver -> AssetResolver {
+    if self._asset_resolver is None {
+        self._asset_resolver = AssetResolver.build(dev=False);
+    }
+    return self._asset_resolver;
 }
 
 impl JacAPIServerStatic.register_static_file_endpoint -> None {
@@ -91,7 +100,7 @@ impl JacAPIServerStatic.register_static_file_endpoint -> None {
         JEndPoint(
             method=HTTPMethod.GET,
             path='/static/{file_path:path}',
-            callback=self.serve_static_file,
+            callback=self.serve_asset,
             parameters=[
                 APIParameter(
                     name='file_path',
@@ -227,115 +236,12 @@ impl JacAPIServerStatic.render_base_route_callback(
     return callback;
 }
 
-impl JacAPIServerStatic.serve_root_asset(file_path: str) -> Response {
-    allowed_extensions = {
-        '.png',
-        '.jpg',
-        '.jpeg',
-        '.gif',
-        '.webp',
-        '.svg',
-        '.ico',
-        '.woff',
-        '.woff2',
-        '.ttf',
-        '.otf',
-        '.eot',
-        '.mp4',
-        '.webm',
-        '.mp3',
-        '.wav',
-        '.css',
-        '.js',
-        '.json',
-        '.pdf',
-        '.txt',
-        '.xml'
-    };
-    file_ext = Path(file_path).suffix.lower();
-    import from jaclang.project.config { get_config }
-    config = get_config();
-    cl_route_prefix = config.serve.cl_route_prefix if config else "cl";
-    api_prefixes = (f'{cl_route_prefix}/', 'walker/', 'function/', 'user/', 'static/');
-    if (not file_ext or (file_ext not in allowed_extensions)) {
-        configured_root = config.serve.base_route_app if config else "";
-        base_route_app = self.introspector.resolve_root_app(configured_root);
-        if (
-            not file_ext and base_route_app and not file_path.startswith(api_prefixes)
-        ) {
-            try {
-                render_payload = self.introspector.render_page(
-                    base_route_app, {}, Con.GUEST.value
-                );
-                return HTMLResponse(
-                    content=render_payload['html'],
-                    status_code=self.introspector.spa_fallback_status(file_path)
-                );
-            } except ValueError {
-                return HTMLResponse(content="<h1>404 Not Found</h1>", status_code=404);
-            } except RuntimeError {
-                return HTMLResponse(
-                    content="<h1>503 Service Unavailable</h1>", status_code=503
-                );
-            }
-        }
-        return Response(status_code=404, content='Not found', media_type='text/plain');
-    }
-    if file_path.startswith(api_prefixes) {
-        return Response(status_code=404, content='Not found', media_type='text/plain');
-    }
-
-    import from jaclang.project.config { find_project_root }
-    base_path_dir = Path(bp_dir)
-        if (bp_dir := Jac.get_context().base_path_dir or Jac.get_base_path_dir())
-        else Path.cwd();
-    project_root_result = find_project_root(base_path_dir);
-    if project_root_result {
-        (base_path, _) = project_root_result;
-    } else {
-        base_path = base_path_dir;
-    }
-    file_name = Path(file_path).name;
-
-    candidates = [
-        base_path / 'dist' / file_path,
-        base_path / 'dist' / file_name,
-        base_path / 'assets' / file_path,
-        base_path / 'assets' / file_name,
-        base_path / 'public' / file_path,
-        base_path / 'src' / file_path,
-        base_path / 'src' / file_name,
-        (base_path / file_path),
-        base_path / '.jac' / 'client' / 'dist' / file_path,
-        base_path / '.jac' / 'client' / 'dist' / file_name
-    ];
-
-    for candidate_file in candidates {
-        if (candidate_file.exists() and candidate_file.is_file()) {
-            file_content = candidate_file.read_bytes();
-            (content_type, _) = mimetypes.guess_type(str(candidate_file));
-            if (content_type is None) {
-                content_type = 'application/octet-stream';
-            }
-            headers = {'Cache-Control': 'public, max-age=31536000'};
-            return Response(
-                content=file_content, media_type=content_type, headers=headers
-            );
-        }
-    }
-    return Response(
-        status_code=404,
-        content=f"Asset not found: {file_path}",
-        media_type='text/plain'
-    );
-}
-
 impl JacAPIServerStatic.register_root_asset_endpoint -> None {
     self.server.add_endpoint(
         JEndPoint(
             method=HTTPMethod.GET,
             path='/{file_path:path}',
-            callback=self.serve_root_asset,
+            callback=self.serve_asset,
             parameters=[
                 APIParameter(
                     name='file_path',
@@ -349,7 +255,7 @@ impl JacAPIServerStatic.register_root_asset_endpoint -> None {
             response_model=None,
             tags=['Static Files'],
             summary='Serve root-level assets',
-            description='Endpoint to serve assets from root path with common extensions (.png, .jpg, .svg, etc.)'
+            description='Serves assets from the configured asset roots, falling back to the base route app for client-side routes.'
         )
     );
 }

--- a/jac/jaclang/scale/server/serve.jac
+++ b/jac/jaclang/scale/server/serve.jac
@@ -21,6 +21,7 @@ import from jaclang.scale.jserver.jserver {
 import from jaclang.jac0core.runtime { JacRuntime as Jac }
 import from jaclang.runtimelib.server { JacAPIServer as JServer }
 import from jaclang.runtimelib.server { JsonValue }
+import from jaclang.runtimelib.client.assets { AssetResolution, AssetResolver }
 import from jaclang.runtimelib.transport { TransportResponse, Meta }
 import from jaclang.scale.shared.utils { _extract_path_param_names }
 import from jaclang.scale.config.config_loader { get_scale_config }
@@ -218,14 +219,17 @@ obj JacAPIServerScheduler {
 }
 
 obj JacAPIServerStatic {
-    def serve_static_file(file_path: str) -> Response;
+    has _asset_resolver: (AssetResolver | None) = None;
+
+    def asset_resolver -> AssetResolver;
+    def asset_response(resolution: AssetResolution, request: Request) -> Response;
+    def serve_asset(file_path: str, request: Request) -> Response;
     def register_static_file_endpoint -> None;
     def serve_client_js_callback -> Callable[..., Response];
     def register_client_js_endpoint -> None;
     def render_page_callback -> Callable[..., HTMLResponse];
     def render_base_route_callback(app_name: str) -> Callable[..., HTMLResponse];
     def register_page_endpoint -> None;
-    def serve_root_asset(file_path: str) -> Response;
     def register_root_asset_endpoint -> None;
     def register_graph_endpoint -> None;
     def serve_graph_page -> HTMLResponse;

--- a/jac/tests/runtimelib/client/test_asset_resolver.jac
+++ b/jac/tests/runtimelib/client/test_asset_resolver.jac
@@ -1,0 +1,489 @@
+"""Conformance tests for unified static asset resolution.
+
+One table drives the shared `AssetResolver`, and the same table is replayed
+through both transport adapters (the dev `BaseHTTPRequestHandler` and the scale
+FastAPI app). Divergence between the two servers is what this file exists to
+prevent: an entry that passes at the resolver level but fails through an adapter
+means an adapter is making a policy decision it has no business making.
+"""
+
+import io;
+import pytest;
+import from pathlib { Path }
+import from tempfile { TemporaryDirectory }
+import from jaclang.runtimelib.client.assets {
+    AssetOutcome,
+    AssetPolicy,
+    AssetResolver,
+    AssetRoot,
+    AssetRootMode,
+    ASSET_MEDIA_TYPES,
+    SOURCE_ONLY_EXTENSIONS,
+    default_asset_roots,
+    is_content_hashed,
+    parse_byte_range
+}
+
+"""Build a project tree covering every root and every interesting file kind."""
+def _make_project(base: Path) {
+    files = {
+        '.jac/client/dist/client.DEADBEEF.js': 'console.log(1)',
+        '.jac/client/dist/styles.css': '.a{}',
+        '.jac/client/dist/nested/deep.png': 'png-bytes',
+        'dist/styles.css': '.stale{}',
+        'dist/report.pdf': '%PDF-1.4',
+        'public/robots.txt': 'User-agent: *',
+        'assets/fonts/Inter.woff2': 'woff2-bytes',
+        'assets/flat-only.svg': '<svg/>',
+        'assets/data.json': '{}',
+        'assets/theme.scss': '$c: red;',
+        'assets/.env': 'SECRET=1',
+        'secrets.json': '{"token": "leak"}',
+        'src/app.js': 'export default 1;'
+    };
+    for (rel, body) in files.items() {
+        target = base / rel;
+        target.parent.mkdir(parents=True, exist_ok=True);
+        target.write_text(body, encoding='utf-8');
+    }
+}
+
+"""A resolver over `base` with the built-in defaults and no jac.toml involved."""
+def _resolver(base: Path, dev: bool = False) -> AssetResolver {
+    return AssetResolver(
+        policy=AssetPolicy(
+            roots=default_asset_roots(base),
+            extensions=set(ASSET_MEDIA_TYPES.keys()),
+            reserved_prefixes=['walker/', 'function/', 'user/', 'cl/', 'healthz'],
+            dev=dev
+        )
+    );
+}
+
+"""(url, expected outcome, expected media type or '', note).
+
+Media type is only asserted when non-empty.
+"""
+glob CASES: list[tuple[(str, str, str, str)]] = [
+         (
+             '/client.DEADBEEF.js',
+             AssetOutcome.SERVED.value,
+             'text/javascript; charset=utf-8',
+             'build output at root'
+         ),
+         (
+             '/static/client.DEADBEEF.js',
+             AssetOutcome.SERVED.value,
+             'text/javascript; charset=utf-8',
+             'same file under the static prefix'
+         ),
+         (
+             '/styles.css',
+             AssetOutcome.SERVED.value,
+             'text/css; charset=utf-8',
+             'css is not a special case'
+         ),
+         (
+             '/nested/deep.png',
+             AssetOutcome.SERVED.value,
+             'image/png',
+             'nested path preserved'
+         ),
+         (
+             '/fonts/Inter.woff2',
+             AssetOutcome.SERVED.value,
+             'font/woff2',
+             'fonts serve without being listed anywhere'
+         ),
+         (
+             '/report.pdf',
+             AssetOutcome.SERVED.value,
+             'application/pdf',
+             'pdf served in both servers, not just scale'
+         ),
+         (
+             '/robots.txt',
+             AssetOutcome.SERVED.value,
+             'text/plain; charset=utf-8',
+             'public root is reachable'
+         ),
+         (
+             '/data.json',
+             AssetOutcome.SERVED.value,
+             'application/json; charset=utf-8',
+             'json asset'
+         ),
+         (
+             '/sub/dir/flat-only.svg',
+             AssetOutcome.SERVED.value,
+             'image/svg+xml',
+             'legacy basename fallback on a flatten root'
+         ),
+         (
+             '/missing.png',
+             AssetOutcome.NOT_FOUND.value,
+             '',
+             'known extension miss is a hard 404, never an SPA render'
+         ),
+         (
+             '/static/missing-anything.xyz',
+             AssetOutcome.NOT_FOUND.value,
+             '',
+             'anything under /static/ that misses is a hard 404'
+         ),
+         (
+             '/dashboard/settings',
+             AssetOutcome.NOT_AN_ASSET.value,
+             '',
+             'extensionless deep link falls through to the SPA router'
+         ),
+         (
+             '/users/v1.2/profile',
+             AssetOutcome.NOT_AN_ASSET.value,
+             '',
+             'a dot in a route segment is not an asset request'
+         ),
+         (
+             '/walker/create_item',
+             AssetOutcome.NOT_AN_ASSET.value,
+             '',
+             'reserved prefixes belong to the router'
+         ),
+         (
+             '/theme.scss',
+             AssetOutcome.FORBIDDEN.value,
+             '',
+             'bundler input is never served'
+         ),
+         ('/.env', AssetOutcome.FORBIDDEN.value, '', 'dotfiles are never served'),
+         (
+             '/../secrets.json',
+             AssetOutcome.FORBIDDEN.value,
+             '',
+             'traversal out of every root'
+         ),
+         (
+             '/..%2Fsecrets.json',
+             AssetOutcome.FORBIDDEN.value,
+             '',
+             'percent-encoded traversal is decoded before the check'
+         ),
+         (
+             '/nested/../../secrets.json',
+             AssetOutcome.FORBIDDEN.value,
+             '',
+             'traversal from a nested path'
+         ),
+         ('/src/app.js', AssetOutcome.NOT_FOUND.value, '', 'src/ is not a served root'),
+         (
+             '/secrets.json',
+             AssetOutcome.NOT_FOUND.value,
+             '',
+             'the project root itself is not a served root'
+         )
+     ];
+
+test "resolver conformance table" {
+    with TemporaryDirectory() as tmp {
+        base = Path(tmp);
+        _make_project(base);
+        resolver = _resolver(base);
+        failures: list[str] = [];
+        for (url, expected, media, note) in CASES {
+            got = resolver.resolve(url);
+            if got.outcome != expected {
+                failures.append(
+                    f"{url}: expected {expected}, got {got.outcome} ({note})"
+                );
+                continue;
+            }
+            if media and (got.media_type != media) {
+                failures.append(
+                    f"{url}: expected media {media}, got {got.media_type} ({note})"
+                );
+            }
+        }
+        assert not failures , "\n".join(failures);
+    }
+}
+
+test "build output wins over a stale checked-in dist" {
+    with TemporaryDirectory() as tmp {
+        base = Path(tmp);
+        _make_project(base);
+        got = _resolver(base).resolve('/styles.css');
+        assert got.is_served();
+        assert got.path.read_text(encoding='utf-8') == '.a{}';
+    }
+}
+
+test "cache policy follows provenance not code path" {
+    with TemporaryDirectory() as tmp {
+        base = Path(tmp);
+        _make_project(base);
+        prod = _resolver(base);
+        hashed = prod.resolve('/client.DEADBEEF.js');
+        assert hashed.cache_control == 'public, max-age=31536000, immutable';
+        plain = prod.resolve('/styles.css');
+        assert plain.cache_control == 'no-cache';
+        busted = prod.resolve('/styles.css', 'hash=abcd1234');
+        assert busted.cache_control == 'public, max-age=31536000, immutable';
+        dev = _resolver(base, dev=True);
+        assert dev.resolve('/styles.css').cache_control == 'no-store';
+        assert dev.resolve('/client.DEADBEEF.js').cache_control == 'public, max-age=31536000, immutable';
+    }
+}
+
+test "served assets carry validators and answer conditional requests" {
+    with TemporaryDirectory() as tmp {
+        base = Path(tmp);
+        _make_project(base);
+        resolver = _resolver(base);
+        got = resolver.resolve('/styles.css');
+        assert got.etag;
+        assert got.last_modified;
+        assert got.is_fresh(if_none_match=got.etag);
+        assert got.is_fresh(if_none_match=f'W/{got.etag}');
+        assert got.is_fresh(if_none_match='*');
+        assert not got.is_fresh(if_none_match='"nope"');
+        assert got.is_fresh(if_modified_since=got.last_modified);
+        assert not got.is_fresh(if_modified_since='Thu, 01 Jan 1970 00:00:00 GMT');
+        missing = resolver.resolve('/missing.png');
+        assert not missing.is_fresh(if_none_match='*');
+    }
+}
+
+test "content hash detection" {
+    hashed = ['client.DEADBEEF.js', 'index-DsUxa2sh.js', 'app.a1b2c3d4.css'];
+    plain = [
+        'styles.css',
+        'logo.png',
+        'hero-illustration.svg',
+        'my-component.js',
+        'background-image01.png',
+        'background-image001.png',
+        'Inter-Regular.woff2',
+        'index.html'
+    ];
+    for name in hashed {
+        assert is_content_hashed(name) , f"{name} should read as content-hashed";
+    }
+    for name in plain {
+        assert not is_content_hashed(name) , f"{name} should not read as hashed";
+    }
+}
+
+test "custom extensions extend rather than replace" {
+    with TemporaryDirectory() as tmp {
+        base = Path(tmp);
+        _make_project(base);
+        (base / 'assets' / 'manual.dat').write_text('x', encoding='utf-8');
+        narrow = AssetResolver(
+            policy=AssetPolicy(
+                roots=default_asset_roots(base),
+                extensions={'.dat'},
+                reserved_prefixes=[]
+            )
+        );
+        # The historical bug: configuring one extension used to drop every
+        # default, so fonts 404'd. Presence on disk is what serves a file now.
+        assert narrow.resolve('/fonts/Inter.woff2').is_served();
+        assert narrow.resolve('/manual.dat').is_served();
+        assert narrow.resolve('/missing.dat').outcome == AssetOutcome.NOT_FOUND.value;
+    }
+}
+
+test "declared roots are confined to the project" {
+    with TemporaryDirectory() as tmp {
+        base = Path(tmp);
+        _make_project(base);
+        escaped = AssetResolver(
+            policy=AssetPolicy(
+                roots=[
+                    AssetRoot(
+                        path=base / 'assets',
+                        mode=AssetRootMode.SOURCE_ASSET.value,
+                        flatten=False
+                    )
+                ],
+                extensions=set(ASSET_MEDIA_TYPES.keys()),
+                reserved_prefixes=[]
+            )
+        );
+        assert escaped.resolve('/fonts/Inter.woff2').is_served();
+        assert escaped.resolve('/flat-only.svg').is_served();
+        # flatten is off, so the basename fallback must not fire
+        assert escaped.resolve('/sub/dir/flat-only.svg').outcome == AssetOutcome.NOT_FOUND.value;
+    }
+}
+
+test "source only extensions are never served" {
+    for ext in SOURCE_ONLY_EXTENSIONS {
+        assert ext not in ASSET_MEDIA_TYPES , f"{ext} is both servable and denied";
+    }
+}
+
+"""The client-only preview server must report the same media types.
+
+`jac serve` on a `web-static` build runs a third, much smaller handler over the
+dist directory. It has no roots or cache policy to share, but a build previewed
+there must not report different content types than the servers that will ship
+it, and it must not fall through to the host's mime database.
+"""
+test "static preview server uses the shared media table" {
+    import from jaclang.runtimelib.client.targets.static_target { _DistRequestHandler }
+    probe = _DistRequestHandler.__new__(_DistRequestHandler);
+    for (ext, expected) in {
+        '.wasm': 'application/wasm',
+        '.woff2': 'font/woff2',
+        '.avif': 'image/avif',
+        '.js': 'text/javascript; charset=utf-8',
+        '.svg': 'image/svg+xml'
+    }.items() {
+        assert probe.guess_type(f"/dist/main{ext}") == expected , (
+            f"{ext} diverged from the shared table"
+        );
+    }
+}
+
+"""A BaseHTTPRequestHandler stand-in that records what the adapter wrote."""
+obj _RecordingHandler {
+    has headers: dict[str, str] = {},
+        status: int = 0,
+        sent: dict[str, str] = {},
+        body: bytes = b'',
+        wfile: io.BytesIO = io.BytesIO();
+
+    def send_response(code: int) {
+        self.status = code;
+    }
+
+    def send_header(key: str, value: str) {
+        self.sent[key] = value;
+    }
+
+    def end_headers { }
+}
+
+"""Drive the dev adapter and report (status, headers, body)."""
+def _via_dev_adapter(
+    resolution: any, request_headers: (dict[(str, str)] | None) = None
+) -> _RecordingHandler {
+    import from jaclang.runtimelib.client.serving { JacClient }
+    handler = _RecordingHandler(headers=request_headers or {});
+    handler.wfile = io.BytesIO();
+    JacClient.send_asset(handler, resolution);
+    handler.body = handler.wfile.getvalue();
+    return handler;
+}
+
+test "dev adapter mirrors the resolution it is given" {
+    with TemporaryDirectory() as tmp {
+        base = Path(tmp);
+        _make_project(base);
+        resolver = _resolver(base);
+        served = _via_dev_adapter(resolver.resolve('/fonts/Inter.woff2'));
+        assert served.status == 200;
+        assert served.sent['Content-Type'] == 'font/woff2';
+        assert served.sent['Cache-Control'] == 'no-cache';
+        assert served.sent['Accept-Ranges'] == 'bytes';
+        assert served.body == b'woff2-bytes';
+        local = _via_dev_adapter(
+            _resolver(base, dev=True).resolve('/fonts/Inter.woff2')
+        );
+        assert local.sent['Cache-Control'] == 'no-store';
+        missing = _via_dev_adapter(resolver.resolve('/missing.png'));
+        assert missing.status == 404;
+        # A missed asset must never come back as an HTML page.
+        assert missing.sent['Content-Type'] == 'text/plain; charset=utf-8';
+        denied = _via_dev_adapter(resolver.resolve('/../secrets.json'));
+        assert denied.status == 403;
+    }
+}
+
+test "dev adapter answers conditional and range requests" {
+    with TemporaryDirectory() as tmp {
+        base = Path(tmp);
+        _make_project(base);
+        resolver = _resolver(base);
+        first = _via_dev_adapter(resolver.resolve('/fonts/Inter.woff2'));
+        etag = first.sent['ETag'];
+        cached = _via_dev_adapter(
+            resolver.resolve('/fonts/Inter.woff2'), {'If-None-Match': etag}
+        );
+        assert cached.status == 304;
+        assert cached.body == b'';
+        ranged = _via_dev_adapter(
+            resolver.resolve('/fonts/Inter.woff2'), {'Range': 'bytes=0-3'}
+        );
+        assert ranged.status == 206;
+        assert ranged.body == b'woff';
+        assert ranged.sent['Content-Range'] == 'bytes 0-3/11';
+        suffix = _via_dev_adapter(
+            resolver.resolve('/fonts/Inter.woff2'), {'Range': 'bytes=-5'}
+        );
+        assert suffix.status == 206;
+        assert suffix.body == b'bytes';
+        bad = _via_dev_adapter(
+            resolver.resolve('/fonts/Inter.woff2'), {'Range': 'bytes=99-200'}
+        );
+        assert bad.status == 200 , "an unsatisfiable range falls back to the whole body";
+    }
+}
+
+test "byte range parsing" {
+    assert parse_byte_range('bytes=0-3', 10) == (0, 3);
+    assert parse_byte_range('bytes=5-', 10) == (5, 9);
+    assert parse_byte_range('bytes=-4', 10) == (6, 9);
+    assert parse_byte_range('bytes=0-99', 10) == (0, 9);
+    assert parse_byte_range(None, 10) is None;
+    assert parse_byte_range('bytes=10-12', 10) is None;
+    assert parse_byte_range('bytes=0-3,6-8', 10) is None , "multi-range is declined";
+    assert parse_byte_range('items=0-3', 10) is None;
+    assert parse_byte_range('bytes=abc', 10) is None;
+    assert parse_byte_range('bytes=0-3', 0) is None;
+}
+
+"""Both servers must answer the same table identically.
+
+The dev adapter is exercised in-process above; the scale adapter is exercised
+here through the same resolution values. If these ever disagree, an adapter has
+grown a policy decision that belongs in the resolver.
+"""
+test "both adapters agree on status and headers" {
+    pytest.importorskip('fastapi');
+    import from fastapi { Request }
+    import from jaclang.scale.server.serve { JacAPIServerStatic }
+    with TemporaryDirectory() as tmp {
+        base = Path(tmp);
+        _make_project(base);
+        resolver = _resolver(base);
+        scale = JacAPIServerStatic();
+        def _scale_request(headers: dict[(str, str)]) -> Request {
+            raw = [
+                (key.lower().encode(), value.encode())
+                for (key, value) in headers.items()
+            ];
+            return Request({'type': 'http', 'method': 'GET', 'headers': raw});
+        }
+        probes = [
+            ('/fonts/Inter.woff2', {}, 200),
+            ('/missing.png', {}, 404),
+            ('/../secrets.json', {}, 403),
+            ('/theme.scss', {}, 403)
+        ];
+        for (url, req_headers, expected_status) in probes {
+            resolution = resolver.resolve(url);
+            dev = _via_dev_adapter(resolution, req_headers);
+            prod = scale.asset_response(resolution, _scale_request(req_headers));
+            assert dev.status == expected_status , f"{url} dev status";
+            assert prod.status_code == expected_status , f"{url} scale status";
+            assert dev.sent['Cache-Control'] == prod.headers['cache-control'] , f"{url} cache directive diverged";
+            if expected_status == 200 {
+                assert dev.sent['Content-Type'] == prod.headers['content-type'] , f"{url} content type diverged";
+                assert dev.body == prod.body , f"{url} body diverged";
+                assert dev.sent['ETag'] == prod.headers['etag'] , f"{url} etag diverged";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Static asset serving lived in four places with four different extension lists, and the two servers disagreed on nearly every axis.

## Why

The dev server used its extension set as a **routing discriminator**, not just a servability check. `[client.assets] custom_extensions` replaced the defaults rather than extending them, via `set(...) or {defaults}` (`X or Y` returns `Y` only when `X` is empty, so the "default when unset" reading was accidental). Miss the gate and the request fell past the asset branch into the SPA fallback, which rendered the root app as HTML with status 404. Fonts came back as a 404 whose body was a full web page.

Scale could not hit that, because its routing came from a registered catch-all. It had its own hardwired set plus `.pdf/.txt/.xml` and a blanket `Cache-Control: max-age=31536000`. Beyond the extension lists, the two also diverged on:

| | dev | scale |
|---|---|---|
| root search order | `.jac/client/dist` first | `.jac/client/dist` **last** |
| extra roots | none | `public/`, `src/`, bare project root |
| cache header | `max-age=3600` binary, `no-cache` CSS | `max-age=31536000` root, none under `/static/` |
| 404 body | JSON | `text/plain` |

So a stale `dist/` shadowed fresh build output in production but not in dev, `src/` and any root-level `.json` were downloadable in production only, and neither canonicalized or confined the joined path (no `resolve()`, `is_relative_to`, or `commonpath` anywhere). A fourth list, `AssetProcessor.ASSET_EXTENSIONS`, omitted `.js`/`.json` while both servers served them, so those assets never reached `dist/`.

The root cause is that the two servers share no response type (one writes to `handler.wfile`, the other returns a `fastapi.Response`), so the shared logic had nowhere to live and got copy-pasted. The tell is the CSS special case: a 6-branch `if/elif` ladder duplicated four times, walking exactly the candidates the generic loop 10 lines below already walks.

## What this does

Adds `AssetResolver` in `runtimelib/client/assets.jac` as the single source of truth. `resolve(url, query)` returns an `AssetResolution` value tagged `SERVED` / `NOT_AN_ASSET` / `NOT_FOUND` / `FORBIDDEN`. Each server only translates that value into its own response type.

- **Routing stops sniffing extensions.** A suffixed path that exists under a declared root is served whatever its extension; a miss is a hard `text/plain` 404, never an SPA render. The font failure mode is structurally impossible now, not just fixed.
- **One media table**, consulted instead of the OS mime database, so a URL yields the same `Content-Type` on every platform. `ASSET_COPY_EXTENSIONS` derives from it, closing the `.js`/`.json` gap.
- **Paths are percent-decoded, then confined** with `resolve()` + `is_relative_to`. Dotfiles and bundler sources (`.scss`, `.ts`, `.jac`, ...) are rejected. `src/` and the bare project root are no longer served.
- **Cache follows provenance:** `immutable` for content-hashed names and `?hash=` URLs, `no-cache` plus a strong ETag otherwise, `no-store` for unhashed files on the local server. Adds `Last-Modified`, 304s, `Accept-Ranges` and single-range 206 responses (Safari needs the latter for `<video>`/`<audio>`).
- **`[client.assets]` is schema'd:** ordered `roots`, `extensions.add`/`.remove`, `immutable_max_age`. There is no spelling of the new key that reproduces the old failure.

## Compatibility

`custom_extensions` still reads, is now **additive**, and warns with the new key name. That alone fixes affected projects with no config edit. The basename fallback (`dist/<file>` for `/a/b/<file>`) is preserved on the historical roots as a per-root `flatten` flag, defaulted on there and off for new roots, so existing apps keep resolving.

Two intentional behavior changes: a missed asset now returns `text/plain` instead of JSON on the dev server (a browser fetching an image should not get JSON), and unhashed assets are revalidated rather than pinned for a year in production.

## Removed

`serve_root_asset`, `serve_static_file`, `send_static_file`, both hardcoded extension sets, all four copies of the CSS ladder, and the 127-line dev asset branch (now 9 lines). The `web-static` preview server keeps its own handler but reads the shared media table instead of hand-rolling a `.wasm` case.

## Testing

`jac/tests/runtimelib/client/test_asset_resolver.jac` is table-driven: one set of URLs replayed through the resolver and both adapters, asserting they agree on status, content type, cache directive, ETag and body. This is the part that keeps them from re-diverging. 13 tests, all passing.

Type errors dropped against baseline (`runtimelib/server.jac` 121 to 86; scale unchanged at 453). Targeted suites match baseline exactly: `test_serve` 7F/5P, `test_serve_client` 30F/56P/8S, `scale/tests/server` 3F/253P, `test_client_config` 8/8 across four runs. Pre-existing failures are unrelated (node toolchain, native linking).

One thing to watch: a full-directory `tests/runtimelib/client/` run showed two `test_client_config` failures that do not reproduce in isolation (8/8 four times) or in a three-file run. Likely vite-build contention under `-n 18`, but unconfirmed.
