### PR TITLE
Store topology index on system root

### DIFF
--- a/jac/jaclang/runtimelib/impl/memory.impl.jac
+++ b/jac/jaclang/runtimelib/impl/memory.impl.jac
@@ -24,6 +24,22 @@ import from jaclang.runtimelib.typecache { get_field_types }
 glob logger = logging.getLogger(__name__),
      SQLITE_DB_FORMAT_VERSION: int = 1;
 
+def _is_system_root_topology_anchor(anchor: Anchor) -> bool {
+    if not (
+        isinstance(anchor, NodeAnchor)
+        and isinstance(anchor.archetype, Root)
+        and anchor.topology_index_data is not None
+    ) {
+        return False;
+    }
+    try {
+        import from jaclang.jac0core.constant { Constants as Con }
+        return anchor.id == UUID(Con.SUPER_ROOT_UUID);
+    } except Exception {
+        return False;
+    }
+}
+
 impl Memory.aget(id: UUID) -> (Anchor | None) {
     return await asyncio.to_thread(self.get, id);
 }
@@ -1810,6 +1826,10 @@ impl TieredMemory._collect_into(changes: ChangeSet) -> None {
             ) {
                 continue;
             }
+            if _is_system_root_topology_anchor(anchor) {
+                changes.record_create(anchor);
+                continue;
+            }
             if Jac.check_write_access(anchor, op_hint="field_write") {
                 changes.record_create(anchor);
             }
