### PR TITLE
ci: capture per-test timings in the compiler and equivalence suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,13 @@ jobs:
           set -uxo pipefail
           WORK="$(mktemp -d)"
           rc=0
-          HOME="$WORK" JAC_TEST_JOBS=auto jac test tests/compiler | tee /tmp/compiler.log || rc=$?
+          # Per-test timings: --durations prints every test's time in the log;
+          # junitxml uploads the same data as a structured artifact. Under
+          # JAC_TEST_JOBS=auto these times include contention from the other
+          # xdist workers — compare distributions across runs, not solo cost.
+          HOME="$WORK" JAC_TEST_JOBS=auto \
+            PYTEST_ADDOPTS="--durations=0 --durations-min=0.001 --junitxml=/tmp/compiler-times.xml -o junit_family=xunit2" \
+            jac test tests/compiler | tee /tmp/compiler.log || rc=$?
           {
             echo "## binary compiler-suite result"
             echo '```'
@@ -199,6 +205,13 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$rc"
+      - name: Upload compiler-suite per-test timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiler-suite-timings
+          path: /tmp/compiler-times.xml
+          if-no-files-found: warn
       - name: Cross-backend equivalence suite (py/es/native congruence)
         working-directory: jac
         # The suite's cross-module tests build fixture paths under jac/tests/
@@ -212,7 +225,9 @@ jobs:
           set -uxo pipefail
           WORK="$(mktemp -d)"
           rc=0
-          HOME="$WORK" JAC_TEST_JOBS=auto jac test jaclang/compiler/tests | tee /tmp/equivalence.log || rc=$?
+          HOME="$WORK" JAC_TEST_JOBS=auto \
+            PYTEST_ADDOPTS="--durations=0 --durations-min=0.001 --junitxml=/tmp/equivalence-times.xml -o junit_family=xunit2" \
+            jac test jaclang/compiler/tests | tee /tmp/equivalence.log || rc=$?
           {
             echo "## binary equivalence-suite result"
             echo '```'
@@ -220,6 +235,13 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$rc"
+      - name: Upload equivalence-suite per-test timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: equivalence-suite-timings
+          path: /tmp/equivalence-times.xml
+          if-no-files-found: warn
 
   # Everything except the compiler tests.
   test-runtime:


### PR DESCRIPTION
## What

Adds per-test timing capture to the two binary suite steps in `test-compiler`, via `PYTEST_ADDOPTS` (no harness or compiler code changes):

- `--durations=0 --durations-min=0.001` — pytest prints every test's wall time (setup/call/teardown) at the end of the run, visible directly in the CI log.
- `--junitxml` — the same timing data uploaded as a structured artifact (`compiler-suite-timings`, `equivalence-suite-timings`) for offline sorting/aggregation.

## Why

The compiler suite step grew from ~12.4m (Jul 14) to ~22.8m (Jul 30) and we need ground-truth per-test numbers from the real Blacksmith runners to see where the time goes. Prior profiling was done on fork runners (different hardware), so absolute numbers were not trustworthy.

## Notes

- Measurement only — no behavior change to the suites.
- The suites run with `JAC_TEST_JOBS=auto` (pytest-xdist, 4 workers on the 4vcpu runner), so recorded times include cross-worker contention. They answer "where does the wall time go", not "what does this test cost solo".
- `if-no-files-found: warn` keeps the upload steps from failing runs where the suite dies before pytest writes the XML.