### PR TITLE
scale: decouple the seal toolchain from the shipped pod binary; self-version the seal scripts (fixes #7810)

### DIFF
--- a/jac/jaclang/runtimelib/jab_vendor.jac
+++ b/jac/jaclang/runtimelib/jab_vendor.jac
@@ -45,22 +45,25 @@ def _pip(args: list[str]) -> tuple[int, str] {
 
 
 def download_wheels(
-    specs: list[str], dest: Path, platform_tag: str = "", python_version: str = ""
+    specs: list[str],
+    dest: Path,
+    platform_tags: (list[str] | None) = None,
+    python_version: str = ""
 ) -> tuple[bool, str] {
     if not specs {
         return (True, "");
     }
     dest.mkdir(parents=True, exist_ok=True);
     args = ["download", "--only-binary=:all:", "--dest", str(dest)];
-    if platform_tag {
-        args = args + ["--platform", platform_tag];
+    for tag in (platform_tags or []) {
+        args = args + ["--platform", tag];
     }
     if python_version {
         args = args + ["--python-version", python_version];
     }
     (rc, out) = _pip(args + specs);
     if rc != 0 {
-        if platform_tag or python_version {
+        if platform_tags or python_version {
             return (False, out);
         }
         return _build_wheels_native(specs, dest, out);

--- a/jac/jaclang/scale/deploy/target/kubernetes/runtime_bootstrap.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/runtime_bootstrap.jac
@@ -1,9 +1,5 @@
-import from jaclang.scale.injector.bundle {
-    JAC_HOME,
-    APP_VOLUME_NAME,
-    APP_MOUNT_PATH,
-    TOOLCHAIN_SUBDIR
-}
+import from jaclang.scale.injector.binary { TOOLCHAIN_SUBDIR }
+import from jaclang.scale.injector.bundle { JAC_HOME, APP_VOLUME_NAME, APP_MOUNT_PATH }
 import from jaclang.scale.injector.pvc_injector {
     BUNDLE_VOLUME_NAME,
     BUNDLE_MOUNT_PATH

--- a/jac/jaclang/scale/injector/binary.jac
+++ b/jac/jaclang/scale/injector/binary.jac
@@ -1,20 +1,36 @@
 import io;
 import os;
+import sys;
 import json;
 import hashlib;
 import logging;
 import shutil;
 import tarfile;
+import tempfile;
 import from pathlib { Path }
 import from urllib.request { urlopen }
 import from urllib.error { HTTPError }
-import from jaclang.scale.injector.bundle { TOOLCHAIN_SUBDIR }
 import from jaclang.runtimelib.utils { release_arch, host_arch }
 
 glob logger = logging.getLogger(__name__);
 
 glob BINARY_ARCNAME: str = "bin/jac",
+     TOOLCHAIN_SUBDIR: str = ".jactoolchain",
      _HTTP_TIMEOUT: int = 60;
+
+
+def host_platform -> str {
+    if sys.platform == "darwin" {
+        return f"macos-{host_arch()}";
+    }
+    if sys.platform.startswith("linux") {
+        return f"linux-{host_arch()}";
+    }
+    raise RuntimeError(
+        f"No jac release binary exists for this driver platform ({sys.platform}); "
+        f"jac-scale deploys can only be driven from linux or macos hosts."
+    );
+}
 
 
 def _node_architecture(k8s_node: object) -> str {
@@ -281,9 +297,17 @@ def reset_deploy_version_cache {
 }
 
 
-def download_release_binary(channel: str, arch: str, version: str = "") -> bytes {
+def _latest_release_version -> str {
+    api = f"https://api.github.com/repos/{GH_REPO}/releases/latest";
+    meta = json.loads(_http_get_bytes(api).decode("utf-8"));
+    tag = str(meta.get("tag_name", ""));
+    return tag[1:] if tag.startswith("v") else "";
+}
+
+
+def download_release_binary(channel: str, platform: str, version: str = "") -> bytes {
     repo = GH_REPO;
-    suffix = f"-linux-{arch}";
+    suffix = f"-{platform}";
     binary_url = "";
     checksum_url = "";
 
@@ -332,17 +356,21 @@ def download_release_binary(channel: str, arch: str, version: str = "") -> bytes
             }
             raise;
         }
+        if not version {
+            tag = str(meta.get("tag_name", ""));
+            version = tag[1:] if tag.startswith("v") else "";
+        }
         (binary_url, checksum_url) = _pick_stable_assets(meta, suffix);
         if not binary_url {
             tag = str(meta.get("tag_name", version or "latest"));
             raise RuntimeError(
-                f"No `jac-*{suffix}` asset on the {repo} release ({tag}). The node "
-                f"arch may be unpublished; set JAC_NODE_ARCH or check "
+                f"No `jac-*{suffix}` asset on the {repo} release ({tag}). The "
+                f"platform may be unpublished; set JAC_NODE_ARCH or check "
                 f"https://github.com/{repo}/releases."
             );
         }
         if version {
-            logger.info(f"Shipping the pinned pod runtime jac {version}.");
+            logger.info(f"Using the pinned jac {version} for {platform}.");
         }
     }
 
@@ -350,18 +378,95 @@ def download_release_binary(channel: str, arch: str, version: str = "") -> bytes
         return _fetch_verified_asset(
             binary_url,
             checksum_url,
-            _binary_cache_path(channel, arch),
-            f"{channel} jac binary"
+            _binary_cache_path(channel, platform, version),
+            f"{channel} jac binary ({platform})"
         );
     } except HTTPError as e {
         if e.code == 404 {
             raise RuntimeError(
-                f"No `jac-*{suffix}` binary published for this arch on the "
-                f"{channel} release; set JAC_NODE_ARCH or check "
-                f"https://github.com/{repo}/releases."
+                f"No `jac-*{suffix}` binary published on the {channel} release; "
+                f"set JAC_NODE_ARCH or check https://github.com/{repo}/releases."
             );
         }
         raise;
+    }
+}
+
+
+obj ResolvedToolchain {
+    has channel: str,
+        version: str = "",
+        local_path: str = "",
+        ship_platform: str = "",
+        _exec: (Path | None) = None;
+
+    def ship_bytes(arch: str) -> bytes {
+        self.ship_platform = f"linux-{arch}";
+        if self.channel == "local" {
+            return Path(self.local_path).read_bytes();
+        }
+        return download_release_binary(self.channel, self.ship_platform, self.version);
+    }
+
+    def exec_path -> Path {
+        if self._exec is not None {
+            return self._exec;
+        }
+        if self.channel == "local" {
+            self._exec = Path(self.local_path);
+            return self._exec;
+        }
+        platform = host_platform();
+        payload = download_release_binary(self.channel, platform, self.version);
+        self._exec = _materialize_exec(
+            payload, _binary_cache_path(self.channel, platform, self.version)
+        );
+        return self._exec;
+    }
+}
+
+
+def resolve_toolchain(channel: str, version: str = "") -> ResolvedToolchain {
+    import from jaclang.scale.config.dev_config { BINARY_PATH_ENV, Channel }
+    if channel == Channel.LOCAL.value {
+        local = os.environ.get(BINARY_PATH_ENV, "");
+        if not local or not Path(local).is_file() {
+            raise RuntimeError(
+                f"channel 'local' requires {BINARY_PATH_ENV} to point at an "
+                f"existing jac binary; got {local!r}."
+            );
+        }
+        return ResolvedToolchain(channel="local", local_path=local);
+    }
+    if channel == Channel.EXPERIMENTAL.value {
+        channel = Channel.DEV.value;
+    }
+    if channel == Channel.STABLE.value and not version {
+        version = _latest_release_version();
+    }
+    return ResolvedToolchain(channel=channel, version=version);
+}
+
+
+def _materialize_exec(payload: bytes, cache_file: Path) -> Path {
+    try {
+        if not (cache_file.is_file() and cache_file.read_bytes() == payload) {
+            cache_file.parent.mkdir(parents=True, exist_ok=True);
+            tmp = cache_file.with_suffix(f".{os.getpid()}.tmp");
+            tmp.write_bytes(payload);
+            tmp.rename(cache_file);
+        }
+        cache_file.chmod(0o755);
+        return cache_file;
+    } except OSError as e {
+        tmp_bin = Path(tempfile.mkdtemp(prefix="jac-toolchain-")) / "jac";
+        tmp_bin.write_bytes(payload);
+        tmp_bin.chmod(0o755);
+        logger.warning(
+            f"Toolchain cache at {cache_file} is not writable ({e}); using a "
+            f"temporary copy at {tmp_bin}."
+        );
+        return tmp_bin;
     }
 }
 
@@ -498,13 +603,15 @@ def _scale_cache_root -> Path {
 }
 
 
-def _binary_cache_path(channel: str, arch: str) -> Path {
-    return _scale_cache_root() / f"jac-{channel}-linux-{arch}";
+def _binary_cache_path(channel: str, platform: str, version: str = "") -> Path {
+    key = f"jac-{version}-{platform}" if version else f"jac-{channel}-{platform}";
+    return _scale_cache_root() / key;
 }
 
 
-def _admin_dist_cache_path(channel: str) -> Path {
-    return _scale_cache_root() / f"jac-{channel}-admin-dist.tar.gz";
+def _admin_dist_cache_path(channel: str, version: str = "") -> Path {
+    key = f"jac-{version}" if version else f"jac-{channel}";
+    return _scale_cache_root() / f"{key}-admin-dist.tar.gz";
 }
 
 
@@ -588,7 +695,7 @@ def download_admin_dist(channel: str, version: str = "") -> bytes | None {
         return _fetch_verified_asset(
             dist_url,
             checksum_url,
-            _admin_dist_cache_path(channel),
+            _admin_dist_cache_path(channel, version),
             f"{channel} admin console"
         );
     } except Exception as e {

--- a/jac/jaclang/scale/injector/binary_injector.jac
+++ b/jac/jaclang/scale/injector/binary_injector.jac
@@ -1,10 +1,10 @@
 import logging;
 import from jaclang.scale.injector.pvc_injector { PvcInjector, bundle_pvc_path }
 import from jaclang.scale.injector.binary {
-    download_release_binary,
     node_arch,
     pack_binary_bytes,
     resolve_deploy_version,
+    resolve_toolchain,
     stage_admin_dist,
     toolchain_object_key
 }
@@ -18,15 +18,14 @@ glob logger = logging.getLogger(__name__),
 obj BinaryInjector(PvcInjector) {
     has channel: Channel = Channel.STABLE,
         _toolchain_object_key: str = "",
-        _toolchain_bytes: bytes = b"",
-        _pod_binary_bytes: bytes = b"";
+        _toolchain_bytes: bytes = b"";
 
     def prepare(app_name: str, namespace: str, project_dir: str) {
         version = resolve_deploy_version(project_dir, self.channel.value);
         stage_admin_dist(project_dir, self.channel.value, version);
 
-        payload = download_release_binary(self.channel.value, node_arch(), version);
-        self._pod_binary_bytes = payload;
+        self._toolchain = resolve_toolchain(self.channel.value, version);
+        payload = self._toolchain.ship_bytes(node_arch());
         super.prepare(app_name, namespace, project_dir);
         raw = pack_binary_bytes(payload);
         self._toolchain_object_key = toolchain_object_key(
@@ -55,12 +54,15 @@ def select_injector(
     namespace: str,
     project_dir: str,
     provisioned_database: str = "",
-    dry_run: bool = False
+    dry_run: bool = False,
+    channel_override: str = ""
 ) -> tuple[PvcInjector, str] {
     import from jaclang.cli.console { console }
     import from jaclang.scale.config.dev_config { resolve_dev_channel }
 
-    channel = resolve_dev_channel(project_dir);
+    channel = Channel(channel_override)
+        if channel_override
+        else resolve_dev_channel(project_dir);
     blurbs = {
         Channel.LOCAL: "shipping the local jac binary",
         Channel.DEV: "downloading the rolling `dev` (main HEAD) jac binary",

--- a/jac/jaclang/scale/injector/bundle.jac
+++ b/jac/jaclang/scale/injector/bundle.jac
@@ -1,7 +1,9 @@
 import io;
 import os;
+import errno;
 import gzip;
 import hashlib;
+import json;
 import logging;
 import shutil;
 import subprocess;
@@ -9,13 +11,13 @@ import tarfile;
 import tempfile;
 import tomllib;
 import from pathlib { Path }
+import from jaclang.scale.injector.binary { ResolvedToolchain, host_platform }
 
 glob logger = logging.getLogger(__name__);
 
 glob APP_VOLUME_NAME: str = "jac-app",
      APP_MOUNT_PATH: str = "/app",
-     JAC_HOME: str = "/app/.jachome",
-     TOOLCHAIN_SUBDIR: str = ".jactoolchain";
+     JAC_HOME: str = "/app/.jachome";
 
 glob _EXCLUDE_DIRS: set[str] = {
          ".jac",
@@ -186,7 +188,68 @@ def open_det_tar(buf: io.BytesIO) -> tuple[tarfile.TarFile, any] {
 }
 
 
-def _precompile_app(base: Path, pod_binary: bytes) -> Path {
+def _write_run_shim(dir_: Path, module: str) -> Path {
+    shim = dir_ / ("__" + module.split(".")[-1] + "_shim.jac");
+    shim.write_text(
+        "import from " + module + " { main }\n\nwith entry { main(); }\n",
+        encoding="utf-8"
+    );
+    return shim;
+}
+
+
+def _run_toolchain_script(
+    toolchain: ResolvedToolchain,
+    workdir: Path,
+    module: str,
+    args: list[str],
+    timeout: int,
+    what: str
+) -> any {
+    import time;
+    exec_bin = toolchain.exec_path();
+    shim = _write_run_shim(workdir, module);
+    try {
+        for attempt in range(3) {
+            try {
+                result = subprocess.run(
+                    [str(exec_bin), "run", str(shim)] + args,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout
+                );
+            } except OSError as e {
+                if e?.errno == errno.ENOEXEC {
+                    raise RuntimeError(
+                        f"The driver host ({host_platform()}) cannot execute "
+                        f"the jac binary at {exec_bin} for the {what}. Point "
+                        f"JAC_SCALE_BINARY_PATH at a binary built for this "
+                        f"host; the pod binary is downloaded separately for "
+                        f"the cluster's arch."
+                    );
+                }
+                raise;
+            }
+
+            transient = result.returncode != 0
+                and "runtime bring-up failed" in (result.stderr or "");
+            if not transient or attempt == 2 {
+                return result;
+            }
+            logger.warning(
+                f"jac launcher bring-up transiently failed during the {what} "
+                f"(attempt {attempt + 1}); retrying: "
+                f"{(result.stderr or '').strip()[-200:]}"
+            );
+            time.sleep(0.5 * (attempt + 1));
+        }
+    } finally {
+        shim.unlink(missing_ok=True);
+    }
+}
+
+
+def _precompile_app(base: Path, toolchain: ResolvedToolchain) -> Path {
     stage_root = Path(tempfile.mkdtemp(prefix="jac-app-precompile-"));
     stage = stage_root / "app";
     try {
@@ -203,20 +266,15 @@ def _precompile_app(base: Path, pod_binary: bytes) -> Path {
         if not marker.exists() {
             marker.write_text("");
         }
-        jac_path = stage_root / ".pod-jac";
-        jac_path.write_bytes(pod_binary);
-        jac_path.chmod(0o755);
-        script = Path(str(__file__)).parent.parent.parent
-            / "utils"
-            / "precompile_bytecode.jac";
 
-        result = subprocess.run(
-            [str(jac_path), "run", str(script), str(stage_root), "--seal"],
-            capture_output=True,
-            text=True,
-            timeout=600
+        result = _run_toolchain_script(
+            toolchain,
+            stage_root,
+            "jaclang.utils.precompile_bytecode",
+            [str(stage_root), "--seal"],
+            600,
+            "app seal"
         );
-        jac_path.unlink();
         if (
             result.returncode != 0
             or not (stage / "_precompiled" / "MANIFEST.json").is_file()
@@ -260,29 +318,44 @@ def fat_bundle_enabled(project_dir: str) -> bool {
 }
 
 
-def _vendor_stage(stage: Path, sanitized_toml: (str | None), pod_binary: bytes) {
+def _vendor_stage(
+    stage: Path, sanitized_toml: (str | None), toolchain: ResolvedToolchain
+) {
     if sanitized_toml is not None {
         (stage / "jac.toml").write_text(sanitized_toml, encoding="utf-8");
     }
-    jac_path = stage.parent / ".pod-jac";
-    jac_path.write_bytes(pod_binary);
-    jac_path.chmod(0o755);
-    script = Path(str(__file__)).parent.parent / "utils" / "vendor_wheels.jac";
-    try {
-        result = subprocess.run(
-            [str(jac_path), "run", str(script), str(stage)],
-            capture_output=True,
-            text=True,
-            timeout=900
-        );
-    } finally {
-        jac_path.unlink(missing_ok=True);
+    cross = toolchain.ship_platform != ""
+        and toolchain.channel != "local"
+        and toolchain.ship_platform != host_platform();
+    args = [str(stage)];
+    if cross {
+        args.append(f"--platform={toolchain.ship_platform}");
     }
-    if (result.returncode != 0 or not (stage / "_vendor" / "VENDOR.json").is_file()) {
+    result = _run_toolchain_script(
+        toolchain,
+        stage.parent,
+        "jaclang.scale.utils.vendor_wheels",
+        args,
+        900,
+        "fat-bundle vendoring"
+    );
+    manifest = stage / "_vendor" / "VENDOR.json";
+    if result.returncode != 0 or not manifest.is_file() {
         raise RuntimeError(
             f"Fat bundle vendoring failed, so the deploy cannot ship offline "
             f"deps: {(result.stderr or result.stdout).strip()[-300:]}"
         );
+    }
+    if cross {
+        stamped = str(json.loads(manifest.read_text()).get("platform_tag", ""));
+        if stamped != toolchain.ship_platform {
+            raise RuntimeError(
+                f"The {toolchain.version or toolchain.channel} jac vendorer "
+                f"resolved wheels for {stamped or 'the driver host'} instead of "
+                f"the pod platform {toolchain.ship_platform}; that jac version "
+                f"cannot cross-vendor from this host."
+            );
+        }
     }
 
     for line in f"{result.stdout}\n{result.stderr}".splitlines() {
@@ -293,21 +366,24 @@ def _vendor_stage(stage: Path, sanitized_toml: (str | None), pod_binary: bytes) 
 }
 
 
-def pack_jab(project_dir: str, provisioned_database: str, pod_binary: bytes) -> bytes {
-    if not pod_binary {
+def pack_jab(
+    project_dir: str, provisioned_database: str, toolchain: (ResolvedToolchain | None)
+) -> bytes {
+    if toolchain is None {
         raise ValueError(
-            "pack_jab requires the pod binary to seal the app image; none given."
+            "pack_jab requires a resolved toolchain to seal the app image; "
+            "none given."
         );
     }
     base = Path(project_dir).resolve();
-    staged = _precompile_app(base, pod_binary);
+    staged = _precompile_app(base, toolchain);
 
     try {
         sanitized = sanitized_jac_toml(base, provisioned_database);
         (fat, fat_explicit) = fat_bundle_setting(project_dir);
         if fat {
             try {
-                _vendor_stage(staged, sanitized, pod_binary);
+                _vendor_stage(staged, sanitized, toolchain);
             } except Exception as exc {
                 if fat_explicit {
                     raise;

--- a/jac/jaclang/scale/injector/pvc_injector.jac
+++ b/jac/jaclang/scale/injector/pvc_injector.jac
@@ -1,6 +1,7 @@
 import os;
 import logging;
 import from jaclang.scale.injector.injector { Injector }
+import from jaclang.scale.injector.binary { ResolvedToolchain }
 import from jaclang.scale.injector.bundle {
     pack_jab,
     content_address,
@@ -178,7 +179,8 @@ obj PvcInjector(Injector) {
         loader_image: str = "busybox:1.36",
         provisioned_database: str = "",
         _object_key: str = "",
-        _bundle_bytes: bytes = b"";
+        _bundle_bytes: bytes = b"",
+        _toolchain: (ResolvedToolchain | None) = None;
 
     def _seed_artifacts -> list[tuple[str, bytes]] {
         return [(self._object_key, self._bundle_bytes)];
@@ -189,11 +191,7 @@ obj PvcInjector(Injector) {
     }
 
     def prepare(app_name: str, namespace: str, project_dir: str) {
-        raw = pack_jab(
-            project_dir,
-            self.provisioned_database,
-            getattr(self, "_pod_binary_bytes", b"")
-        );
+        raw = pack_jab(project_dir, self.provisioned_database, self._toolchain);
         digest = content_address(raw);
         self._object_key = bundle_object_key(app_name, digest);
         self._bundle_bytes = raw;

--- a/jac/jaclang/scale/tests/deploy/test_dry_run_purity.jac
+++ b/jac/jaclang/scale/tests/deploy/test_dry_run_purity.jac
@@ -160,7 +160,7 @@ test "--dry-run reads no cluster state, downloads nothing, and builds nothing" {
         ), unittest.mock.patch(
             "jaclang.scale.injector.binary_injector.node_arch"
         ) as mock_cluster, unittest.mock.patch(
-            "jaclang.scale.injector.binary_injector.download_release_binary"
+            "jaclang.scale.injector.binary_injector.resolve_toolchain"
         ) as mock_download, unittest.mock.patch(
             "jaclang.scale.injector.binary_injector.stage_admin_dist"
         ) as mock_console, unittest.mock.patch(
@@ -185,7 +185,7 @@ test "selecting an injector for a dry run neither downloads nor probes the clust
         with unittest.mock.patch(
             "jaclang.scale.injector.binary_injector.node_arch"
         ) as mock_arch, unittest.mock.patch(
-            "jaclang.scale.injector.binary_injector.download_release_binary"
+            "jaclang.scale.injector.binary_injector.resolve_toolchain"
         ) as mock_download, unittest.mock.patch(
             "jaclang.scale.injector.binary_injector.stage_admin_dist"
         ) as mock_stage {

--- a/jac/jaclang/scale/tests/microservices/test_app_precompile.jac
+++ b/jac/jaclang/scale/tests/microservices/test_app_precompile.jac
@@ -3,6 +3,7 @@ import os;
 import tarfile;
 import tempfile;
 import from pathlib { Path }
+import from jaclang.scale.injector.binary { ResolvedToolchain }
 import from jaclang.scale.injector.bundle { pack_jab }
 
 
@@ -22,10 +23,15 @@ def _names(raw: bytes) -> list[str] {
 }
 
 
-test "pack_jab without a pod binary is a hard error (a .jab requires a seal)" {
+def _local_toolchain(binary_path: str) -> ResolvedToolchain {
+    return ResolvedToolchain(channel="local", local_path=binary_path);
+}
+
+
+test "pack_jab without a toolchain is a hard error (a .jab requires a seal)" {
     caught = False;
     try {
-        pack_jab(_mini_app(), "", b"");
+        pack_jab(_mini_app(), "", None);
     } except ValueError {
         caught = True;
     }
@@ -33,26 +39,33 @@ test "pack_jab without a pod binary is a hard error (a .jab requires a seal)" {
 }
 
 
-test "an unrunnable pod binary fails the seal instead of shipping unsealed" {
+test "an unrunnable toolchain binary fails the seal instead of shipping unsealed" {
+    with tempfile.NamedTemporaryFile(suffix="-jac", delete=False) as tmp {
+        tmp.write(b"not-an-elf");
+        bogus = tmp.name;
+    }
+    os.chmod(bogus, 0o755);
     caught = False;
     try {
-        pack_jab(_mini_app(), "", b"not-an-elf");
+        pack_jab(_mini_app(), "", _local_toolchain(bogus));
     } except Exception {
         caught = True;
+    } finally {
+        os.unlink(bogus);
     }
     assert caught;
 }
 
 
-test "a real pod binary seals the app into a .jab (source + _precompiled + manifest)" {
-    # The checkout's own binary stands in for the downloaded pod binary; the
-    # mechanism (stage -> precompile_bytecode.jac --seal -> pack _precompiled/**)
-    # is identical for release binaries.
+test "a real toolchain binary seals the app into a .jab (source + _precompiled + manifest)" {
+    # The checkout's own binary stands in for the downloaded toolchain binary;
+    # the mechanism (stage -> shim-import its own sealer --seal -> pack
+    # _precompiled/**) is identical for release binaries.
     jac_bin = Path(__file__).parents[4] / "zig-out" / "bin" / "jac";
     if not jac_bin.is_file() {
         return;
     }
-    names = _names(pack_jab(_mini_app(), "", jac_bin.read_bytes()));
+    names = _names(pack_jab(_mini_app(), "", _local_toolchain(str(jac_bin))));
     assert "svc.jac" in names;
     # The sealed manifest sits at the tar root, which is what makes this a .jab.
     assert "_precompiled/MANIFEST.json" in names;
@@ -62,4 +75,6 @@ test "a real pod binary seals the app into a .jab (source + _precompiled + manif
         if n.startswith("_precompiled/")
     ];
     assert any([n.endswith("svc.jir") for n in pre]) , pre;
+    # The seal shim never leaks into the packed bundle.
+    assert not any(["_shim.jac" in n for n in names]) , names;
 }

--- a/jac/jaclang/scale/tests/microservices/test_binary_cache.jac
+++ b/jac/jaclang/scale/tests/microservices/test_binary_cache.jac
@@ -26,7 +26,7 @@ test "an unchanged release is served from the local cache, not re-downloaded" {
     os.environ["JAC_SCALE_CACHE_DIR"] = cache_dir;
     binmod._http_get_bytes = _fake_http;
     try {
-        assert binmod.download_release_binary("dev", "x86_64") == _payload;
+        assert binmod.download_release_binary("dev", "linux-x86_64") == _payload;
         assert len(
             [
                 c
@@ -35,7 +35,7 @@ test "an unchanged release is served from the local cache, not re-downloaded" {
             ]
         )
             == 1;
-        assert binmod.download_release_binary("dev", "x86_64") == _payload;
+        assert binmod.download_release_binary("dev", "linux-x86_64") == _payload;
         # Round two fetched only the tiny checksum; the binary came from cache.
         assert len(
             [

--- a/jac/jaclang/scale/tests/microservices/test_binary_injector.jac
+++ b/jac/jaclang/scale/tests/microservices/test_binary_injector.jac
@@ -22,11 +22,14 @@ import from jaclang.scale.injector.binary {
     cluster_node_archs,
     node_arch,
     download_release_binary,
-    stage_admin_dist
+    host_platform,
+    resolve_toolchain,
+    stage_admin_dist,
+    ResolvedToolchain,
+    TOOLCHAIN_SUBDIR
 }
 import from jaclang.runtimelib.utils { host_arch }
 import from jaclang.scale.injector.binary_injector { BinaryInjector }
-import from jaclang.scale.injector.bundle { TOOLCHAIN_SUBDIR }
 import from jaclang.scale.deploy.target.kubernetes.runtime_bootstrap {
     build_runtime_install_commands,
     runtime_container_env,
@@ -111,7 +114,8 @@ test "LOCAL channel ships the binary at JAC_SCALE_BINARY_PATH, no download" {
     saved = os.environ.get(BINARY_PATH_ENV);
     try {
         os.environ[BINARY_PATH_ENV] = tmp_path;
-        assert download_release_binary("local", node_arch()) == b"ELF-local-binary";
+        assert download_release_binary("local", f"linux-{node_arch()}")
+            == b"ELF-local-binary";
     } finally {
         os.environ.pop(BINARY_PATH_ENV, None);
         if saved is not None {
@@ -126,7 +130,7 @@ test "LOCAL channel without JAC_SCALE_BINARY_PATH is a loud error" {
     saved = os.environ.pop(BINARY_PATH_ENV, None);
     caught = False;
     try {
-        download_release_binary("local", node_arch());
+        download_release_binary("local", f"linux-{node_arch()}");
     } except RuntimeError {
         caught = True;
     } finally {
@@ -135,6 +139,84 @@ test "LOCAL channel without JAC_SCALE_BINARY_PATH is a loud error" {
         }
     }
     assert caught;
+}
+
+
+test "host_platform names the driver like a release asset (os-arch)" {
+    hp = host_platform();
+    assert hp in (f"linux-{host_arch()}", f"macos-{host_arch()}") , hp;
+}
+
+
+test "local toolchain: exec_path IS the local binary; ship reads its bytes" {
+    with tempfile.NamedTemporaryFile(suffix="-jac", delete=False) as tmp {
+        tmp.write(b"ELF-local-binary");
+        tmp_path = tmp.name;
+    }
+    saved = os.environ.get(BINARY_PATH_ENV);
+    try {
+        os.environ[BINARY_PATH_ENV] = tmp_path;
+        tc = resolve_toolchain(Channel.LOCAL.value);
+        # The seal execs the operator's own binary in place: no copy, no cache.
+        assert str(tc.exec_path()) == tmp_path;
+        assert tc.ship_bytes(node_arch()) == b"ELF-local-binary";
+        assert tc.ship_platform == f"linux-{node_arch()}";
+    } finally {
+        os.environ.pop(BINARY_PATH_ENV, None);
+        if saved is not None {
+            os.environ[BINARY_PATH_ENV] = saved;
+        }
+        os.unlink(tmp_path);
+    }
+}
+
+
+test "local toolchain without JAC_SCALE_BINARY_PATH is a loud error" {
+    saved = os.environ.pop(BINARY_PATH_ENV, None);
+    caught = False;
+    try {
+        resolve_toolchain(Channel.LOCAL.value);
+    } except RuntimeError {
+        caught = True;
+    } finally {
+        if saved is not None {
+            os.environ[BINARY_PATH_ENV] = saved;
+        }
+    }
+    assert caught;
+}
+
+
+test "stable resolve pins the latest release version exactly once" {
+    payload = json.dumps({"tag_name": "v9.9.9"}).encode();
+    saved = binary_mod._http_get_bytes;
+    binary_mod._http_get_bytes = functools.partial(_payload_response, payload);
+    try {
+        tc = resolve_toolchain(Channel.STABLE.value);
+        # Both the seal (exec) and ship binaries resolve from this single pin,
+        # so a release landing mid-deploy can never skew them apart.
+        assert tc.version == "9.9.9";
+        assert resolve_toolchain(Channel.STABLE.value, "1.2.3").version == "1.2.3";
+    } finally {
+        binary_mod._http_get_bytes = saved;
+    }
+}
+
+
+test "experimental resolves to the dev toolchain (pods run the PR image)" {
+    assert resolve_toolchain(Channel.EXPERIMENTAL.value).channel == "dev";
+    assert resolve_toolchain(Channel.DEV.value).version == "";
+}
+
+
+test "the binary cache is keyed by version when known, channel otherwise" {
+    assert binary_mod._binary_cache_path("stable", "linux-x86_64", "1.2.3").name
+        == "jac-1.2.3-linux-x86_64";
+    assert binary_mod._binary_cache_path("dev", "macos-aarch64").name
+        == "jac-dev-macos-aarch64";
+    assert binary_mod._admin_dist_cache_path("stable", "1.2.3").name
+        == "jac-1.2.3-admin-dist.tar.gz";
+    assert binary_mod._admin_dist_cache_path("dev").name == "jac-dev-admin-dist.tar.gz";
 }
 
 

--- a/jac/jaclang/scale/tests/microservices/test_fat_bundle.jac
+++ b/jac/jaclang/scale/tests/microservices/test_fat_bundle.jac
@@ -3,6 +3,7 @@ import tarfile;
 import tempfile;
 import json;
 import from pathlib { Path }
+import from jaclang.scale.injector.binary { ResolvedToolchain }
 import from jaclang.scale.injector.bundle {
     content_address,
     fat_bundle_enabled,
@@ -19,14 +20,14 @@ def _app(toml: str) -> str {
 }
 
 
-def _pod_binary -> bytes | None {
-    # The checkout's own binary stands in for the downloaded pod binary, same
+def _pod_binary -> ResolvedToolchain | None {
+    # The checkout's own binary stands in for the downloaded toolchain, same
     # as test_app_precompile; skip when the toolchain has not been built.
     jac_bin = Path(__file__).parents[4] / "zig-out" / "bin" / "jac";
     if not jac_bin.is_file() {
         return None;
     }
-    return jac_bin.read_bytes();
+    return ResolvedToolchain(channel="local", local_path=str(jac_bin));
 }
 
 

--- a/jac/jaclang/scale/tests/microservices/test_pvc_injector.jac
+++ b/jac/jaclang/scale/tests/microservices/test_pvc_injector.jac
@@ -5,6 +5,7 @@ import tempfile;
 import tomllib;
 import from pathlib { Path }
 import from unittest.mock { patch }
+import from jaclang.scale.injector.binary { ResolvedToolchain }
 import from jaclang.scale.injector.bundle {
     bake_database_intent,
     sanitized_jac_toml,
@@ -64,7 +65,9 @@ test "secrets are stripped and secret-bearing files excluded from the sealed .ja
                     + "# s3 access creds\n[scale.secrets]\napi_key = \"shhhh\"\n"
             );
         }
-        raw = pack_jab(project, "", _JAC_BIN.read_bytes());
+        raw = pack_jab(
+            project, "", ResolvedToolchain(channel="local", local_path=str(_JAC_BIN))
+        );
         names: list[str] = [];
         toml_text = "";
         with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tar {

--- a/jac/jaclang/scale/tests/microservices/test_seed_determinism.jac
+++ b/jac/jaclang/scale/tests/microservices/test_seed_determinism.jac
@@ -2,7 +2,7 @@ import os;
 import tempfile;
 import from pathlib { Path }
 import from jaclang.scale.injector.bundle { pack_jab, content_address }
-import from jaclang.scale.injector.binary { pack_binary_bytes }
+import from jaclang.scale.injector.binary { ResolvedToolchain, pack_binary_bytes }
 
 
 glob _JAC_BIN: Path = Path(__file__).parents[4] / "zig-out" / "bin" / "jac";
@@ -16,15 +16,15 @@ test "identical content packs to identical bytes (content-address stable)" {
     if not _JAC_BIN.is_file() {
         return;
     }
-    binary = _JAC_BIN.read_bytes();
+    toolchain = ResolvedToolchain(channel="local", local_path=str(_JAC_BIN));
     d = tempfile.mkdtemp();
     src = Path(d, "svc.jac");
     src.write_text("with entry { print(\"ok\"); }");
-    first = pack_jab(d, "", binary);
+    first = pack_jab(d, "", toolchain);
     # A different mtime on the same content must not change the digest.
     os.utime(str(src), (0, 0));
     try {
-        assert content_address(pack_jab(d, "", binary)) == content_address(first);
+        assert content_address(pack_jab(d, "", toolchain)) == content_address(first);
     } finally {
         import shutil;
         shutil.rmtree(d, ignore_errors=True);

--- a/jac/jaclang/scale/utils/vendor_wheels.jac
+++ b/jac/jaclang/scale/utils/vendor_wheels.jac
@@ -12,9 +12,23 @@ import from jaclang.runtimelib.jab_vendor {
 }
 
 
+def _pip_platform_tags(jac_platform: str) -> list[str] {
+    if not jac_platform.startswith("linux-") {
+        return [];
+    }
+    arch = jac_platform.split("-", 1)[1];
+    return [
+        f"manylinux_2_28_{arch}",
+        f"manylinux_2_17_{arch}",
+        f"manylinux2014_{arch}"
+    ];
+}
+
+
 obj WheelVendor {
     has config: JacConfig,
-        app_dir: Path;
+        app_dir: Path,
+        target_platform: str = "";
 
     def resolve_specs -> list[str] {
         plan = resolve_plan(self.config, include_dev=False);
@@ -43,33 +57,55 @@ obj WheelVendor {
     def run {
         specs = self.resolve_specs();
         if specs {
-            (ok, err) = download_wheels(specs, wheels_dir(self.app_dir));
+            (ok, err) = download_wheels(
+                specs,
+                wheels_dir(self.app_dir),
+                platform_tags=_pip_platform_tags(self.target_platform)
+            );
             if not ok {
                 console.error(f"Wheel download failed:\n{err}");
                 sys.exit(1);
             }
         }
-        write_vendor_manifest(self.app_dir, specs, python_tag=python_tag());
+        write_vendor_manifest(
+            self.app_dir,
+            specs,
+            python_tag=python_tag(),
+            platform_tag=self.target_platform
+        );
         wd = wheels_dir(self.app_dir);
         count = len(list(wd.glob("*.whl"))) if wd.is_dir() else 0;
-        console.print(f"  Vendored {count} wheel(s) for {len(specs)} spec(s).");
+        target = self.target_platform or "the vendoring host";
+        console.print(
+            f"  Vendored {count} wheel(s) for {len(specs)} spec(s) ({target})."
+        );
     }
 }
 
 
 def main {
-    args = sys.argv[1:];
-    if not args {
-        console.error("usage: jac run vendor_wheels.jac <app_dir>");
+    plat = "";
+    rest: list[str] = [];
+    for a in sys.argv[1:] {
+        if a.startswith("--platform=") {
+            plat = a.split("=", 1)[1];
+        } else {
+            rest.append(a);
+        }
+    }
+    if not rest {
+        console.error(
+            "usage: jac run vendor_wheels.jac <app_dir> [--platform=<os-arch>]"
+        );
         sys.exit(2);
     }
-    app_dir = Path(args[0]).resolve();
+    app_dir = Path(rest[0]).resolve();
     config = get_config_for_path(app_dir);
     if config is None {
         console.error(f"No jac.toml under {app_dir}; nothing to vendor.");
         sys.exit(1);
     } else {
-        WheelVendor(config=config, app_dir=app_dir).run();
+        WheelVendor(config=config, app_dir=app_dir, target_platform=plat).run();
     }
 }
 

--- a/jac/launcher/launcher.zig
+++ b/jac/launcher/launcher.zig
@@ -59,6 +59,14 @@ fn die(comptime msg: []const u8) noreturn {
     std.process.exit(70); // EX_SOFTWARE
 }
 
+fn dieBringup(e: anyerror) noreturn {
+    std.debug.print(
+        "jac (launcher): runtime bring-up failed: {s}\n",
+        .{@errorName(e)},
+    );
+    std.process.exit(70); // EX_SOFTWARE
+}
+
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
     const env = init.environ_map;
@@ -138,7 +146,7 @@ pub fn main(init: std.process.Init) !void {
         @intCast(std.c.getuid()),
         @intCast(std.c.getpid()),
         &rt_buf,
-    ) catch die("runtime bring-up failed (payload not materialized?)");
+    ) catch |e| dieBringup(e);
 
     std.process.exit(boot(&emb, exe_z, init));
 }
@@ -320,7 +328,7 @@ fn runNinja(init: std.process.Init, exe_path: []const u8, exe_z: [*:0]const u8, 
         @intCast(std.c.getuid()),
         @intCast(std.c.getpid()),
         &rt_buf,
-    ) catch die("runtime bring-up failed (payload not materialized?)");
+    ) catch |e| dieBringup(e);
 
     // Environment for the editor + its children. JAC_BIN is what init.lua uses
     // to spawn `jac lsp` -- the same binary, so editor+parser+LSP stay one file.


### PR DESCRIPTION
## Summary

Clean break of the deploy toolchain plumbing so a driver on any platform can deploy any pinned jac version. Fixes #7810 and lands the platform-generality half of #7724 (P0 version-addressable exec/ship resolution, P2 per-deploy pinning hook).

### ResolvedToolchain: exec vs ship
`injector/binary.jac` gains one value object resolved per deploy that separates the binary that PERFORMS the seal/vendor (`exec_path()`, driver platform, served from the verified cache and exec'd in place) from the binary PODS BOOT (`ship_bytes(arch)`, `linux-<node-arch>`). On an all-linux deploy both resolve to the same cached file, so the common path is behavior-identical. On a macOS driver or a cross-arch builder pod (x86_64 builder deploying to arm64 nodes) they differ and the deploy works instead of dying on `[Errno 8] Exec format error`. This retires the 'drive the deploy from a linux container' constraint documented in #7724's kind runbook.

### Self-versioned seal and vendor scripts (#7810)
`_precompile_app` / `_vendor_stage` no longer donate the driver's `precompile_bytecode.jac` / `vendor_wheels.jac` to the pinned binary. A generated 3-line shim (`import from jaclang.utils.precompile_bytecode { main } with entry { main(); }`) makes the pinned binary import the sealer from its OWN payload, so the script version always matches the runtime pods boot. The cross-version contract shrinks from 'every internal API the script touches' to 'module path + argv', which holds for 0.34/0.35. This is exactly the fix experiment B in #7810 validated. The `.pod-jac` write/chmod/unlink temp dance is deleted from both sites.

### Version-keyed binary cache
`scale-binaries` entries are now keyed `jac-<version>-<platform>`; a stable deploy with no pin resolves the latest tag ONCE per deploy and threads that version to both exec and ship downloads, so 'stable' no longer silently mutates under a long-running builder and exec/ship can never skew across a mid-deploy release. Admin-dist caching is version-keyed the same way when pinned.

### Cross-platform fat bundles
`vendor_wheels.jac` accepts `--platform=<os-arch>` and resolves manylinux wheels for the pod platform when the driver host is not the ship platform (`pip download --platform manylinux_2_28/_2_17/2014 --only-binary=:all:`). `_vendor_stage` verifies the VENDOR.json platform stamp, so an older pinned vendorer that silently ignores the flag falls back to a thin bundle instead of shipping wrong-platform wheels.

### Per-deploy channel override
`select_injector(..., channel_override=...)` lets embedders (jacBuilder's threaded deploy manager) pin the channel per deploy instead of racing on process-global `JAC_SCALE_BINARY_PATH`.

### Honest errors + launcher hardening
- ENOEXEC on the seal subprocess now reports 'the driver host cannot execute the jac binary' instead of the misleading check-github-network hint.
- `launcher.zig` reports the actual bring-up error name (`dieBringup`) instead of the catch-all 'payload not materialized?'. This is how the next item was found at all.
- Found while testing: concurrent same-binary launches can transiently fail the launcher's `cacheRoot` probe with `NoWritableCacheDir` (load-dependent, ~50% repro rate with 18 pytest workers sharing one exec path on macOS; never narrated before the error-name change). The seal/vendor runner now retries twice with backoff. The underlying `dirWritable` race deserves its own launcher issue; I will file it separately.

## Testing
- `test_app_precompile` (real end-to-end shim seal), `test_fat_bundle` (6 consecutive green parallel runs, previously ~50% flaky via the launcher race), `test_seed_determinism`, `test_pvc_injector`, `test_binary_cache` all pass.
- `test_binary_injector`: 38 passed plus the pre-existing 7 local failures from the missing `kubernetes` package (identical set on main).
- New tests: local-toolchain exec/ship identity, stable resolve-once pinning, experimental-to-dev mapping, version-keyed cache paths, host_platform naming, shim never leaks into the packed .jab.

## Follow-ups
- CI invariant job: seal one fixture on macos-aarch64 and linux-x86_64, assert identical content_address (guards the bytecode-is-platform-independent assumption at fixed CPython minor).
- Launcher issue for the `NoWritableCacheDir` concurrency race in `dirWritable`.
- jacBuilder-side adoption: replace its five binary-resolution ladders with `resolve_toolchain`/`ResolvedToolchain` and pass `channel_override` per deploy.