### PR TITLE
test: restore JAC_CLIENT_SKIP_NPM_INSTALL after scaffolding in test_create_kinds

### DIFF
--- a/jac/tests/runtimelib/client/test_create_kinds.jac
+++ b/jac/tests/runtimelib/client/test_create_kinds.jac
@@ -18,13 +18,22 @@ glob _tmp_dirs: list[str] = [],
      _orig_cwd: str = os.getcwd();
 
 def _scaffold(kind: str) -> Path {
+    prev_skip = os.environ.get("JAC_CLIENT_SKIP_NPM_INSTALL");
     os.environ["JAC_CLIENT_SKIP_NPM_INSTALL"] = "1";
     initialize_template_registry();
     d = tempfile.mkdtemp(prefix="jacclientkind_");
     _tmp_dirs.append(d);
     os.chdir(d);
-    rc = project.create(name="app", kind=kind, force=True);
-    os.chdir(_orig_cwd);
+    try {
+        rc = project.create(name="app", kind=kind, force=True);
+    } finally {
+        os.chdir(_orig_cwd);
+        if prev_skip is None {
+            os.environ.pop("JAC_CLIENT_SKIP_NPM_INSTALL", None);
+        } else {
+            os.environ["JAC_CLIENT_SKIP_NPM_INSTALL"] = prev_skip;
+        }
+    }
     assert rc == 0 , f"create --kind {kind} returned {rc}";
     return Path(d) / "app";
 }

--- a/release_notes/unreleased/jaclang/7771.refactor.md
+++ b/release_notes/unreleased/jaclang/7771.refactor.md
@@ -1,0 +1,1 @@
+- **Test hygiene: `test_create_kinds` no longer leaks `JAC_CLIENT_SKIP_NPM_INSTALL`**: the scaffold helper now restores the variable after `project.create`, so sibling tests in the same pytest worker (and their spawned `jac` subprocesses) no longer inherit a skip-install environment they never asked for.


### PR DESCRIPTION
## Summary

`_scaffold` in `test_create_kinds.jac` sets `os.environ["JAC_CLIENT_SKIP_NPM_INSTALL"] = "1"` and never restores it. Under pytest-xdist, one worker process runs many test files in sequence, so once this file runs, every later test in that worker (and every subprocess it spawns with an environment derived from `os.environ`, e.g. the littlex e2e builds) inherits the variable.

Today the leak is invisible because only `jac install`'s npm closure honors the variable, but it makes test outcomes depend on worker scheduling and silently constrains any future code that reads it: an early revision of #7769 made the bundler honor the variable and three CI jobs failed from this leak rather than from the change under test.

## Change

Save the prior value and restore it in a `try/finally` (also covering the `os.chdir` restore), the same save-and-restore pattern `jac create --skip` itself uses in `project.impl.jac`.

## Tests

`jac test jac/tests/runtimelib/client/test_create_kinds.jac`: 3 passed; scaffolds still skip npm install during `project.create` and the variable no longer outlives the helper.