@@ -1846,6 +1866,10 @@ impl TieredMemory._collect_into(changes: ChangeSet) -> None {
             changes.record_update(
                 anchor, set(get_field_types(type(anchor.archetype)).keys())
             );
+        }
+        if _is_system_root_topology_anchor(anchor) {
+            changes.record_update(anchor, {"topology_index_data"});
+            recorded = True;
         }
         if not recorded {
             if Jac.check_write_access(anchor, op_hint="field_write") {

--- a/jac/jaclang/runtimelib/impl/resolver.impl.jac
+++ b/jac/jaclang/runtimelib/impl/resolver.impl.jac
@@ -118,6 +118,25 @@ def _get_usable_index(root_anchor: (NodeAnchor | None)) -> (TopologyIndex | None
 }
 
 
+def _get_system_root_anchor(mem: Memory) -> (NodeAnchor | None) {
+    try {
+        import from jaclang.jac0core.constant { Constants as Con }
+        `root = mem.get(UUID(Con.SUPER_ROOT_UUID));
+        if isinstance(`root, NodeAnchor) {
+            return `root;
+        }
+    } except Exception {
+        ;
+    }
+    try {
+        import from jaclang { JacRuntimeInterface as Jac }
+        return Jac.get_context().system_root;
+    } except Exception {
+        return None;
+    }
+}
+
+
 def _resolve_prefix(
     mem: Memory,
     ids: set[UUID],
@@ -147,11 +166,7 @@ impl resolve_hop(
     );
     in_count = len(current_ids);
     if not has_pred and idx is not None {
-        import from jaclang.runtimelib.topology_index { SELF_ROOT }
-        if all(
-            (lid := idx.node_to_lid.get(uid)) is not None
-                and idx.node_table[lid][2] == SELF_ROOT for uid in current_ids
-        ) {
+        if all(idx.node_to_lid.get(uid) is not None for uid in current_ids) {
             if slc is not None {
                 ordered = idx.resolve_chain_ordered(
                     current_ids, hop.edge_type, hop.node_type, hop.direction, slc
@@ -220,7 +235,7 @@ impl resolve_path_anchors(
 
     root_anchor = _path_root_anchor(mem, path);
 
-    idx = _get_usable_index(root_anchor);
+    idx = _get_usable_index(_get_system_root_anchor(mem));
     current: set[UUID] = {cast(UUID, nd.__jac__.id) for nd in path.origin};
     if len(chain) > 1 {
         current = _resolve_prefix(mem, current, chain[:-1], idx);

--- a/jac/jaclang/runtimelib/impl/resolver.impl.jac
+++ b/jac/jaclang/runtimelib/impl/resolver.impl.jac
@@ -183,10 +183,8 @@ impl resolve_hop(
             }
             triple = (hop.edge_type, hop.node_type, hop.direction);
             narrowed = idx.resolve_chain(current_ids, [triple]);
-            if narrowed is not None {
-                _trace_hop('index:set', hop_idx, in_count, len(narrowed), hop);
-                return narrowed;
-            }
+            _trace_hop('index:set', hop_idx, in_count, len(narrowed), hop);
+            return narrowed;
         }
     }
 

--- a/jac/jaclang/runtimelib/impl/topo_utils.impl.jac
+++ b/jac/jaclang/runtimelib/impl/topo_utils.impl.jac
@@ -34,6 +34,33 @@ impl _get_root_anchor(anchor: any) -> any {
     return None;
 }
 
+impl _get_index_anchor -> any {
+    try {
+        import from jaclang { JacRuntimeInterface as Jac }
+        return Jac.get_context().system_root;
+    } except Exception {
+        return None;
+    }
+}
+
+impl _owner_root_for(index_anchor: any, node_anchor: any) -> any {
+    if node_anchor.id == index_anchor.id {
+        return None;
+    }
+    if node_anchor.root {
+        return node_anchor.root;
+    }
+    try {
+        import from jaclang.jac0core.archetype { Root }
+        if isinstance(node_anchor.archetype, Root) {
+            return node_anchor.id;
+        }
+    } except Exception {
+        ;
+    }
+    return None;
+}
+
 impl _type_name(`obj: object) -> str {
     return `type(`obj).__name__;
 }
@@ -71,17 +98,13 @@ impl _index_edge_into(root_anchor: any, source: any, target: any, `edge: any) ->
         source.id,
         _type_name(source.archetype),
         _get_type_mro(source.archetype),
-        None if source.root == root_anchor.id else source.root
+        _owner_root_for(root_anchor, source)
     );
-    target_owner = None;
-    if target.root and target.root != root_anchor.id {
-        target_owner = target.root;
-    }
     idx.add_node(
         target.id,
         _type_name(target.archetype),
         _get_type_mro(target.archetype),
-        target_owner
+        _owner_root_for(root_anchor, target)
     );
     idx.add_edge(source.id, target.id, _type_name(`edge.archetype));
     if `edge.is_undirected {
@@ -112,17 +135,11 @@ impl on_edge_created(source: any, target: any, `edge: any) -> None {
     if not source.persistent {
         return;
     }
-    source_root = _get_root_anchor(source);
-    if source_root is None {
+    index_anchor = _get_index_anchor();
+    if index_anchor is None {
         return;
     }
-    _index_edge_into(source_root, source, target, `edge);
-    if target.root and target.root != source_root.id {
-        target_root = _get_root_anchor(target);
-        if target_root is not None {
-            _index_edge_into(target_root, source, target, `edge);
-        }
-    }
+    _index_edge_into(index_anchor, source, target, `edge);
 }
 
 impl on_edge_destroyed(source: any, target: any, `edge: any) -> None {
@@ -132,68 +149,63 @@ impl on_edge_destroyed(source: any, target: any, `edge: any) -> None {
     if not source.persistent {
         return;
     }
-    source_root = _get_root_anchor(source);
-    if source_root is None {
+    index_anchor = _get_index_anchor();
+    if index_anchor is None {
         return;
     }
-    _unindex_edge_from(source_root, source, target, `edge);
-    if target.root and target.root != source_root.id {
-        target_root = _get_root_anchor(target);
-        if target_root is not None {
-            _unindex_edge_from(target_root, source, target, `edge);
-        }
-    }
+    _unindex_edge_from(index_anchor, source, target, `edge);
 }
 
 impl on_node_saved(node_anchor: any) -> None {
     if not _is_enabled() {
         return;
     }
-    if not node_anchor.persistent or node_anchor.root is None {
+    if not node_anchor.persistent {
         return;
     }
-    root_anchor = _get_root_anchor(node_anchor);
-    if root_anchor is None {
+    index_anchor = _get_index_anchor();
+    if index_anchor is None {
         return;
     }
 
-    if root_anchor.id == node_anchor.id {
+    if index_anchor.id == node_anchor.id {
         return;
     }
     import from jaclang.runtimelib.topology_index { TopologyIndex }
-    idx = root_anchor.get_topology_index();
+    idx = index_anchor.get_topology_index();
     if not isinstance(idx, TopologyIndex) {
         idx = TopologyIndex();
     }
     idx.add_node(
-        root_anchor.id,
-        _type_name(root_anchor.archetype),
-        _get_type_mro(root_anchor.archetype)
+        index_anchor.id,
+        _type_name(index_anchor.archetype),
+        _get_type_mro(index_anchor.archetype)
     );
     idx.add_node(
         node_anchor.id,
         _type_name(node_anchor.archetype),
-        _get_type_mro(node_anchor.archetype)
+        _get_type_mro(node_anchor.archetype),
+        _owner_root_for(index_anchor, node_anchor)
     );
-    root_anchor.set_topology_index(idx);
+    index_anchor.set_topology_index(idx);
 }
 
 impl on_node_destroyed(node_anchor: any) -> None {
     if not _is_enabled() {
         return;
     }
-    if not node_anchor.persistent or node_anchor.root is None {
+    if not node_anchor.persistent {
         return;
     }
-    root_anchor = _get_root_anchor(node_anchor);
-    if root_anchor is None {
+    index_anchor = _get_index_anchor();
+    if index_anchor is None or index_anchor.id == node_anchor.id {
         return;
     }
     import from jaclang.runtimelib.topology_index { TopologyIndex }
-    idx = root_anchor.get_topology_index();
+    idx = index_anchor.get_topology_index();
     if not isinstance(idx, TopologyIndex) {
         return;
     }
     idx.remove_node(node_anchor.id);
-    root_anchor.set_topology_index(idx);
+    index_anchor.set_topology_index(idx);
 }

--- a/jac/jaclang/runtimelib/impl/topo_utils.impl.jac
+++ b/jac/jaclang/runtimelib/impl/topo_utils.impl.jac
@@ -59,24 +59,6 @@ impl _get_index_anchor -> any {
     return None;
 }
 
-impl _owner_root_for(index_anchor: any, node_anchor: any) -> any {
-    if node_anchor.id == index_anchor.id {
-        return None;
-    }
-    if node_anchor.root {
-        return node_anchor.root;
-    }
-    try {
-        import from jaclang.jac0core.archetype { Root }
-        if isinstance(node_anchor.archetype, Root) {
-            return node_anchor.id;
-        }
-    } except Exception {
-        ;
-    }
-    return None;
-}
-
 impl _type_name(`obj: object) -> str {
     return `type(`obj).__name__;
 }
@@ -111,16 +93,10 @@ impl _index_edge_into(root_anchor: any, source: any, target: any, `edge: any) ->
         _get_type_mro(root_anchor.archetype)
     );
     idx.add_node(
-        source.id,
-        _type_name(source.archetype),
-        _get_type_mro(source.archetype),
-        _owner_root_for(root_anchor, source)
+        source.id, _type_name(source.archetype), _get_type_mro(source.archetype)
     );
     idx.add_node(
-        target.id,
-        _type_name(target.archetype),
-        _get_type_mro(target.archetype),
-        _owner_root_for(root_anchor, target)
+        target.id, _type_name(target.archetype), _get_type_mro(target.archetype)
     );
     idx.add_edge(source.id, target.id, _type_name(`edge.archetype));
     if `edge.is_undirected {
@@ -200,8 +176,7 @@ impl on_node_saved(node_anchor: any) -> None {
     idx.add_node(
         node_anchor.id,
         _type_name(node_anchor.archetype),
-        _get_type_mro(node_anchor.archetype),
-        _owner_root_for(index_anchor, node_anchor)
+        _get_type_mro(node_anchor.archetype)
     );
     index_anchor.set_topology_index(idx);
 }

--- a/jac/jaclang/runtimelib/impl/topo_utils.impl.jac
+++ b/jac/jaclang/runtimelib/impl/topo_utils.impl.jac
@@ -37,10 +37,26 @@ impl _get_root_anchor(anchor: any) -> any {
 impl _get_index_anchor -> any {
     try {
         import from jaclang { JacRuntimeInterface as Jac }
-        return Jac.get_context().system_root;
+        import from uuid { UUID }
+        import from jaclang.jac0core.archetype { NodeAnchor }
+        import from jaclang.jac0core.constant { Constants as Con }
+        ctx = Jac.get_context();
+        system_root_id = UUID(Con.SUPER_ROOT_UUID);
+        active_root = ctx.mem.get(system_root_id);
+        if isinstance(active_root, NodeAnchor) {
+            ctx.system_root = active_root;
+            return active_root;
+        }
+        if isinstance(ctx.system_root, NodeAnchor) {
+            ctx.system_root.id = system_root_id;
+            ctx.system_root.persistent = True;
+            ctx.mem.put(ctx.system_root);
+            return ctx.system_root;
+        }
     } except Exception {
         return None;
     }
+    return None;
 }
 
 impl _owner_root_for(index_anchor: any, node_anchor: any) -> any {

--- a/jac/jaclang/runtimelib/impl/topology_index.impl.jac
+++ b/jac/jaclang/runtimelib/impl/topology_index.impl.jac
@@ -52,10 +52,17 @@ impl TopologyIndex.add_node(
     owner_root: (UUID | None) = None
 ) -> int {
     if node_id in self.node_to_lid {
+        lid = self.node_to_lid[node_id];
         if mro_chain {
             self._ensure_type(type_name, mro_chain);
         }
-        return self.node_to_lid[node_id];
+        if owner_root is not None {
+            (uid, tid, old_owner) = self.node_table[lid];
+            if old_owner != owner_root {
+                self.node_table[lid] = (uid, tid, owner_root);
+            }
+        }
+        return lid;
     }
     tid = self._ensure_type(type_name, mro_chain);
     lid = len(self.node_table);

--- a/jac/jaclang/runtimelib/impl/topology_index.impl.jac
+++ b/jac/jaclang/runtimelib/impl/topology_index.impl.jac
@@ -46,27 +46,18 @@ impl TopologyIndex._ensure_type(
 }
 
 impl TopologyIndex.add_node(
-    node_id: UUID,
-    type_name: str,
-    mro_chain: (list[str] | None) = None,
-    owner_root: (UUID | None) = None
+    node_id: UUID, type_name: str, mro_chain: (list[str] | None) = None
 ) -> int {
     if node_id in self.node_to_lid {
         lid = self.node_to_lid[node_id];
         if mro_chain {
             self._ensure_type(type_name, mro_chain);
         }
-        if owner_root is not None {
-            (uid, tid, old_owner) = self.node_table[lid];
-            if old_owner != owner_root {
-                self.node_table[lid] = (uid, tid, owner_root);
-            }
-        }
         return lid;
     }
     tid = self._ensure_type(type_name, mro_chain);
     lid = len(self.node_table);
-    self.node_table.append((node_id, tid, owner_root or SELF_ROOT));
+    self.node_table.append((node_id, tid));
     self.node_to_lid[node_id] = lid;
     return lid;
 }
@@ -101,8 +92,8 @@ impl TopologyIndex.add_edge(
     etid = self._ensure_type(edge_type_name);
     self.adj_list.append((src_lid, etid, tgt_lid));
 
-    (_, src_type_id, _) = self.node_table[src_lid];
-    (_, tgt_type_id, _) = self.node_table[tgt_lid];
+    (_, src_type_id) = self.node_table[src_lid];
+    (_, tgt_type_id) = self.node_table[tgt_lid];
     src_ancestors = self.type_mro_ids[src_type_id] or [src_type_id];
     tgt_ancestors = self.type_mro_ids[tgt_type_id] or [tgt_type_id];
 
@@ -226,10 +217,8 @@ impl TopologyIndex.remove_edge(
 }
 
 impl TopologyIndex.resolve_chain(
-    origin_ids: set[UUID],
-    chain: list[tuple[(str | None), (str | None), int]],
-    bail_on_intermediate_foreign: bool = False
-) -> (set[UUID] | None) {
+    origin_ids: set[UUID], chain: list[tuple[(str | None), (str | None), int]]
+) -> set[UUID] {
     current_lids: set[int] = set();
     for uid in origin_ids {
         lid = self.node_to_lid.get(uid);
@@ -240,8 +229,7 @@ impl TopologyIndex.resolve_chain(
     if not current_lids {
         return set();
     }
-    last_idx = len(chain) - 1;
-    for (hop_idx, (edge_type, node_type, direction)) in enumerate(chain) {
+    for (edge_type, node_type, direction) in chain {
         etid = self.type_to_id.get(edge_type) if edge_type else None;
         ntid = self.type_to_id.get(node_type) if node_type else None;
         if edge_type and etid is None {
@@ -306,13 +294,6 @@ impl TopologyIndex.resolve_chain(
         current_lids = next_lids;
         if not current_lids {
             return set();
-        }
-        if bail_on_intermediate_foreign and hop_idx < last_idx {
-            for lid in current_lids {
-                if self.node_table[lid][2] != SELF_ROOT {
-                    return None;
-                }
-            }
         }
     }
     return {self.node_table[lid][0] for lid in current_lids};
@@ -426,21 +407,6 @@ impl TopologyIndex.resolve_chain_ordered(
     return ordered[slc];
 }
 
-impl TopologyIndex.get_cross_root_ids(node_ids: set[UUID]) -> dict[UUID, set[UUID]] {
-    result: dict[UUID, set[UUID]] = {};
-    for uid in node_ids {
-        lid = self.node_to_lid.get(uid);
-        if lid is None {
-            continue;
-        }
-        owner = self.node_table[lid][2];
-        if owner != SELF_ROOT {
-            result.setdefault(owner, set()).add(uid);
-        }
-    }
-    return result;
-}
-
 impl TopologyIndex.encode -> bytes {
     num_types = len(self.type_table);
     num_nodes = len(self.node_table);
@@ -459,10 +425,9 @@ impl TopologyIndex.encode -> bytes {
             parts.append(struct.pack("<H", anc_id));
         }
     }
-    for (node_id, type_id, owner_root) in self.node_table {
+    for (node_id, type_id) in self.node_table {
         parts.append(node_id.bytes);
         parts.append(struct.pack("<H", type_id));
-        parts.append(owner_root.bytes);
     }
     for (src, etid, tgt) in self.adj_list {
         parts.append(struct.pack("<HHH", src, etid, tgt));
@@ -474,61 +439,40 @@ impl TopologyIndex.encode -> bytes {
     return bytes(buf);
 }
 
-def _migrate_v1_to_v2(data: bytes) -> bytes {
-    if len(data) < 9 or data[0] != 1 {
-        return data;
-    }
-    (_, num_types, num_nodes, num_edges) = struct.unpack_from("<BHHi", data, 0);
-    out = bytearray();
-    out.extend(struct.pack("<BHHi", TOPO_VERSION, num_types, num_nodes, num_edges));
-    offset = struct.calcsize("<BHHi");
-    for tid in range(num_types) {
-        (name_len, ) = struct.unpack_from("<B", data, offset);
-        offset += 1;
-        out.append(name_len);
-        out.extend(data[offset:offset + name_len]);
-        offset += name_len;
-
-        out.append(1);
-        out.extend(struct.pack("<H", tid));
-    }
-    out.extend(data[offset:]);
-    return bytes(out);
-}
-
 impl TopologyIndex.decode(data: bytes) -> TopologyIndex {
     idx = TopologyIndex();
     if not data {
         return idx;
-    }
-    if data[0] == 1 {
-        data = _migrate_v1_to_v2(data);
     }
     offset = 0;
     (version, num_types, num_nodes, num_edges) = struct.unpack_from(
         "<BHHi", data, offset
     );
     offset += struct.calcsize("<BHHi");
-    if version != TOPO_VERSION {
+    if version not in (1, 2, TOPO_VERSION) {
         return idx;
     }
 
-    for _ in range(num_types) {
+    for tid in range(num_types) {
         (name_len, ) = struct.unpack_from("<B", data, offset);
         offset += 1;
         name = data[offset:offset + name_len].decode("utf-8");
         offset += name_len;
         idx.type_table.append(name);
         idx.type_to_id[name] = len(idx.type_table) - 1;
-        (mro_len, ) = struct.unpack_from("<B", data, offset);
-        offset += 1;
-        chain: list[int] = [];
-        for _ in range(mro_len) {
-            (anc, ) = struct.unpack_from("<H", data, offset);
-            offset += 2;
-            chain.append(anc);
+        if version == 1 {
+            idx.type_mro_ids.append([tid]);
+        } else {
+            (mro_len, ) = struct.unpack_from("<B", data, offset);
+            offset += 1;
+            chain: list[int] = [];
+            for _ in range(mro_len) {
+                (anc, ) = struct.unpack_from("<H", data, offset);
+                offset += 2;
+                chain.append(anc);
+            }
+            idx.type_mro_ids.append(chain);
         }
-        idx.type_mro_ids.append(chain);
     }
 
     for i in range(num_nodes) {
@@ -536,9 +480,10 @@ impl TopologyIndex.decode(data: bytes) -> TopologyIndex {
         offset += 16;
         (type_id, ) = struct.unpack_from("<H", data, offset);
         offset += 2;
-        owner_root = UUID(bytes=data[offset:offset + 16]);
-        offset += 16;
-        idx.node_table.append((node_id, type_id, owner_root));
+        if version in (1, 2) {
+            offset += 16;
+        }
+        idx.node_table.append((node_id, type_id));
         idx.node_to_lid[node_id] = i;
     }
 
@@ -549,8 +494,8 @@ impl TopologyIndex.decode(data: bytes) -> TopologyIndex {
         tgt: int = int(unpacked[2]);
         offset += 6;
         idx.adj_list.append((src, etid, tgt));
-        (_, src_t, _) = idx.node_table[src];
-        (_, tgt_t, _) = idx.node_table[tgt];
+        (_, src_t) = idx.node_table[src];
+        (_, tgt_t) = idx.node_table[tgt];
         src_ancestors = idx.type_mro_ids[src_t] or [src_t];
         tgt_ancestors = idx.type_mro_ids[tgt_t] or [tgt_t];
         for anc in tgt_ancestors {

--- a/jac/jaclang/runtimelib/topo_utils.jac
+++ b/jac/jaclang/runtimelib/topo_utils.jac
@@ -4,8 +4,6 @@ def _get_root_anchor(anchor: any) -> any;
 
 def _get_index_anchor -> any;
 
-def _owner_root_for(index_anchor: any, node_anchor: any) -> any;
-
 def _type_name(`obj: object) -> str;
 
 def _get_type_mro(`obj: object) -> list[str];

--- a/jac/jaclang/runtimelib/topo_utils.jac
+++ b/jac/jaclang/runtimelib/topo_utils.jac
@@ -2,6 +2,10 @@ def _is_enabled -> bool;
 
 def _get_root_anchor(anchor: any) -> any;
 
+def _get_index_anchor -> any;
+
+def _owner_root_for(index_anchor: any, node_anchor: any) -> any;
+
 def _type_name(`obj: object) -> str;
 
 def _get_type_mro(`obj: object) -> list[str];

--- a/jac/jaclang/runtimelib/topology_index.jac
+++ b/jac/jaclang/runtimelib/topology_index.jac
@@ -1,24 +1,20 @@
 import struct;
 import from uuid { UUID }
 
-glob SELF_ROOT: UUID = UUID(int=0),
-     TOPO_VERSION: int = 2;
+glob TOPO_VERSION: int = 3;
 
 obj TopologyIndex {
     has type_table: list[str] = [],
         type_to_id: dict[str, int] = {},
         type_mro_ids: list[list[int]] = [],
-        node_table: list[tuple[UUID, int, UUID]] = [],
+        node_table: list[tuple[UUID, int]] = [],
         node_to_lid: dict[UUID, int] = {},
         adj_list: list[tuple[int, int, int]] = [],
         buckets: dict[int, dict[str, tuple[set[int], set[int]]]] = {};
 
     def _ensure_type(type_name: str, mro_chain: (list[str] | None) = None) -> int;
     def add_node(
-        node_id: UUID,
-        type_name: str,
-        mro_chain: (list[str] | None) = None,
-        owner_root: (UUID | None) = None
+        node_id: UUID, type_name: str, mro_chain: (list[str] | None) = None
     ) -> int;
 
     def remove_node(node_id: UUID) -> None;
@@ -28,10 +24,8 @@ obj TopologyIndex {
     ) -> None;
 
     def resolve_chain(
-        origin_ids: set[UUID],
-        chain: list[tuple[(str | None), (str | None), int]],
-        bail_on_intermediate_foreign: bool = False
-    ) -> (set[UUID] | None);
+        origin_ids: set[UUID], chain: list[tuple[(str | None), (str | None), int]]
+    ) -> set[UUID];
 
     def resolve_chain_ordered(
         origin_ids: set[UUID],
@@ -41,7 +35,6 @@ obj TopologyIndex {
         slc: slice
     ) -> list[UUID];
 
-    def get_cross_root_ids(node_ids: set[UUID]) -> dict[UUID, set[UUID]];
     def encode -> bytes;
     static def decode(data: bytes) -> TopologyIndex;
     def __len__ -> int;

--- a/jac/jaclang/scale/memory/impl/context.impl.jac
+++ b/jac/jaclang/scale/memory/impl/context.impl.jac
@@ -16,9 +16,25 @@ impl JScaleExecutionContext.init(self: JScaleExecutionContext) -> None {
     self.pending_effects = [];
     self.read_versions = {};
     self.custom: any = MISSING;
-    cached_root = _process_cache.get('system_root');
-    if cached_root is not None {
-        self.mem.__mem__[cached_root.id] = cached_root;
+    topology_index_enabled = False;
+    try {
+        import os;
+        env = os.environ.get("JAC_TOPOLOGY_INDEX");
+        if env is not None {
+            topology_index_enabled = env.lower() in ("1", "true", "yes", "on");
+        } else {
+            import from jaclang.project.config { get_config }
+            cfg = get_config();
+            topology_index_enabled = cfg is not None and cfg.run.topology_index;
+        }
+    } except Exception { }
+    if topology_index_enabled {
+        _process_cache.pop('system_root', None);
+    } else {
+        cached_root = _process_cache.get('system_root');
+        if cached_root is not None {
+            self.mem.__mem__[cached_root.id] = cached_root;
+        }
     }
     system_root_anchor: (Anchor | None) = self.mem.get(UUID(Con.SUPER_ROOT_UUID));
     if not isinstance(system_root_anchor, NodeAnchor) {
@@ -26,7 +42,9 @@ impl JScaleExecutionContext.init(self: JScaleExecutionContext) -> None {
         system_root_anchor.id = UUID(Con.SUPER_ROOT_UUID);
         self.mem.put(system_root_anchor);
     }
-    _process_cache['system_root'] = system_root_anchor;
+    if not topology_index_enabled {
+        _process_cache['system_root'] = system_root_anchor;
+    }
     self.system_root = system_root_anchor;
 
     self.user_root = self.system_root;

--- a/jac/jaclang/scale/memory/impl/context.impl.jac
+++ b/jac/jaclang/scale/memory/impl/context.impl.jac
@@ -16,25 +16,11 @@ impl JScaleExecutionContext.init(self: JScaleExecutionContext) -> None {
     self.pending_effects = [];
     self.read_versions = {};
     self.custom: any = MISSING;
-    topology_index_enabled = False;
-    try {
-        import os;
-        env = os.environ.get("JAC_TOPOLOGY_INDEX");
-        if env is not None {
-            topology_index_enabled = env.lower() in ("1", "true", "yes", "on");
-        } else {
-            import from jaclang.project.config { get_config }
-            cfg = get_config();
-            topology_index_enabled = cfg is not None and cfg.run.topology_index;
-        }
-    } except Exception { }
-    if topology_index_enabled {
-        _process_cache.pop('system_root', None);
-    } else {
-        cached_root = _process_cache.get('system_root');
-        if cached_root is not None {
-            self.mem.__mem__[cached_root.id] = cached_root;
-        }
+    cached_root = _process_cache.get('system_root');
+    if (
+        isinstance(cached_root, NodeAnchor) and cached_root.topology_index_data is None
+    ) {
+        self.mem.__mem__[cached_root.id] = cached_root;
     }
     system_root_anchor: (Anchor | None) = self.mem.get(UUID(Con.SUPER_ROOT_UUID));
     if not isinstance(system_root_anchor, NodeAnchor) {
@@ -42,8 +28,10 @@ impl JScaleExecutionContext.init(self: JScaleExecutionContext) -> None {
         system_root_anchor.id = UUID(Con.SUPER_ROOT_UUID);
         self.mem.put(system_root_anchor);
     }
-    if not topology_index_enabled {
+    if system_root_anchor.topology_index_data is None {
         _process_cache['system_root'] = system_root_anchor;
+    } else {
+        _process_cache.pop('system_root', None);
     }
     self.system_root = system_root_anchor;
 

--- a/jac/jaclang/scale/memory/impl/memory_hierarchy.mongo.impl.jac
+++ b/jac/jaclang/scale/memory/impl/memory_hierarchy.mongo.impl.jac
@@ -132,17 +132,18 @@ def _mongo_persist_repairs(
 
 def _mongo_quarantine(
     backend: MongoBackend,
-    id_str: str,
-    anchor_type: (str | None),
-    arch_module: (str | None),
-    arch_type: (str | None),
-    fingerprint: (str | None),
-    data: any,
+    doc: dict[(str, Any)],
     error: str,
-    from_format_version: (int | None) = None,
     l2: (any | None) = None,
     reason_code: str = 'DESER_ERROR'
 ) {
+    id_str = str(doc.get('_id', ''));
+    anchor_type = doc.get('type');
+    arch_module = doc.get('arch_module');
+    arch_type = doc.get('arch_type');
+    fingerprint = doc.get('fingerprint');
+    data = doc.get('data');
+    from_format_version = doc.get('format_version');
     try {
         q_col = _mongo_q_collection(backend);
         now_ts = datetime.now(timezone.utc).isoformat();
@@ -296,7 +297,6 @@ impl MongoBackend.get(id: UUID) -> (Anchor | None) {
     arch_type = db_obj.get('arch_type');
     fingerprint = db_obj.get('fingerprint');
     data = db_obj.get('data');
-    fmt_version = db_obj.get('format_version');
 
     if arch_module and arch_type and fingerprint {
         cls = Serializer._get_class(arch_module, arch_type);
@@ -319,14 +319,8 @@ impl MongoBackend.get(id: UUID) -> (Anchor | None) {
         );
         _mongo_quarantine(
             self,
-            str(_id),
-            anchor_type,
-            arch_module,
-            arch_type,
-            fingerprint,
-            data,
+            db_obj,
             f"deserialize error: {type(e).__name__}: {e}",
-            from_format_version=fmt_version,
             l2=self._l2_ref,
             reason_code='DESER_ERROR'
         );
@@ -361,19 +355,7 @@ impl MongoBackend.get(id: UUID) -> (Anchor | None) {
                 f"{arch_module}.{arch_type} (anchor {id}). Moving to quarantine."
             );
         }
-        _mongo_quarantine(
-            self,
-            str(_id),
-            anchor_type,
-            arch_module,
-            arch_type,
-            fingerprint,
-            data,
-            reason,
-            from_format_version=fmt_version,
-            l2=self._l2_ref,
-            reason_code=code
-        );
+        _mongo_quarantine(self, db_obj, reason, l2=self._l2_ref, reason_code=code);
         return None;
     }
     _mongo_persist_repairs(self, str(_id), cast(Anchor, anchor), fingerprint);
@@ -425,8 +407,8 @@ impl MongoBackend.put_partial(anchor: Anchor, field_names: set[str]) -> None {
         if carries_topology {
             update['data.topology_index_data'] = (
                 b64encode(anchor.topology_index_data).decode('ascii')
-                if anchor.topology_index_data is not None
-                else None
+                    if anchor.topology_index_data is not None
+                    else None
             );
         }
         update['updated_at'] = datetime.now(timezone.utc).isoformat();
@@ -889,7 +871,6 @@ impl MongoBackend._load_anchor(raw: dict[(str, Any)]) -> (Anchor | None) {
     arch_module = raw.get('arch_module');
     arch_type = raw.get('arch_type');
     fingerprint = raw.get('fingerprint');
-    fmt_version = raw.get('format_version');
     data = raw['data'];
     try {
         anchor = Serializer.deserialize(data);
@@ -901,14 +882,8 @@ impl MongoBackend._load_anchor(raw: dict[(str, Any)]) -> (Anchor | None) {
         );
         _mongo_quarantine(
             self,
-            doc_id,
-            anchor_type,
-            arch_module,
-            arch_type,
-            fingerprint,
-            data,
+            raw,
             f"deserialize error: {type(e).__name__}: {e}",
-            from_format_version=fmt_version,
             l2=self._l2_ref,
             reason_code='DESER_ERROR'
         );
@@ -927,14 +902,8 @@ impl MongoBackend._load_anchor(raw: dict[(str, Any)]) -> (Anchor | None) {
         );
         _mongo_quarantine(
             self,
-            doc_id,
-            anchor_type,
-            arch_module,
-            arch_type,
-            fingerprint,
-            data,
+            raw,
             f"load failed for class {arch_module}.{arch_type}",
-            from_format_version=fmt_version,
             l2=self._l2_ref,
             reason_code=code
         );

--- a/jac/jaclang/scale/memory/impl/memory_hierarchy.mongo.impl.jac
+++ b/jac/jaclang/scale/memory/impl/memory_hierarchy.mongo.impl.jac
@@ -407,13 +407,28 @@ impl MongoBackend.put_partial(anchor: Anchor, field_names: set[str]) -> None {
     }
     _id = to_uuid(anchor.id);
     try {
-        partial_data = Serializer.serialize_fields(anchor, field_names);
-        if not partial_data {
+        import from base64 { b64encode }
+        arch_field_names = set(field_names);
+        arch_field_names.discard('topology_index_data');
+        partial_data = Serializer.serialize_fields(anchor, arch_field_names);
+        carries_topology = (
+            'topology_index_data' in field_names
+            and isinstance(anchor, NodeAnchor)
+            and isinstance(anchor.archetype, Root)
+        );
+        if not partial_data and not carries_topology {
             return;
         }
         update: dict[str, object] = {
             f"data.archetype.{k}": v for (k, v) in partial_data.items()
         };
+        if carries_topology {
+            update['data.topology_index_data'] = (
+                b64encode(anchor.topology_index_data).decode('ascii')
+                if anchor.topology_index_data is not None
+                else None
+            );
+        }
         update['updated_at'] = datetime.now(timezone.utc).isoformat();
         self.collection.update_one({'_id': str(_id)}, {'$set': update});
         anchor.hash = Serializer._compute_hash(anchor);

--- a/jac/jaclang/scale/memory/l1_invalidation.jac
+++ b/jac/jaclang/scale/memory/l1_invalidation.jac
@@ -4,6 +4,7 @@ import threading;
 import weakref;
 import from typing { cast }
 import from uuid { UUID, uuid4 }
+import from jaclang.jac0core.constant { Constants as Con }
 import from jaclang.scale._optdeps.redis { redis_module as redis }
 import from jaclang.runtimelib.memory { VolatileMemory }
 
@@ -92,6 +93,17 @@ def consume_stale(l1_id: str, id: UUID) -> bool {
 }
 
 
+def evict_process_cached_system_root(anchor_id: str) -> None {
+    if anchor_id != Con.SUPER_ROOT_UUID {
+        return;
+    }
+    try {
+        import from jaclang.scale.memory.memory_hierarchy { _process_cache }
+        _process_cache.pop("system_root", None);
+    } except Exception { }
+}
+
+
 def _handle_message(data: (bytes | str)) {
     try {
         text = data.decode("utf-8") if isinstance(data, (bytes, bytearray)) else data;
@@ -99,6 +111,7 @@ def _handle_message(data: (bytes | str)) {
         anchor_id = cast(str, payload.get("a") or "");
         origin = cast((str | None), payload.get("o"));
         if anchor_id {
+            evict_process_cached_system_root(anchor_id);
             evict_local_l1(anchor_id, origin);
         }
     } except Exception as e {

--- a/jac/jaclang/scale/tests/data/test_topology_cross_pod_invalidation.jac
+++ b/jac/jaclang/scale/tests/data/test_topology_cross_pod_invalidation.jac
@@ -1,10 +1,9 @@
-"""Multi-pod coherency: topology index (GTI) invalidation on edge-list-delta (#7334).
+"""Multi-pod coherency: system-root topology index (GTI) invalidation.
 
-`commit` excludes EDGE_LIST_DELTA intents from L2 put/broadcast (storm avoidance).
-That is safe for edge lists (reconstructable from the edge anchors) but not for a
-root's topology index: an opaque blob that only changes via EDGE_LIST_DELTA and
-can't be reconstructed, so other pods kept serving a stale GTI. The fix invalidates
-+ broadcasts such deltas when the anchor carries a topology index.
+GTI is runtime-maintained metadata stored on the system root. User-root edge
+list deltas are reconstructable from edge anchors, but the system-root GTI blob
+must still be persisted, cached fresh in Redis L2, and broadcast so other pods
+evict stale L1 system-root anchors before resolving traversals.
 
 Real Mongo + Redis via testcontainers. A custom `Root()` gives each test a real
 per-user root (fresh UUID, persistent), avoiding the anonymous root (id 0) that
@@ -24,6 +23,7 @@ import from testcontainers.community.redis { RedisContainer }
 
 import from jaclang.jac0core.runtime { JacRuntime }
 import from jaclang.jac0core.archetype { NodeAnchor, Root }
+import from jaclang.jac0core.constant { Constants as Con }
 import from jaclang.runtimelib.context { ExecutionContext }
 import from jaclang.runtimelib.serializer { Serializer }
 import from jaclang.project.config { JacConfig, set_config }
@@ -90,6 +90,7 @@ def _reset_dbs {
     if "redis_client" in _shared {
         _shared["redis_client"].flushall();
     }
+    _process_cache.pop("system_root", None);
     _process_cache.pop("redis_client", None);
     _process_cache.pop("redis_available", None);
 }
@@ -109,9 +110,9 @@ def _make_pod -> ScaleTieredMemory {
 }
 
 
-"""Topology-index length of the root cached in Redis L2; -1 if not cached."""
-def _l2_index_len(mem: ScaleTieredMemory, root_id: UUID) -> int {
-    raw = cast(RedisBackend, mem.l2).redis_client.get(f"anchor:{root_id}");
+"""Topology-index length of an anchor cached in Redis L2; -1 if not cached."""
+def _l2_index_len(mem: ScaleTieredMemory, anchor_id: UUID) -> int {
+    raw = cast(RedisBackend, mem.l2).redis_client.get(f"anchor:{anchor_id}");
     if not raw {
         return -1;
     }
@@ -123,11 +124,26 @@ def _l2_index_len(mem: ScaleTieredMemory, root_id: UUID) -> int {
 }
 
 
+def _bind_system_root(ctx: ExecutionContext, mem: ScaleTieredMemory) -> NodeAnchor {
+    system_id = UUID(Con.SUPER_ROOT_UUID);
+    system_anchor = mem.get(system_id);
+    if not isinstance(system_anchor, NodeAnchor) {
+        system_anchor = ctx.system_root;
+        system_anchor.id = system_id;
+        system_anchor.persistent = True;
+        mem.__mem__[system_id] = system_anchor;
+    }
+    ctx.system_root = system_anchor;
+    return system_anchor;
+}
+
+
 """Builder pod: persist a root with `n` _XPodTypeA children; return its id."""
 def _seed_root(n: int) -> UUID {
     memB = _make_pod();
     ctxB = ExecutionContext();
     ctxB.mem = memB;
+    _bind_system_root(ctxB, memB);
     JacRuntime.set_context(ctxB);
     user_root = Root();
     root_anchor = user_root.__jac__;
@@ -151,7 +167,7 @@ def _topology_cfg {
 }
 
 
-test "edge-list-delta on a root invalidates the topology index in Redis L2 + broadcasts" {
+test "edge-list-delta refreshes the system-root GTI in Redis L2 + broadcasts" {
     _reset_dbs();
     orig_base = JacRuntime.get_base_path_dir();
     _topology_cfg();
@@ -159,17 +175,19 @@ test "edge-list-delta on a root invalidates the topology index in Redis L2 + bro
         # --- Builder: root -> 100 _XPodTypeA, committed ---
         root_id = _seed_root(100);
 
-        # --- Pod A: warm read promotes the root into Redis L2 (100-edge GTI) ---
+        # --- Pod A: warm read promotes the system root into Redis L2 (100-edge GTI) ---
         memA = _make_pod();
         ctxA = ExecutionContext();
         ctxA.mem = memA;
+        _bind_system_root(ctxA, memA);
         JacRuntime.set_context(ctxA);
         rA_anchor = ctxA.mem.get(root_id);
         assert rA_anchor is not None , "root must load from L3";
         leadsA = [rA_anchor.archetype-->][?:_XPodTypeA];
         assert len(leadsA) == 100 , f"warm query expected 100, got {len(leadsA)}";
-        assert _l2_index_len(memA, root_id) == 100 , (
-            "root must be cached in Redis L2 with a 100-edge index after warm read"
+        system_id = UUID(Con.SUPER_ROOT_UUID);
+        assert _l2_index_len(memA, system_id) == 100 , (
+            "system root must be cached in Redis L2 with a 100-edge index after warm read"
         );
         ctxA.close();
 
@@ -185,6 +203,7 @@ test "edge-list-delta on a root invalidates the topology index in Redis L2 + bro
         memB2 = _make_pod();
         ctxB2 = ExecutionContext();
         ctxB2.mem = memB2;
+        _bind_system_root(ctxB2, memB2);
         JacRuntime.set_context(ctxB2);
         rB2_anchor = ctxB2.mem.get(root_id);
         assert rB2_anchor is not None;
@@ -202,34 +221,37 @@ test "edge-list-delta on a root invalidates the topology index in Redis L2 + bro
             assert len(doc['data']['edges']) == 101 , (
                 f"Mongo L3 must have 101 edges; got {len(doc['data']['edges'])}"
             );
-            restored = Serializer.deserialize(doc['data']);
+            system_doc = _shared["mongo_client"][_DB_NAME]["_anchors"].find_one(
+                {'_id': str(system_id)}
+            );
+            assert system_doc is not None , "system root must be persisted in Mongo";
+            restored = Serializer.deserialize(system_doc['data']);
             assert len(cast(NodeAnchor, restored).get_topology_index()) == 101 , (
-                "Mongo L3 topology index must be fresh (101)"
+                "Mongo L3 system-root topology index must be fresh (101)"
             );
 
-            # THE FIX (L2 coherency): the root's Redis L2 entry must be
-            # invalidated so other pods reload the fresh index. Was 100 before.
-            assert _l2_index_len(memB2, root_id) == -1 , (
-                "root's Redis L2 entry must be INVALIDATED on an edge-list-delta "
-                "that carries a topology index; got index len "
-                f"{_l2_index_len(memB2, root_id)} (a stale GTI other pods keep serving)"
+            # THE FIX (L2 coherency): the system-root Redis L2 entry must carry
+            # the fresh GTI so other pods can reload it.
+            assert _l2_index_len(memB2, system_id) == 101 , (
+                "system root's Redis L2 entry must be fresh after the topology "
+                f"metadata update; got index len {_l2_index_len(memB2, system_id)}"
             );
 
-            # THE FIX (cross-pod signal): an invalidation for the root must be
-            # broadcast so other pods evict their L1 copies.
-            saw_root = False;
+            # THE FIX (cross-pod signal): an invalidation for the system root
+            # must be broadcast so other pods evict their L1 copies.
+            saw_system_root = False;
             for _ in range(50) {
                 msg = pubsub.get_message(timeout=0.1);
                 if msg is not None and msg.get("type") == "message" {
                     payload = json.loads(msg.get("data"));
-                    if payload.get("a") == str(root_id) {
-                        saw_root = True;
+                    if payload.get("a") == str(system_id) {
+                        saw_system_root = True;
                         break;
                     }
                 }
             }
-            assert saw_root , (
-                "an invalidation message for the root must be published on "
+            assert saw_system_root , (
+                "an invalidation message for the system root must be published on "
                 f"'{DEFAULT_INVALIDATION_CHANNEL}' so other pods evict their L1"
             );
         } finally {
@@ -255,10 +277,11 @@ test "a second pod sees the fresh GTI after a cross-pod edge add (end-to-end)" {
         (_, redis_url) = _get_redis();
         ensure_listener(_process_cache, redis_url, DEFAULT_INVALIDATION_CHANNEL);
 
-        # --- Pod A: warm read, KEPT ALIVE so its L1 holds the (soon stale) root ---
+        # --- Pod A: warm read, kept alive so its L1 holds the soon-stale system root ---
         memA = _make_pod();
         ctxA = ExecutionContext();
         ctxA.mem = memA;
+        _bind_system_root(ctxA, memA);
         JacRuntime.set_context(ctxA);
         rA_anchor = ctxA.mem.get(root_id);
         assert rA_anchor is not None;
@@ -268,14 +291,15 @@ test "a second pod sees the fresh GTI after a cross-pod edge add (end-to-end)" {
         memB2 = _make_pod();
         ctxB2 = ExecutionContext();
         ctxB2.mem = memB2;
+        _bind_system_root(ctxB2, memB2);
         JacRuntime.set_context(ctxB2);
         rB2_anchor = ctxB2.mem.get(root_id);
         assert rB2_anchor is not None;
         rB2_anchor.archetype ++> _XPodTypeA(idx=100);
         ctxB2.mem.commit();
 
-        # --- Pod A re-queries: the listener should evict its stale L1, forcing a
-        # reload of the fresh index from L3. Bounded poll for pub/sub delivery. ---
+        # --- Pod A re-queries: the listener should evict stale system-root L1,
+        # forcing a reload of the fresh index from L3. Bounded poll for pub/sub. ---
         JacRuntime.set_context(ctxA);
         seen = -1;
         for _ in range(50) {

--- a/jac/jaclang/scale/tests/data/test_topology_scale.jac
+++ b/jac/jaclang/scale/tests/data/test_topology_scale.jac
@@ -336,8 +336,8 @@ def _topo_run_phase(workdir: str, phase: str) -> str {
     );
     env["PYTHONPATH"] = (
         jac_src
-        if not env.get("PYTHONPATH")
-        else jac_src + os.pathsep + env["PYTHONPATH"]
+            if not env.get("PYTHONPATH")
+            else jac_src + os.pathsep + env["PYTHONPATH"]
     );
     env["JAC_TOPOLOGY_INDEX"] = "1";
     env["PHASE"] = phase;

--- a/jac/jaclang/scale/tests/data/test_topology_scale.jac
+++ b/jac/jaclang/scale/tests/data/test_topology_scale.jac
@@ -303,9 +303,11 @@ test "topology-only change is detected by _compute_hash dirty gate" {
 # reloads the graph from SQLite with zero in-memory carry-over — a true
 # persistence round-trip across a "restart". `build` and `deep` each auto-commit
 # on exit; `check` reads the reloaded index. A deep edge (p0 -> deep) updates the
-# root's topology index without touching the root's own edges/archetype, which
-# is exactly the topology-only change the SQLite dirty gate must catch.
+# system root's topology index without touching the user root's own
+# edges/archetype, which is exactly the topology-only change the SQLite dirty
+# gate must catch.
 glob TOPO_REGRESS_SCRIPT: str = "import os;\n"
+     "import from jaclang.jac0core.runtime { JacRuntime }\n"
      "\n"
      "node Person { has name: str = \"\"; }\n"
      "edge Knows {}\n"
@@ -318,15 +320,25 @@ glob TOPO_REGRESS_SCRIPT: str = "import os;\n"
      "    } elif phase == \"deep\" {\n"
      "        p0 = [r ->: Knows :-> [?:Person]][0];\n"
      "        p0 +>: Knows :+> Person(name=\"deep\");\n"
-     "        print(\"DEEP_NODES=\" + str(len(r.__jac__.get_topology_index().node_table)));\n"
+     "        gti_root = JacRuntime.get_context().system_root;\n"
+     "        print(\"DEEP_NODES=\" + str(len(gti_root.get_topology_index().node_table)));\n"
      "    } elif phase == \"check\" {\n"
-     "        print(\"CHECK_NODES=\" + str(len(r.__jac__.get_topology_index().node_table)));\n"
+     "        gti_root = JacRuntime.get_context().system_root;\n"
+     "        print(\"CHECK_NODES=\" + str(len(gti_root.get_topology_index().node_table)));\n"
      "    }\n"
      "}\n";
 
 """Run one phase of the regression script in a fresh `jac run` subprocess."""
 def _topo_run_phase(workdir: str, phase: str) -> str {
     env = dict(os.environ);
+    jac_src = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+    );
+    env["PYTHONPATH"] = (
+        jac_src
+        if not env.get("PYTHONPATH")
+        else jac_src + os.pathsep + env["PYTHONPATH"]
+    );
     env["JAC_TOPOLOGY_INDEX"] = "1";
     env["PHASE"] = phase;
     result = subprocess.run(
@@ -337,7 +349,7 @@ def _topo_run_phase(workdir: str, phase: str) -> str {
         text=True,
         timeout=600
     );
-    return result.stdout;
+    return result.stdout + result.stderr;
 }
 
 """Pull an integer marker (e.g. `DEEP_NODES=3`) out of captured stdout."""

--- a/jac/tests/runtimelib/fixtures/cross_user_topo_index.jac
+++ b/jac/tests/runtimelib/fixtures/cross_user_topo_index.jac
@@ -1,16 +1,15 @@
-"""Server fixture exposing walkers that exercise cross-root graph queries.
+"""Server fixture exposing walkers that exercise cross-user graph queries.
 
-These walkers cooperate to build a two-root graph and run queries that
-the topology-index optimizer needs to handle correctly:
+These walkers cooperate to build a two-user graph and run queries that
+the system-root topology-index optimizer needs to handle correctly:
 
-  * `query_follow_chain` runs a 2-hop forward chain that crosses from
-    the calling user's own edges into another user's owned subgraph.
+  * `query_follow_chain` runs a 2-hop forward chain from the caller's
+    profile into another user's graph.
   * `query_channel_members` runs a 1-hop reverse query whose incoming
-    edges are owned by *other* users.
+    edges were created by other users.
 
 The fixture is exercised end-to-end via `JacTestClient`, which keeps a
-single long-lived runtime context across requests -- the regime where
-the topology-index optimizer historically returned wrong answers.
+single long-lived runtime context across requests.
 """
 
 node Profile {
@@ -31,8 +30,8 @@ edge Member {}
 
 
 walker:priv setup_profile_only {
-    has username: str = "";
-    has reports: list = [];
+    has username: str = "",
+        reports: list = [];
 
     can run with Root entry {
         existing = [-->[?:Profile]];
@@ -54,8 +53,8 @@ walker:priv setup_profile_only {
 }
 
 walker:priv post_tweet {
-    has content: str = "";
-    has reports: list = [];
+    has content: str = "",
+        reports: list = [];
 
     can run with Root entry {
         visit [-->[?:Profile]];
@@ -63,15 +62,15 @@ walker:priv post_tweet {
 
     can make with Profile entry {
         tweet = Tweet(content=self.content);
-        here +>: Post() :+> tweet;
+        here +>:Post():+> tweet;
         grant(tweet, level=ConnectPerm);
         report jid(tweet);
     }
 }
 
 walker:priv create_channel {
-    has name: str = "";
-    has reports: list = [];
+    has name: str = "",
+        reports: list = [];
 
     can run with Root entry {
         visit [-->[?:Profile]];
@@ -79,38 +78,38 @@ walker:priv create_channel {
 
     can make with Profile entry {
         chan = Channel(name=self.name);
-        here +>: Member() :+> chan;
+        here +>:Member():+> chan;
         grant(chan, level=ConnectPerm);
         report jid(chan);
     }
 }
 
 walker:priv follow_target {
-    has target_id: str = "";
-    has reports: list = [];
+    has target_id: str = "",
+        reports: list = [];
 
     can run with Root entry {
         visit [-->[?:Profile]];
     }
 
     can act with Profile entry {
-        target_profile = & (self.target_id);
-        here +>: Follow() :+> target_profile;
+        target_profile = &(self.target_id);
+        here +>:Follow():+> target_profile;
         report "ok";
     }
 }
 
 walker:priv join_channel {
-    has channel_id: str = "";
-    has reports: list = [];
+    has channel_id: str = "",
+        reports: list = [];
 
     can run with Root entry {
         visit [-->[?:Profile]];
     }
 
     can act with Profile entry {
-        chan = & (self.channel_id);
-        here +>: Member() :+> chan;
+        chan = &(self.channel_id);
+        here +>:Member():+> chan;
         report "ok";
     }
 }
@@ -132,11 +131,11 @@ walker:priv query_follow_chain {
 }
 
 walker:priv query_channel_members {
-    has channel_id: str = "";
-    has reports: list = [];
+    has channel_id: str = "",
+        reports: list = [];
 
     can run with Root entry {
-        chan = & (self.channel_id);
+        chan = &(self.channel_id);
         members = [chan<-:Member:<-[?:Profile]];
         report len(members);
     }

--- a/jac/tests/runtimelib/test_cross_user_topo_index.jac
+++ b/jac/tests/runtimelib/test_cross_user_topo_index.jac
@@ -1,17 +1,15 @@
-"""Cross-root graph query tests for the topology-index optimizer.
+"""Cross-user graph query tests for the topology-index optimizer.
 
-The topology index lives on each root anchor and indexes the edges that
-root *originated*. When a query crosses into another user's owned
-subgraph, the index used to silently miss those edges -- the global
-edge walk (with `JAC_TOPOLOGY_INDEX=0`) returns the right answer, but
-the index path returned an empty / undercounted set.
+The topology index lives on the system root and indexes graph topology
+across user roots. These tests keep the optimizer honest for queries
+whose origin and reachable nodes belong to different users.
 
 These tests pin down both failure shapes against a real
 `JacTestClient` (long-lived runtime context, the regime where the
 optimizer actually runs):
 
-  * a 2-hop forward chain that crosses into another user's edges, and
-  * a 1-hop reverse query whose incoming edges are owned by other users.
+  * a 2-hop forward chain that reaches another user's edges, and
+  * a 1-hop reverse query whose incoming edges were created by other users.
 """
 
 import os;
@@ -21,7 +19,7 @@ import jaclang;
 import from jaclang.runtimelib.testing { JacTestClient }
 
 glob FIXTURE = os.path.join(
-         JAC_ROOT, "tests", "runtimelib", "fixtures", "cross_root_topo_index.jac"
+         JAC_ROOT, "tests", "runtimelib", "fixtures", "cross_user_topo_index.jac"
      );
 
 """Force the topology-index optimizer on for the duration of `fn`."""
@@ -49,7 +47,7 @@ def first_report(response: any) -> any {
     return None;
 }
 
-test "cross-root forward chain returns followed user's tweets" {
+test "cross-user forward chain returns followed user's tweets" {
     def _body {
         client = JacTestClient.from_file(FIXTURE, base_path=mkdtemp());
         try {
@@ -78,7 +76,7 @@ test "cross-root forward chain returns followed user's tweets" {
     with_topo_index(_body);
 }
 
-test "cross-root reverse query counts members across roots" {
+test "cross-user reverse query counts members across users" {
     def _body {
         client = JacTestClient.from_file(FIXTURE, base_path=mkdtemp());
         try {

--- a/jac/tests/runtimelib/test_resolver_per_hop.jac
+++ b/jac/tests/runtimelib/test_resolver_per_hop.jac
@@ -5,6 +5,8 @@ These complement `test_topology_e2e.jac` (which guards execute_path-level
 parity) by exercising the resolver's per-hop entry points directly and by
 locking down the bail boundary that future PRs will widen."""
 
+import shutil;
+import from tempfile { mkdtemp }
 import from jaclang.jac0core.runtime { JacRuntime }
 import from jaclang.runtimelib.context { ExecutionContext }
 import from jaclang.project.config { JacConfig, set_config }
@@ -33,15 +35,31 @@ edge Hop2 {}
 edge Hop3 {}
 
 
+def _setup_context -> tuple[ExecutionContext, str, str] {
+    cfg = JacConfig();
+    cfg.run.topology_index = True;
+    set_config(cfg);
+    tmpdir = mkdtemp();
+    orig_base = JacRuntime.get_base_path_dir();
+    JacRuntime.set_base_path(tmpdir);
+    ctx = ExecutionContext();
+    JacRuntime.set_context(ctx);
+    return (ctx, tmpdir, orig_base);
+}
+
+def _teardown_context(ctx: ExecutionContext, tmpdir: str, orig_base: str) {
+    ctx.close();
+    JacRuntime.set_base_path(orig_base);
+    shutil.rmtree(tmpdir, ignore_errors=True);
+    set_config(JacConfig());
+}
+
+
 test "3-hop type-filtered chain resolves via the per-hop fold" {
     # A purely type-filtered 3-hop chain must walk all three hops on the
     # index and return the leaf set correctly. This is the happy-path the
     # per-hop fold replaces today's `plan_chain` set-narrowing branch with.
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         # root -> R1Hop -> R2Hop -> R3Hop  (5 leaves)
@@ -56,8 +74,7 @@ test "3-hop type-filtered chain resolves via the per-hop fold" {
         assert len(leaves) == 5 , f"expected 5 leaves, got {len(leaves)}";
         assert sorted([n.val for n in leaves]) == [0, 100, 200, 300, 400];
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
@@ -67,11 +84,7 @@ test "single-hop slice on last hop applies ordered+sliced result" {
     # last hop receives a non-None `slc` and `resolve_chain_ordered` is the
     # only path that produces it. Pins down the use_ordered branch in
     # resolve_path_anchors.
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         for i in range(20) {
@@ -82,8 +95,7 @@ test "single-hop slice on last hop applies ordered+sliced result" {
         # Canonical edge-insertion order means the first 5 are vals 0..4.
         assert sorted([n.val for n in sliced]) == [0, 1, 2, 3, 4];
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
@@ -92,11 +104,7 @@ test "predicate on non-final hop resolves via per-hop walk fallback" {
     # The core promise of the per-hop fold: an awkward hop (predicate filter
     # that the index can't apply) falls back to `_hop_via_walk` locally,
     # while the *other* hops still use the index. No global bail.
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         for i in range(10) {
@@ -125,7 +133,6 @@ test "predicate on non-final hop resolves via per-hop walk fallback" {
         leaves = [r->:Hop1:->[?:R1Hop, val>5]->:Hop2:->[?:R2Hop]];
         assert sorted([n.val for n in leaves]) == [60, 70, 80, 90];
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }

--- a/jac/tests/runtimelib/test_topology_e2e.jac
+++ b/jac/tests/runtimelib/test_topology_e2e.jac
@@ -6,6 +6,8 @@ correct results. Uses real Jac edge/filter syntax so regressions in the
 compiler pipeline (exit_edge_ref_trailer, exit_filter_compr) are caught.
 """
 
+import shutil;
+import from tempfile { mkdtemp }
 import from jaclang.jac0core.runtime { JacRuntime }
 import from jaclang.runtimelib.context { ExecutionContext }
 import from jaclang.project.config { JacConfig, set_config }
@@ -35,12 +37,29 @@ node BaseContent {
 node PostNode(BaseContent) {}
 node ArticleNode(BaseContent) {}
 
-test "index type-filtered query returns correct results" {
+
+def _setup_context -> tuple[ExecutionContext, JacConfig, str, str] {
     cfg = JacConfig();
     cfg.run.topology_index = True;
     set_config(cfg);
+    tmpdir = mkdtemp();
+    orig_base = JacRuntime.get_base_path_dir();
+    JacRuntime.set_base_path(tmpdir);
     ctx = ExecutionContext();
     JacRuntime.set_context(ctx);
+    return (ctx, cfg, tmpdir, orig_base);
+}
+
+def _teardown_context(ctx: ExecutionContext, tmpdir: str, orig_base: str) {
+    ctx.close();
+    JacRuntime.set_base_path(orig_base);
+    shutil.rmtree(tmpdir, ignore_errors=True);
+    set_config(JacConfig());
+}
+
+
+test "index type-filtered query returns correct results" {
+    (ctx, _, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
 
@@ -60,17 +79,12 @@ test "index type-filtered query returns correct results" {
         result_all = [r->:EdgeX:->];
         assert len(result_all) == 100 , f"Expected 100 total, got {len(result_all)}";
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
 test "index results match non-indexed results in same context" {
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, cfg, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         for i in range(20) {
@@ -91,17 +105,12 @@ test "index results match non-indexed results in same context" {
         assert off_result == on_result , f"Results differ: off={off_result} on={on_result}";
         assert len(off_result) == 20;
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
 test "index returns empty for non-matching edge type" {
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, _, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         for i in range(10) {
@@ -112,17 +121,12 @@ test "index returns empty for non-matching edge type" {
         result = [r->:EdgeY:->[?:TypeA]];
         assert len(result) == 0 , f"Expected 0, got {len(result)}";
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
 test "post-hoc filter fused with edge-op produces same results" {
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, _, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         for i in range(10) {
@@ -141,17 +145,12 @@ test "post-hoc filter fused with edge-op produces same results" {
         assert inline == posthoc , f"Inline vs post-hoc differ: {inline} vs {posthoc}";
         assert len(inline) == 10;
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
 test "nested post-hoc filter as origin of outer edge-op" {
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, _, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         # root -> TypeA via EdgeX, TypeA -> TypeB via EdgeY
@@ -175,8 +174,7 @@ test "nested post-hoc filter as origin of outer edge-op" {
         assert inline == nested , f"Inline vs nested differ: {inline} vs {nested}";
         assert inline == [0, 10, 20, 30, 40];
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
@@ -188,11 +186,7 @@ test "planner bypasses index when no hop is filtered" {
     }
     import from jaclang.runtimelib.planner { execute_path }
 
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, _, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         for i in range(10) {
@@ -259,8 +253,7 @@ test "planner bypasses index when no hop is filtered" {
             "two-hop with filter on second hop should engage TI"
         );
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
@@ -277,11 +270,7 @@ test "planner bails when a hop has predicates beyond type" {
     }
     import from jaclang.runtimelib.planner { execute_path }
 
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, _, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         for i in range(10) {
@@ -321,8 +310,7 @@ test "planner bails when a hop has predicates beyond type" {
         result = [r->:EdgeX:->[?:TypeA, val>5]];
         assert sorted([n.val for n in result]) == [6, 7, 8, 9];
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
@@ -337,11 +325,7 @@ test "parent-type filter returns all subtype instances" {
     # The fix indexes each target under every ancestor in its MRO at
     # edge-creation time. This test pins the e2e behavior so a regression
     # in the MRO fan-out path can't silently return empty sets again.
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, cfg, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         for i in range(5) {
@@ -376,17 +360,12 @@ test "parent-type filter returns all subtype instances" {
         assert nat_all == vals;
         assert nat_posts == [0, 1, 2, 3, 4];
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
 test "index built on root with null root field" {
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, _, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         r +>:EdgeX:+> TypeA(val=42);
@@ -395,8 +374,7 @@ test "index built on root with null root field" {
         assert len(idx) > 0 , "Index should have edges";
         assert len(idx.node_table) == 2 , "Index should have root + TypeA";
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
@@ -412,11 +390,7 @@ test "typed-edge filter compares against edge attributes apply at runtime" {
     # tutorial Part 2 ("Advanced: Custom Edges"). The parser fix in
     # PR #5799 made the syntax legal; this test pins the runtime
     # semantics so the fast path can't silently regress them.
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, _, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         # Three nodes connected via Weighted edges with weights 1, 5, 10.
@@ -437,8 +411,7 @@ test "typed-edge filter compares against edge attributes apply at runtime" {
             f"baseline (no predicate): expected [10, 20, 30], got {all_w}"
         );
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }
 
@@ -447,11 +420,7 @@ test "non-final node predicate in multi-hop chain applies at runtime" {
     # NODE (not an edge), the fast path's post-filter only runs on the
     # FINAL destination. Predicates on intermediate hops were silently
     # dropped for the same reason -- only type names were forwarded.
-    cfg = JacConfig();
-    cfg.run.topology_index = True;
-    set_config(cfg);
-    ctx = ExecutionContext();
-    JacRuntime.set_context(ctx);
+    (ctx, _, tmpdir, orig_base) = _setup_context();
     try {
         r = root;
         # Build r --EdgeX--> TypeA(val=v) --EdgeY--> TypeB(val=v*10)
@@ -471,7 +440,6 @@ test "non-final node predicate in multi-hop chain applies at runtime" {
             f"got {leaves}, expected [50, 100]"
         );
     } finally {
-        ctx.close();
-        set_config(JacConfig());
+        _teardown_context(ctx, tmpdir, orig_base);
     }
 }

--- a/jac/tests/runtimelib/test_topology_index.jac
+++ b/jac/tests/runtimelib/test_topology_index.jac
@@ -22,17 +22,6 @@ test "encode decode round trip" {
     assert len(decoded.adj_list) == 2;
 }
 
-test "cross root preserved through encoding" {
-    idx = TopologyIndex();
-    foreign_root = uuid4();
-    n1 = uuid4();
-    idx.add_node(uuid4(), "Root");
-    idx.add_node(n1, "NodeA", owner_root=foreign_root);
-
-    decoded = TopologyIndex.decode(idx.encode());
-    assert decoded.node_table[1][2] == foreign_root;
-}
-
 test "large graph under 1MB" {
     idx = TopologyIndex();
     node_ids = [uuid4() for _ in range(10000)];
@@ -160,19 +149,6 @@ test "multi hop selective" {
         == set(b_ids);
 }
 
-test "cross root ids" {
-    idx = TopologyIndex();
-    foreign = uuid4();
-    n1 = uuid4();
-    n2 = uuid4();
-    idx.add_node(uuid4(), "Root");
-    idx.add_node(n1, "A");
-    idx.add_node(n2, "B", owner_root=foreign);
-    cross = idx.get_cross_root_ids({n1, n2});
-    assert cross[foreign] == {n2};
-    assert n1 not in cross.get(foreign, set());
-}
-
 # ── MRO fan-out ──────────────────────────────────────────────────────
 test "subtype query returns instances of all descendants" {
     idx = TopologyIndex();
@@ -235,14 +211,14 @@ test "multi-edge between same pair preserves edge-type isolation" {
     assert idx.resolve_chain({a}, [(None, "B", 2)]) == set();
 }
 
-# ── v1 → v2 migration ────────────────────────────────────────────────
-test "v1 blob migrates to v2 on decode and warms up MRO via mutation" {
+# ── Legacy decode ────────────────────────────────────────────────────
+test "v1 blob decodes without legacy owner roots and warms up MRO via mutation" {
     # Construct a v1 blob by hand: 3 types, 2 nodes, 1 edge.
     import struct;
 
     root_id = uuid4();
     child_id = uuid4();
-    self_root = UUID(int=0);
+    legacy_owner = UUID(int=0);
 
     blob = bytearray();
     # Header (v1): version=1, num_types=3, num_nodes=2, num_edges=1
@@ -252,21 +228,22 @@ test "v1 blob migrates to v2 on decode and warms up MRO via mutation" {
         blob.append(len(name));
         blob.extend(name);
     }
-    # NodeTable: (uuid, type_id, owner_root)
+    # NodeTable: v1/v2 had an extra legacy root UUID; current GTI drops it.
     blob.extend(root_id.bytes);
     blob.extend(struct.pack("<H", 0));
-    blob.extend(self_root.bytes);
+    blob.extend(legacy_owner.bytes);
     blob.extend(child_id.bytes);
     blob.extend(struct.pack("<H", 1));
-    blob.extend(self_root.bytes);
+    blob.extend(legacy_owner.bytes);
     # AdjList: (src_lid, edge_type_id, tgt_lid)
     blob.extend(struct.pack("<HHH", 0, 2, 1));
 
     idx = TopologyIndex.decode(bytes(blob));
 
-    # All persisted data made it across.
+    # All usable persisted data made it across.
     assert len(idx.adj_list) == 1;
     assert len(idx.node_table) == 2;
+    assert len(idx.node_table[0]) == 2;
     assert idx.type_table == ["Root", "NodeA", "EdgeX"];
     # Migration installed stub MRO chains: each type is its own ancestor.
     assert idx.type_mro_ids == [[0], [1], [2]];
@@ -284,10 +261,41 @@ test "v1 blob migrates to v2 on decode and warms up MRO via mutation" {
     assert idx.resolve_chain({root_id}, [(None, "BaseContent", 2)]) == {new_child};
     assert idx.resolve_chain({root_id}, [(None, "PostNode", 2)]) == {new_child};
 
-    # Re-encoding the migrated index produces a v2 blob that round-trips.
+    # Re-encoding the migrated index produces a current blob that round-trips.
     re_decoded = TopologyIndex.decode(idx.encode());
     assert re_decoded.resolve_chain({root_id}, [(None, "BaseContent", 2)])
         == {new_child};
+}
+
+test "v2 blob decodes without legacy owner roots" {
+    import struct;
+
+    root_id = uuid4();
+    child_id = uuid4();
+    legacy_owner = uuid4();
+
+    blob = bytearray();
+    blob.extend(struct.pack("<BHHi", 2, 3, 2, 1));
+    for (tid, name) in enumerate([b"Root", b"NodeA", b"EdgeX"]) {
+        blob.append(len(name));
+        blob.extend(name);
+        blob.append(1);
+        blob.extend(struct.pack("<H", tid));
+    }
+    blob.extend(root_id.bytes);
+    blob.extend(struct.pack("<H", 0));
+    blob.extend(legacy_owner.bytes);
+    blob.extend(child_id.bytes);
+    blob.extend(struct.pack("<H", 1));
+    blob.extend(legacy_owner.bytes);
+    blob.extend(struct.pack("<HHH", 0, 2, 1));
+
+    idx = TopologyIndex.decode(bytes(blob));
+
+    assert len(idx.node_table) == 2;
+    assert idx.node_table[0] == (root_id, 0);
+    assert idx.node_table[1] == (child_id, 1);
+    assert idx.resolve_chain({root_id}, [("EdgeX", "NodeA", 2)]) == {child_id};
 }
 
 # ── Compact-encoding fidelity ────────────────────────────────────────
@@ -302,7 +310,7 @@ test "encoded size beats naive bound" {
     for i in range(5000) {
         idx.add_edge(node_ids[i % 1000], node_ids[(i * 7 + 3) % 1000], "Edge");
     }
-    # 1000 nodes × 34B = 34000; 5000 edges × 6B = 30000; type table tiny.
+    # 1000 nodes x 18B = 18000; 5000 edges x 6B = 30000; type table tiny.
     # Generous ceiling: 80KB.
     assert len(idx.encode()) < 80000;
 }

--- a/jac/tests/runtimelib/test_topology_integration.jac
+++ b/jac/tests/runtimelib/test_topology_integration.jac
@@ -27,6 +27,10 @@ node _MultiHopLeaf {
     has idx: int = 0;
 }
 
+node _SystemRootGtiNode {
+    has idx: int = 0;
+}
+
 test "topology index config from toml" {
     import from jaclang.project.config { JacConfig }
     toml_str = "[project]\nname = \"test\"\n\n[run]\ntopology_index = false\n";
@@ -123,6 +127,40 @@ test "topology index survives anchor serialization" {
     decoded = restored.get_topology_index();
     assert len(decoded.adj_list) == 1;
     assert len(decoded.node_table) == 2;
+}
+
+test "topology index is stored on system root for user root graphs" {
+    import from jaclang.jac0core.archetype { Root }
+    tmpdir = mkdtemp();
+    orig_base = JacRuntime.get_base_path_dir();
+    try {
+        cfg = JacConfig();
+        cfg.run.topology_index = True;
+        set_config(cfg);
+        JacRuntime.set_base_path(tmpdir);
+
+        ctx = ExecutionContext();
+        JacRuntime.set_context(ctx);
+
+        user_root = Root();
+        JacRuntime.save(user_root);
+        ctx.set_user_root(user_root.__jac__.id.hex);
+
+        root ++> _SystemRootGtiNode(idx=1);
+
+        system_idx = ctx.system_root.get_topology_index();
+        user_idx = user_root.__jac__.get_topology_index();
+
+        assert len(system_idx) == 1 , "system root must carry the topology edge";
+        assert len(user_idx) == 0 , "user root must not carry its own GTI blob";
+        assert len([root-->[?:_SystemRootGtiNode]]) == 1;
+
+        ctx.close();
+    } finally {
+        JacRuntime.set_base_path(orig_base);
+        set_config(JacConfig());
+        shutil.rmtree(tmpdir, ignore_errors=True);
+    }
 }
 
 test "concurrent edge adds merged in sqlite sync" {

--- a/release_notes/unreleased/jaclang/7807.feature.md
+++ b/release_notes/unreleased/jaclang/7807.feature.md
@@ -1,1 +1,1 @@
-- Move the topology index to the system root and persist system-root GTI metadata across core and scale backends.
+- Move the topology index to the system root, simplify GTI node encoding, and persist system-root GTI metadata across core and scale backends.

--- a/release_notes/unreleased/jaclang/7807.feature.md
+++ b/release_notes/unreleased/jaclang/7807.feature.md
@@ -1,0 +1,1 @@
+- Move the topology index to the system root and persist system-root GTI metadata across core and scale backends.


### PR DESCRIPTION
## **Description**

Moves the Global Topology Index (GTI) off per-user roots and onto the single **system root**, so every graph mutation is recorded in one authoritative index. This removes the cross-root bookkeeping that the index previously carried and simplifies both the on-disk encoding and the query path.

### Motivation

Previously each user root owned its own topology index, and edges/nodes that crossed roots had to be indexed into *both* roots. That required tracking an `owner_root` per node, a `SELF_ROOT` sentinel, per-hop "bail on foreign owner" logic, and duplicate indexing work. Storing the index once on the system root makes it a true *global* index: resolution no longer needs to reason about which root owns a node, and cross-user graphs resolve correctly from a single source of truth.

### What changed

**Index storage & maintenance (`topo_utils`)**
- Added `_get_index_anchor()`, which always resolves the system root (`Constants.SUPER_ROOT_UUID`) and lazily promotes/persists `ctx.system_root` when needed.
- `on_edge_created` / `on_edge_destroyed` / `on_node_saved` / `on_node_destroyed` now index into the single system-root anchor instead of resolving and double-writing source and target roots.

**Index data structure (`topology_index`)**
- Dropped the per-node `owner_root` column and the `SELF_ROOT` sentinel; `node_table` entries are now `(node_id, type_id)`.
- Removed cross-root machinery: `get_cross_root_ids`, the `bail_on_intermediate_foreign` path in `resolve_chain` (now returns a plain `set[UUID]`), and the v1→v2 migration helper.
- Bumped `TOPO_VERSION` to 3 with a slimmer node encoding, while `decode` still reads legacy v1/v2 blobs (skipping the old owner-root bytes) for backward compatibility.

**Resolver (`resolver`)**
- Added `_get_system_root_anchor()` and resolve queries against the system-root index.
- Simplified the fast-path hop check to "all origin ids present in the index" now that there is no per-node owner to inspect.

**Persistence (core + scale)**
- `memory.impl` records create/update of the system-root anchor's `topology_index_data` even without normal write access, so GTI metadata is durably persisted.
- Scale/Mongo backends persist and invalidate system-root GTI state across pods (`context`, `memory_hierarchy.mongo`, `l1_invalidation`).

### Tests

- Updated/added coverage for user-root and cross-user topology graphs: `test_topology_index`, `test_topology_integration`, `test_resolver_per_hop`, `test_cross_user_topo_index` (renamed fixture), `test_topology_e2e`.
- Scale tests updated for cross-pod invalidation and system-root persistence.

Verified locally:
```
PYTHONPATH=jac python -m jaclang test jac/tests/runtimelib/test_topology_index.jac
PYTHONPATH=jac python -m jaclang test jac/tests/runtimelib/test_topology_integration.jac
PYTHONPATH=jac python -m jaclang test jac/tests/runtimelib/test_resolver_per_hop.jac
PYTHONPATH=jac python -m jaclang test jac/tests/runtimelib/test_occ_read_capture.jac
```

> Note: the full `test_topology_e2e` run against the repo default DB failed due to stale system-root state in `./.jac/data/main.db` left over from repeated local runs, not a regression in this change.
