### PR TITLE
refactor(compiler): shared intent pipeline + esast hooks

### DIFF
--- a/jac/jaclang/compiler/passes/compose/kotlin_ast.jac
+++ b/jac/jaclang/compiler/passes/compose/kotlin_ast.jac
@@ -1,0 +1,251 @@
+import from typing { TypeAlias }
+import from typing { Literal as TypingLiteral }
+
+obj KtNode {
+    has `type: str;
+}
+
+obj KtIdentifier(KtNode) {
+    has name: str = "",
+        `type: TypingLiteral["KtIdentifier"] = "KtIdentifier";
+}
+
+obj KtLiteral(KtNode) {
+    has value: str | bool | None | int | float = None,
+        `type: TypingLiteral["KtLiteral"] = "KtLiteral";
+}
+
+obj KtStringTemplate(KtNode) {
+    has parts: list[str | KtNode] = [],
+        `type: TypingLiteral["KtStringTemplate"] = "KtStringTemplate";
+}
+
+obj KtThis(KtNode) {
+    has `type: TypingLiteral["KtThis"] = "KtThis";
+}
+
+obj KtMemberAccess(KtNode) {
+    has object: (KtNode | None) = None,
+        property: (KtNode | None) = None,
+        computed: bool = False,
+        safe: bool = False,
+        `type: TypingLiteral["KtMemberAccess"] = "KtMemberAccess";
+}
+
+obj KtNamedArg {
+    has name: str = "",
+        value: (KtNode | None) = None;
+}
+
+obj KtLambda(KtNode) {
+    has params: list[str] = [],
+        body: list[KtNode] = [],
+        expression_body: (KtNode | None) = None,
+        label: (str | None) = None,
+        `type: TypingLiteral["KtLambda"] = "KtLambda";
+}
+
+obj KtCall(KtNode) {
+    has callee: (KtNode | None) = None,
+        args: list[KtNode] = [],
+        named_args: list[KtNamedArg] = [],
+        trailing_lambda: (KtLambda | None) = None,
+        safe: bool = False,
+        `type: TypingLiteral["KtCall"] = "KtCall";
+}
+
+obj KtBinary(KtNode) {
+    has operator: str = "",
+        left: (KtNode | None) = None,
+        right: (KtNode | None) = None,
+        infix_fun: bool = False,
+        `type: TypingLiteral["KtBinary"] = "KtBinary";
+}
+
+obj KtUnary(KtNode) {
+    has operator: str = "",
+        argument: (KtNode | None) = None,
+        prefix: bool = True,
+        `type: TypingLiteral["KtUnary"] = "KtUnary";
+}
+
+obj KtConditional(KtNode) {
+    has `test: (KtNode | None) = None,
+        consequent: (KtNode | None) = None,
+        alternate: (KtNode | None) = None,
+        `type: TypingLiteral["KtConditional"] = "KtConditional";
+}
+
+obj KtAssignment(KtNode) {
+    has operator: str = "=",
+        left: (KtNode | None) = None,
+        right: (KtNode | None) = None,
+        `type: TypingLiteral["KtAssignment"] = "KtAssignment";
+}
+
+obj KtListLiteral(KtNode) {
+    has elements: list[KtNode] = [],
+        `type: TypingLiteral["KtListLiteral"] = "KtListLiteral";
+}
+
+obj KtMapLiteral(KtNode) {
+    has entries: list[(KtNode, KtNode)] = [],
+        `type: TypingLiteral["KtMapLiteral"] = "KtMapLiteral";
+}
+
+obj KtSpread(KtNode) {
+    has argument: (KtNode | None) = None,
+        `type: TypingLiteral["KtSpread"] = "KtSpread";
+}
+
+obj KtRaw(KtNode) {
+    has code: str = "",
+        `type: TypingLiteral["KtRaw"] = "KtRaw";
+}
+
+obj KtExprStmt(KtNode) {
+    has expression: (KtNode | None) = None,
+        `type: TypingLiteral["KtExprStmt"] = "KtExprStmt";
+}
+
+obj KtBlock(KtNode) {
+    has body: list[KtNode] = [],
+        `type: TypingLiteral["KtBlock"] = "KtBlock";
+}
+
+obj KtProperty(KtNode) {
+    has name: str = "",
+        mutable: bool = False,
+        `init: (KtNode | None) = None,
+        type_ann: (str | None) = None,
+        delegate: (KtNode | None) = None,
+        annotations: list[str] = [],
+        `type: TypingLiteral["KtProperty"] = "KtProperty";
+}
+
+obj KtIf(KtNode) {
+    has `test: (KtNode | None) = None,
+        consequent: list[KtNode] = [],
+        alternate: list[KtNode] = [],
+        `type: TypingLiteral["KtIf"] = "KtIf";
+}
+
+obj KtFor(KtNode) {
+    has variable: str = "",
+        iterable: (KtNode | None) = None,
+        body: list[KtNode] = [],
+        `type: TypingLiteral["KtFor"] = "KtFor";
+}
+
+obj KtWhile(KtNode) {
+    has `test: (KtNode | None) = None,
+        body: list[KtNode] = [],
+        `type: TypingLiteral["KtWhile"] = "KtWhile";
+}
+
+obj KtReturn(KtNode) {
+    has argument: (KtNode | None) = None,
+        label: (str | None) = None,
+        `type: TypingLiteral["KtReturn"] = "KtReturn";
+}
+
+obj KtTry(KtNode) {
+    has try_body: list[KtNode] = [],
+        catch_param: str = "e",
+        catch_type: str = "Exception",
+        catch_body: list[KtNode] = [],
+        finally_body: list[KtNode] = [],
+        `type: TypingLiteral["KtTry"] = "KtTry";
+}
+
+obj KtThrow(KtNode) {
+    has argument: (KtNode | None) = None,
+        `type: TypingLiteral["KtThrow"] = "KtThrow";
+}
+
+obj KtBreak(KtNode) {
+    has `type: TypingLiteral["KtBreak"] = "KtBreak";
+}
+
+obj KtContinue(KtNode) {
+    has `type: TypingLiteral["KtContinue"] = "KtContinue";
+}
+
+obj KtWhenEntry {
+    has `test: (KtNode | None) = None,
+        body: list[KtNode] = [];
+}
+
+obj KtWhen(KtNode) {
+    has subject: (KtNode | None) = None,
+        entries: list[KtWhenEntry] = [],
+        `type: TypingLiteral["KtWhen"] = "KtWhen";
+}
+
+obj KtParam {
+    has name: str = "",
+        type_ann: str = "",
+        default: (KtNode | None) = None;
+}
+
+obj KtFunction(KtNode) {
+    has name: str = "",
+        params: list[KtParam] = [],
+        return_type: (str | None) = None,
+        body: list[KtNode] = [],
+        annotations: list[str] = [],
+        modifiers: list[str] = [],
+        is_suspend: bool = False,
+        is_expression_body: bool = False,
+        expression_body: (KtNode | None) = None,
+        `type: TypingLiteral["KtFunction"] = "KtFunction";
+}
+
+obj KtClass(KtNode) {
+    has name: str = "",
+        kind: str = "class",
+        primary_params: list[KtParam] = [],
+        body: list[KtNode] = [],
+        annotations: list[str] = [],
+        modifiers: list[str] = [],
+        super_types: list[str] = [],
+        `type: TypingLiteral["KtClass"] = "KtClass";
+}
+
+obj KtObject(KtNode) {
+    has name: str = "",
+        body: list[KtNode] = [],
+        annotations: list[str] = [],
+        `type: TypingLiteral["KtObject"] = "KtObject";
+}
+
+obj KtImport(KtNode) {
+    has path: str = "",
+        alias: (str | None) = None,
+        `type: TypingLiteral["KtImport"] = "KtImport";
+}
+
+obj KtFile(KtNode) {
+    has package: str = "",
+        imports: list[KtImport] = [],
+        declarations: list[KtNode] = [],
+        `type: TypingLiteral["KtFile"] = "KtFile";
+}
+
+obj KtModifierCall {
+    has name: str = "",
+        args: list[KtNode] = [],
+        named_args: list[KtNamedArg] = [];
+}
+
+obj KtModifierChain(KtNode) {
+    has calls: list[KtModifierCall] = [],
+        `type: TypingLiteral["KtModifierChain"] = "KtModifierChain";
+}
+
+obj KtComposableCall(KtNode) {
+    has name: str = "",
+        args: list[KtNamedArg] = [],
+        content: list[KtNode] = [],
+        `type: TypingLiteral["KtComposableCall"] = "KtComposableCall";
+}

--- a/jac/jaclang/compiler/passes/ecmascript/backends/impl/react.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/backends/impl/react.impl.jac
@@ -6,6 +6,7 @@ import from jaclang.compiler.passes.ecmascript.reactive_intent {
     Effect,
     AsyncBoundary
 }
+import type from jaclang.compiler.passes.ecmascript.view_ir { ViewElement }
 
 impl ReactBackend.name -> str {
     return "react";
@@ -94,27 +95,26 @@ impl ReactBackend._jsx_fragment(children: list[es.Expression]) -> es.CallExpress
     );
 }
 
-impl ReactBackend.state_field_symbols(s: StateField) -> list[str] {
-    return ["useState"];
-}
-
-impl ReactBackend.ref_field_symbols(r: RefField) -> list[str] {
-    return ["useRef"];
-}
-
-impl ReactBackend.effect_symbols(e: Effect) -> list[str] {
-    return ["useEffect"];
-}
-
-impl ReactBackend.async_boundary_symbols(a: AsyncBoundary) -> list[str] {
-    syms = ["JacAwaiting"];
-    if a.except_exprs {
-        syms.append("JacClientErrorBoundary");
+impl ReactBackend.runtime_symbols(
+    intent: StateField | RefField | Effect | AsyncBoundary | ViewElement
+) -> list[str] {
+    if isinstance(intent, StateField) {
+        return ["useState"];
     }
-    return syms;
-}
+    if isinstance(intent, RefField) {
+        return ["useRef"];
+    }
+    if isinstance(intent, Effect) {
+        return ["useEffect"];
+    }
+    if isinstance(intent, AsyncBoundary) {
+        syms = ["JacAwaiting"];
+        if intent.except_exprs {
+            syms.append("JacClientErrorBoundary");
+        }
+        return syms;
+    }
 
-impl ReactBackend.view_runtime_symbols(view: ViewElement) -> list[str] {
     return [];
 }
 

--- a/jac/jaclang/compiler/passes/ecmascript/backends/impl/solid.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/backends/impl/solid.impl.jac
@@ -6,6 +6,7 @@ import from jaclang.compiler.passes.ecmascript.reactive_intent {
     Effect,
     AsyncBoundary
 }
+import from jaclang.compiler.passes.ecmascript.view_ir { ViewElement }
 
 impl SolidBackend.name -> str {
     return "solid";
@@ -308,32 +309,6 @@ impl SolidBackend._jsx_show(child: any, sync_loc: any) -> es.JsxElement {
     );
 }
 
-impl SolidBackend.view_runtime_symbols(view: ViewElement) -> list[str] {
-    import from jaclang.compiler.passes.ecmascript.view_ir {
-        ElementChild,
-        IfChild,
-        EachChild
-    }
-    syms = [];
-    stack = list(view.children);
-    while stack {
-        child = stack.pop();
-        if isinstance(child, EachChild) {
-            syms.append("For");
-            stack.extend(child.body);
-        } elif isinstance(child, IfChild) {
-            syms.append("Show");
-            stack.extend(child.consequent);
-            if child.alternate is not None {
-                stack.extend(child.alternate);
-            }
-        } elif isinstance(child, ElementChild) {
-            stack.extend(child.element.children);
-        }
-    }
-    return syms;
-}
-
 impl SolidBackend._jsx_element(
     name_node: any, attrs: list, children: list, jac_node: any, sync_loc: any
 ) -> es.JsxElement {
@@ -509,25 +484,52 @@ impl SolidBackend.lower_async_boundary(a: AsyncBoundary) -> es.Expression {
     return self.lower_view(error_view, self._noloc);
 }
 
-impl SolidBackend.state_field_symbols(s: StateField) -> list[str] {
-    return ["createSignal"];
-}
-
-impl SolidBackend.ref_field_symbols(r: RefField) -> list[str] {
+impl SolidBackend.runtime_symbols(
+    intent: StateField | RefField | Effect | AsyncBoundary | ViewElement
+) -> list[str] {
+    if isinstance(intent, StateField) {
+        return ["createSignal"];
+    }
+    if isinstance(intent, RefField) {
+        return [];
+    }
+    if isinstance(intent, Effect) {
+        if not intent.is_entry {
+            return ["onCleanup"];
+        }
+        return ["createEffect"];
+    }
+    if isinstance(intent, AsyncBoundary) {
+        syms = ["Suspense"];
+        if intent.except_exprs {
+            syms.append("ErrorBoundary");
+        }
+        return syms;
+    }
+    if isinstance(intent, ViewElement) {
+        import from jaclang.compiler.passes.ecmascript.view_ir {
+            ElementChild,
+            IfChild,
+            EachChild
+        }
+        syms = [];
+        stack = list(intent.children);
+        while stack {
+            child = stack.pop();
+            if isinstance(child, EachChild) {
+                syms.append("For");
+                stack.extend(child.body);
+            } elif isinstance(child, IfChild) {
+                syms.append("Show");
+                stack.extend(child.consequent);
+                if child.alternate is not None {
+                    stack.extend(child.alternate);
+                }
+            } elif isinstance(child, ElementChild) {
+                stack.extend(child.element.children);
+            }
+        }
+        return syms;
+    }
     return [];
-}
-
-impl SolidBackend.effect_symbols(e: Effect) -> list[str] {
-    if not e.is_entry {
-        return ["onCleanup"];
-    }
-    return ["createEffect"];
-}
-
-impl SolidBackend.async_boundary_symbols(a: AsyncBoundary) -> list[str] {
-    syms = ["Suspense"];
-    if a.except_exprs {
-        syms.append("ErrorBoundary");
-    }
-    return syms;
 }

--- a/jac/jaclang/compiler/passes/ecmascript/backends/react.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/backends/react.jac
@@ -22,11 +22,10 @@ obj ReactBackend(FrameworkBackend) {
     def lower_view_expr(expr: es.Expression) -> es.Expression;
     def lower_view(view: ViewElement, sync_loc: any) -> es.Expression;
     def _view_attr_property(attr: any, sync_loc: any) -> es.Property;
-    def state_field_symbols(s: StateField) -> list[str];
-    def ref_field_symbols(r: RefField) -> list[str];
-    def effect_symbols(e: Effect) -> list[str];
-    def async_boundary_symbols(a: AsyncBoundary) -> list[str];
-    def view_runtime_symbols(view: ViewElement) -> list[str];
+    def runtime_symbols(
+        intent: StateField | RefField | Effect | AsyncBoundary | ViewElement
+    ) -> list[str];
+
     def jsx_factory_name -> str;
     def import_source(symbol: str) -> str;
     def required_globals -> list[str];

--- a/jac/jaclang/compiler/passes/ecmascript/backends/solid.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/backends/solid.jac
@@ -33,7 +33,10 @@ obj SolidBackend(ReactBackend) {
     def _jsx_for(child: any, sync_loc: any) -> es.JsxElement;
     def _jsx_show(child: any, sync_loc: any) -> es.JsxElement;
     def _view_children_as_expr(children: list, sync_loc: any) -> es.Expression;
-    def view_runtime_symbols(view: ViewElement) -> list[str];
+    def runtime_symbols(
+        intent: StateField | RefField | Effect | AsyncBoundary | ViewElement
+    ) -> list[str];
+
     def _jsx_element(
         name_node: any, attrs: list, children: list, jac_node: any, sync_loc: any
     ) -> es.JsxElement;
@@ -47,10 +50,6 @@ obj SolidBackend(ReactBackend) {
     ) -> es.JsxElement;
 
     def _noloc(es_node: any, jac_node: any = None) -> any;
-    def state_field_symbols(s: StateField) -> list[str];
-    def ref_field_symbols(r: RefField) -> list[str];
-    def effect_symbols(e: Effect) -> list[str];
-    def async_boundary_symbols(a: AsyncBoundary) -> list[str];
     def import_source(symbol: str) -> str;
     def required_globals -> list[str];
     def runtime_source_basename -> str;

--- a/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
@@ -15,6 +15,13 @@ import from jaclang.compiler.passes.ecmascript.scoped_styles {
     load_style_annex
 }
 import from jaclang.compiler.passes.ecmascript.framework_backend { FrameworkBackend }
+import from jaclang.compiler.passes.ecmascript.intent.collector { IntentCollector }
+import from jaclang.compiler.passes.ecmascript.intent.leaf_converter {
+    LeafConverter,
+    EsastLeafConverter
+}
+import from jaclang.compiler.passes.ecmascript.intent.detection { JSX_COMPONENT_TYPES }
+import from jaclang.compiler.passes.ecmascript.intent.session { IntentSession }
 import from jaclang.jac0core.modresolver {
     convert_to_js_import_path,
     resolve_relative_path
@@ -166,12 +173,17 @@ obj EsastGenPass(BaseAstGenPass[es.Statement]) {
         scope_stack: list[ScopeInfo] = [],
         scope_map: dict[(uni.UniScopeNode, ScopeInfo)] = {},
         backend: (FrameworkBackend | None) = None,
+        intent_session: (IntentSession | None) = None,
+        collector: (IntentCollector | None) = None,
+        converter: (EsastLeafConverter | None) = None,
+        reactive_vars: set[str] = set(),
+        _reactive_vars_stack: list[set[str]] = [],
+        strict_arch_has: bool = True,
+        use_arch_has_dedup: bool = False,
         client_manifest: (ClientManifest | None) = None,
         jsx_processor: (EsJsxProcessor | None) = None,
         scoped_styles: (ScopedStyleSheet | None) = None,
-        reactive_vars: set[str] = set(),
         component_export_names: set[str] = set(),
-        reactive_vars_stack: list[set[str]] = [],
         injected_imports: set[str] = set(),
         _view_stack: list[(str | None)] = [],
         _view_used_base: bool = False,
@@ -291,6 +303,7 @@ obj EsastGenPass(BaseAstGenPass[es.Statement]) {
     def exit_archetype(nd: uni.Archetype) -> None;
     def exit_enum(nd: uni.Enum) -> None;
     def enter_ability(nd: uni.Ability) -> None;
+    def effect_deps(nd: uni.Ability) -> list;
     def exit_ability(nd: uni.Ability) -> None;
     def exit_visit_stmt(nd: uni.VisitStmt) -> None;
     def exit_disengage_stmt(nd: uni.DisengageStmt) -> None;

--- a/jac/jaclang/compiler/passes/ecmascript/framework_backend.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/framework_backend.jac
@@ -20,11 +20,10 @@ obj FrameworkBackend {
     def lower_state_read(name: str) -> es.Expression;
     def lower_view_expr(expr: es.Expression) -> es.Expression;
     def lower_view(view: ViewElement, sync_loc: any) -> es.Expression;
-    def state_field_symbols(s: StateField) -> list[str];
-    def ref_field_symbols(r: RefField) -> list[str];
-    def effect_symbols(e: Effect) -> list[str];
-    def async_boundary_symbols(a: AsyncBoundary) -> list[str];
-    def view_runtime_symbols(view: ViewElement) -> list[str];
+    def runtime_symbols(
+        intent: StateField | RefField | Effect | AsyncBoundary | ViewElement
+    ) -> list[str];
+
     def jsx_factory_name -> str;
     def import_source(symbol: str) -> str;
     def required_globals -> list[str];

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -1,29 +1,75 @@
-import from jaclang.compiler.passes.ecmascript.reactive_intent {
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
     StateField,
     RefField,
     StateUpdate,
     Effect,
     AsyncBoundary
 }
+import from jaclang.compiler.passes.ecmascript.intent.leaf_converter {
+    EsastLeafConverter
+}
+import from jaclang.compiler.passes.ecmascript.intent.es_adapter { EsIntentAdapter }
+import from jaclang.compiler.passes.ecmascript.intent.session {
+    IntentSession,
+    SkipExistingPolicy
+}
+import from jaclang.compiler.passes.ecmascript.intent.detection {
+    JSX_COMPONENT_TYPES,
+    arch_has_applicable,
+    ref_head_name,
+    return_type_includes,
+    return_type_route_role
+}
 
 impl EsastGenPass._ensure_backend -> None {
-    if self.backend is None {
-        import from jaclang.compiler.passes.ecmascript.backends.registry {
-            resolve_active_backend
-        }
-        try {
+    if self.backend is not None {
+        return;
+    }
+
+    opts = self.prog._compile_options if self.prog else None;
+    override = (getattr(opts, "client_framework", "") or "") if opts else "";
+    import from jaclang.compiler.passes.ecmascript.backends.registry {
+        resolve_active_backend,
+        resolve_framework_backend
+    }
+
+    if override {
+        effective_fw = override;
+    } else {
+        import from jaclang.project.config { get_config }
+        cfg = get_config();
+        effective_fw = (cfg.client.framework if (cfg and cfg.client) else "")
+            or "react";
+    }
+    if effective_fw == "compose" {
+        import from jaclang.jac0core.diagnostics { E5085 }
+        import from jaclang.compiler.passes.ecmascript.backends.react { ReactBackend }
+        self.emit(E5085);
+        self.backend = ReactBackend();
+        return;
+    }
+
+    try {
+        if override {
+            import from jaclang.project.client_kind { resolve_client_surface }
+            mod_path = self.ir_in.loc.mod_path
+                if (self.ir_in and self.ir_in.loc)
+                else "";
+            surface = resolve_client_surface(
+                mod_path,
+                override,
+                getattr(opts, "project_kind", "web") or "web",
+                opts?.project_root,
+            );
+            self.backend = resolve_framework_backend(surface.framework);
+        } else {
             self.backend = resolve_active_backend();
-        } except ValueError {
-            import from jaclang.project.config { get_config }
-            import from jaclang.jac0core.diagnostics { E5081 }
-            import from jaclang.compiler.passes.ecmascript.backends.react {
-                ReactBackend
-            }
-            cfg = get_config();
-            fw = cfg.client.framework if (cfg and cfg.client) else "unknown";
-            self.emit(E5081, framework=fw);
-            self.backend = ReactBackend();
         }
+    } except ValueError {
+        import from jaclang.jac0core.diagnostics { E5081 }
+        import from jaclang.compiler.passes.ecmascript.backends.react { ReactBackend }
+        self.emit(E5081, framework=effective_fw);
+        self.backend = ReactBackend();
     }
 }
 
@@ -174,9 +220,8 @@ impl EsastGenPass.exit_global_vars(nd: uni.GlobalVars) -> None {
 
 impl EsastGenPass.exit_name(nd: uni.Name) -> None {
     if nd.sym_name in self.reactive_vars {
-        self._ensure_backend();
         nd.gen.es_ast = self.sync_loc(
-            self.backend.lower_state_read(nd.sym_name), jac_node=nd
+            self.intent_session.adapter.lower_state_read(nd.sym_name), jac_node=nd
         );
         return;
     }
@@ -989,38 +1034,11 @@ impl EsastGenPass._resolve_call_ability(nd: uni.FuncCall) -> (uni.Ability | None
 }
 
 impl EsastGenPass._return_type_includes_jsx_element(rt: uni.Expr) -> bool {
-    if (
-        isinstance(rt, uni.BinaryExpr)
-        and isinstance(rt.op, uni.Token)
-        and rt.op.name == Tok.BW_OR
-    ) {
-        return (
-            self._return_type_includes_jsx_element(rt.left)
-            or self._return_type_includes_jsx_element(rt.right)
-        );
-    }
-    return isinstance(rt, uni.Name)
-        and rt.value in ('JsxElement', 'JsxPage', 'JsxLayout');
+    return return_type_includes(rt, JSX_COMPONENT_TYPES);
 }
 
 impl EsastGenPass._return_type_route_role(rt: uni.Expr) -> (str | None) {
-    if (
-        isinstance(rt, uni.BinaryExpr)
-        and isinstance(rt.op, uni.Token)
-        and rt.op.name == Tok.BW_OR
-    ) {
-        left_role = self._return_type_route_role(rt.left);
-        return left_role or self._return_type_route_role(rt.right);
-    }
-    if isinstance(rt, uni.Name) {
-        if rt.value == 'JsxPage' {
-            return 'page';
-        }
-        if rt.value == 'JsxLayout' {
-            return 'layout';
-        }
-    }
-    return None;
+    return return_type_route_role(rt);
 }
 
 impl EsastGenPass._component_pascal_name(nd: uni.Ability) -> (str | None) {
@@ -1987,40 +2005,18 @@ impl EsastGenPass.exit_assignment(nd: uni.Assignment) -> None {
     if len(nd.target) == 1 and isinstance(nd.target[0], uni.Name) {
         target_name = nd.target[0].sym_name;
         if target_name in self.reactive_vars {
-            setter_arg: es.Expression;
-            aug_op: (str | None) = None;
-            if nd.aug_op {
-                aug_tok = Tok(nd.aug_op.name)
-                    if (nd.aug_op.name in Tok.__members__)
-                    else None;
-                aug_to_binary: dict[Tok, str] = {
-                    Tok.ADD_EQ: '+',
-                    Tok.SUB_EQ: '-',
-                    Tok.MUL_EQ: '*',
-                    Tok.DIV_EQ: '/',
-                    Tok.MOD_EQ: '%'
-                };
-                binary_op = aug_to_binary.get(aug_tok, '+') if aug_tok else '+';
-                aug_op = binary_op;
-
-                setter_arg = cast(es.Expression, value_expr or es.Literal(value=0));
-            } else {
-                setter_arg = cast(
-                    es.Expression, value_expr or es.Identifier(name='undefined')
+            self.converter.reactive_vars = self.reactive_vars;
+            update = self.intent_session.scan_state_update(nd);
+            if update is not None {
+                setter_call = self.sync_loc(
+                    self.intent_session.lower_state_update(nd, update), jac_node=nd
                 );
+                expr_stmt = self.sync_loc(
+                    es.ExpressionStatement(expression=setter_call), jac_node=nd
+                );
+                nd.gen.es_ast = expr_stmt;
+                return;
             }
-            state_update = StateUpdate(
-                name=target_name, value=setter_arg, aug_op=aug_op
-            );
-            self._ensure_backend();
-            setter_call = self.sync_loc(
-                self.backend.lower_state_update(state_update), jac_node=nd
-            );
-            expr_stmt = self.sync_loc(
-                es.ExpressionStatement(expression=setter_call), jac_node=nd
-            );
-            nd.gen.es_ast = expr_stmt;
-            return;
         }
     }
     if nd.aug_op {
@@ -3011,12 +3007,9 @@ impl EsastGenPass.exit_try_stmt(nd: uni.TryStmt) -> None {
         async_boundary = AsyncBoundary(
             try_expr=try_iife, awaiting_expr=awaiting_iife, except_exprs=except_iifes
         );
-        self._ensure_backend();
-        for sym in self.backend.async_boundary_symbols(async_boundary) {
-            self._inject_runtime_import(sym, nd);
-        }
         wrapper = self.sync_loc(
-            self.backend.lower_async_boundary(async_boundary), jac_node=nd
+            self.intent_session.adapter.lower_async_boundary(nd, async_boundary),
+            jac_node=nd
         );
         outer = self._cur_view_acc();
         if outer is not None {
@@ -3491,18 +3484,17 @@ impl EsastGenPass.exit_jsx_element(nd: uni.JsxElement) -> None {
 
     if nd.dynamic_tag is not None {
         self._ensure_backend();
-        if self.backend.import_source("Dynamic") != self.backend.runtime_module() {
+        if self.backend is not None
+            and self.backend.import_source("Dynamic")
+                != self.backend.runtime_module() {
             self._inject_runtime_import("Dynamic", nd);
         }
     }
     nd.gen.es_ast = self.jsx_processor.element(nd);
 
-    self._ensure_backend();
     view = self.jsx_processor._view_by_node.get(id(nd));
     if view is not None {
-        for sym in self.backend.view_runtime_symbols(view) {
-            self._inject_runtime_import(sym, nd);
-        }
+        self.intent_session.adapter.lower_view_symbols(nd, view);
     }
 }
 
@@ -3560,17 +3552,7 @@ impl EsastGenPass._inject_runtime_import(name: str, nd: uni.UniNode) -> None {
 }
 
 impl EsastGenPass._ref_head_name(expr: (uni.UniNode | None)) -> (str | None) {
-    cur = expr;
-    while True {
-        if isinstance(cur, uni.FuncCall) {
-            cur = cur.target;
-        } elif isinstance(cur, uni.AtomTrailer) {
-            cur = cur.target;
-        } else {
-            break;
-        }
-    }
-    return cur.value if isinstance(cur, uni.Name) else None;
+    return ref_head_name(expr);
 }
 
 impl EsastGenPass._ref_forward_param(nd: uni.Ability) -> (uni.ParamVar | None) {
@@ -3591,12 +3573,13 @@ impl EsastGenPass._ref_forward_param(nd: uni.Ability) -> (uni.ParamVar | None) {
 }
 
 impl EsastGenPass._transform_to_useeffect(nd: uni.Ability) -> None {
-    inner = self.unwrap_body(nd);
-    body_stmts = self._collect_stmt_body(inner);
+    lowered = self.intent_session.record_and_lower_effect(nd);
+    if lowered {
+        nd.gen.es_ast = self.sync_loc(lowered[0], jac_node=nd);
+    }
+}
 
-    is_entry = nd.signature.event.name == Tok.KW_ENTRY;
-    is_async = nd.is_async;
-
+impl EsastGenPass.effect_deps(nd: uni.Ability) -> list {
     deps_elements: list[es.Expression | es.SpreadElement | None] = [];
     arch_tag = nd.signature.arch_tag_info;
     if arch_tag {
@@ -3610,85 +3593,41 @@ impl EsastGenPass._transform_to_useeffect(nd: uni.Ability) -> None {
             deps_elements.append(cast(es.Expression, arch_tag.gen.es_ast));
         }
     }
-    effect = Effect(
-        body=body_stmts, deps=deps_elements, is_entry=is_entry, is_async=is_async
-    );
-    self._ensure_backend();
-    for sym in self.backend.effect_symbols(effect) {
-        self._inject_runtime_import(sym, nd);
-    }
-    lowered = self.backend.lower_effect(effect);
-    if lowered {
-        nd.gen.es_ast = self.sync_loc(lowered[0], jac_node=nd);
-    }
+    return deps_elements;
 }
 
 impl EsastGenPass.exit_arch_has(nd: uni.ArchHas) -> None {
-    owner: (uni.UniNode | None) = nd.parent;
-    while (owner is not None and not isinstance(owner, (uni.Ability, uni.Archetype))) {
-        owner = owner.parent;
-    }
-    if isinstance(owner, uni.Archetype) or not nd.in_client_context() {
+    if not arch_has_applicable(nd, strict_client=True) {
         nd.gen.es_ast = None;
         return;
     }
 
+    null_expr = self.sync_loc(es.Literal(value=None, raw='null'), jac_node=nd);
+    undefined_expr = es.Identifier(name='undefined');
+    self.converter.null_expr = null_expr;
+    self.converter.fallback_expr = undefined_expr;
+    self.converter.reactive_vars = self.reactive_vars;
+
+    scan = self.intent_session.scan_arch_has(nd);
+    if scan is None {
+        nd.gen.es_ast = None;
+        return;
+    }
+
+    for has_var in scan.typed_ref_only {
+        self.emit(E2025, node_override=has_var);
+    }
+
     statements: list[es.Statement] = [];
-    for has_var in nd.vars {
-        var_name = has_var.name.sym_name;
-
-        ref_ctor = (
-            isinstance(has_var.value, uni.FuncCall)
-            and self._ref_head_name(has_var.value) == 'Ref'
-        );
-        ref_typed = (
-            has_var.type_tag is not None
-            and self._ref_head_name(has_var.type_tag.tag) == 'Ref'
-        );
-        if ref_ctor or ref_typed {
-            if ref_typed and not ref_ctor {
-                self.emit(E2025, node_override=has_var);
-            }
-            ref_init: es.Expression = self.sync_loc(
-                es.Literal(value=None, raw='null'), jac_node=has_var
-            );
-            if isinstance(has_var.value, uni.FuncCall) and has_var.value.params {
-                seed = has_var.value.params[0];
-                seed_expr = seed.value if isinstance(seed, uni.KWPair) else seed;
-                if seed_expr.gen.es_ast {
-                    ref_init = cast(es.Expression, seed_expr.gen.es_ast);
-                }
-            }
-            ref_field = RefField(name=var_name, init_expr=ref_init);
-            self._ensure_backend();
-            for sym in self.backend.ref_field_symbols(ref_field) {
-                self._inject_runtime_import(sym, nd);
-            }
-            for stmt in self.backend.lower_ref_field(ref_field) {
-                statements.append(self.sync_loc(stmt, jac_node=has_var));
-            }
-            self._register_declaration(var_name);
-            continue;
-        }
-
-        init_value: es.Expression;
-        if has_var.value and has_var.value.gen.es_ast {
-            init_value = cast(es.Expression, has_var.value.gen.es_ast);
-        } else {
-            init_value = es.Identifier(name='undefined');
-        }
-
-        state_field = StateField(name=var_name, init_expr=init_value);
-        self._ensure_backend();
-        for sym in self.backend.state_field_symbols(state_field) {
-            self._inject_runtime_import(sym, nd);
-        }
-        for stmt in self.backend.lower_state_field(state_field) {
-            statements.append(self.sync_loc(stmt, jac_node=has_var));
-        }
-
-        self.reactive_vars.add(var_name);
-        self._register_declaration(var_name);
+    for stmt in self.intent_session.adapter.apply_arch_has_scan(nd, scan) {
+        statements.append(self.sync_loc(stmt, jac_node=nd));
+    }
+    for r in scan.ref_fields {
+        self._register_declaration(r.name);
+    }
+    for s in scan.state_fields {
+        self.reactive_vars.add(s.name);
+        self._register_declaration(s.name);
     }
     if len(statements) == 1 {
         nd.gen.es_ast = statements[0];
@@ -3725,8 +3664,9 @@ impl EsastGenPass.exit_ability(nd: uni.Ability) -> None {
         self._view_stack.pop();
     }
 
-    if self.reactive_vars_stack {
-        self.reactive_vars = self.reactive_vars_stack.pop();
+    self.intent_session.pop_ability_scope();
+    if self._reactive_vars_stack {
+        self.reactive_vars = self._reactive_vars_stack.pop();
     }
 
     osp_info = self._osp_ability_info(nd);
@@ -4417,7 +4357,9 @@ impl EsastGenPass.enter_ability(nd: uni.Ability) -> None {
     }
 
     self._view_stack.append(None);
-    self.reactive_vars_stack.append(self.reactive_vars);
+    self.intent_session.enter_ability(nd);
+
+    self._reactive_vars_stack.append(self.reactive_vars);
     self.reactive_vars = set(self.reactive_vars);
 }
 
@@ -6367,6 +6309,24 @@ impl EsastGenPass.before_pass -> None {
         if a.name is not None
     };
     self.jsx_processor = EsJsxProcessor(self);
+    self.collector = IntentCollector();
+    self.converter = EsastLeafConverter(
+        pass_inst=self,
+        null_expr=es.Identifier(name='undefined'),
+        fallback_expr=es.Identifier(name='undefined'),
+        reactive_vars=self.reactive_vars
+    );
+    self.intent_session = IntentSession(
+        collector=self.collector,
+        adapter=EsIntentAdapter(pass_ref=self, collector=self.collector),
+        converter=self.converter,
+        pass_ref=self,
+        component_types=JSX_COMPONENT_TYPES,
+        strict_arch_has=True,
+        use_arch_has_dedup=False,
+        skip_existing_policy=SkipExistingPolicy.NONE,
+        reactive_vars=self.reactive_vars
+    );
 
     self.scoped_styles = load_style_annex(
         self.ir_in.annexable_by or self.ir_in.loc.mod_path

--- a/jac/jaclang/compiler/passes/ecmascript/intent/collector.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/collector.jac
@@ -1,0 +1,89 @@
+import jaclang.jac0core.unitree as uni;
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
+    StateField,
+    RefField,
+    StateUpdate,
+    Effect,
+    AsyncBoundary
+}
+import type from jaclang.compiler.passes.ecmascript.view_ir { ViewElement }
+import from jaclang.compiler.passes.ecmascript.intent.model { IntentModule }
+
+obj IntentCollector {
+    has _own_module: (IntentModule | None) = None,
+        _linked_module: (IntentModule | None) = None,
+        reactive_vars: set[str] = set();
+
+    def init(module: (IntentModule | None) = None) {
+        if module is not None {
+            self._linked_module = module;
+        }
+    }
+
+    def link_module(module: IntentModule) {
+        self._linked_module = module;
+    }
+
+    def module -> IntentModule {
+        if self._linked_module is not None {
+            return self._linked_module;
+        }
+        if self._own_module is None {
+            self._own_module = IntentModule();
+        }
+        self._linked_module = self._own_module;
+        return self._linked_module;
+    }
+
+    def enter_component(name: str) {
+        m = self.module();
+        m.current = name;
+        m.ensure_component(name);
+    }
+
+    def mark_screen(name: str, is_screen: bool = True, route_path: (str | None) = "/") {
+        comp = self.module().ensure_component(name);
+        comp.is_screen = is_screen;
+        if route_path {
+            comp.route_path = route_path;
+        }
+    }
+
+    def existing_reactive_names -> set[str] {
+        comp = self.module().current_component();
+        names: set[str] = set();
+        for s in comp.state {
+            names.add(s.name);
+        }
+        for r in comp.refs {
+            names.add(r.name);
+        }
+        return names;
+    }
+
+    def record_state_field(s: StateField) {
+        self.module().current_component().state.append(s);
+        self.reactive_vars.add(s.name);
+    }
+
+    def record_ref_field(r: RefField) {
+        self.module().current_component().refs.append(r);
+        self.reactive_vars.add(r.name);
+    }
+
+    def record_state_update(u: StateUpdate) {
+        self.module().current_component().updates.append(u);
+    }
+
+    def record_effect(e: Effect) {
+        self.module().current_component().effects.append(e);
+    }
+
+    def record_async_boundary(a: AsyncBoundary) {
+        self.module().current_component().asyncs.append(a);
+    }
+
+    def record_view(view: ViewElement) {
+        self.module().current_component().view = view;
+    }
+}

--- a/jac/jaclang/compiler/passes/ecmascript/intent/detection.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/detection.jac
@@ -1,0 +1,72 @@
+import jaclang.jac0core.unitree as uni;
+import from jaclang.jac0core.constant { CodeContext, Tokens as Tok }
+import from jaclang.compiler.passes.ecmascript.intent.leaf_converter { LeafConverter }
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
+    IntentLeaf,
+    StateField,
+    RefField,
+    StateUpdate,
+    Effect
+}
+
+glob JSX_COMPONENT_TYPES: Sequence[str] = ('JsxElement', 'JsxPage', 'JsxLayout'),
+     COMPOSE_COMPONENT_TYPES: Sequence[str] = (
+         'Composable',
+         'JsxElement',
+         'JsxPage',
+         'JsxLayout'
+     ),
+     HOME_COMPONENT_NAMES: Sequence[str] = ("app", "App", "__root__"),
+     ASSIGNMENT_AUG_OPS: dict[str, str] = {
+         Tok.ADD_EQ.name: '+',
+         Tok.SUB_EQ.name: '-',
+         Tok.MUL_EQ.name: '*',
+         Tok.DIV_EQ.name: '/',
+         Tok.MOD_EQ.name: '%'
+     },
+     ASSIGNMENT_KT_OPS: dict[str, str] = {
+         Tok.ADD_EQ.name: '+=',
+         Tok.SUB_EQ.name: '-=',
+         Tok.MUL_EQ.name: '*=',
+         Tok.DIV_EQ.name: '/=',
+         Tok.MOD_EQ.name: '%='
+     };
+
+obj ArchHasScanResult {
+    has state_fields: list[StateField] = [],
+        ref_fields: list[RefField] = [],
+        typed_ref_only: list[uni.HasVar] = [];
+}
+
+def ref_head_name(expr: (uni.UniNode | None)) -> (str | None);
+def arch_has_owner(nd: uni.ArchHas) -> (uni.UniNode | None);
+def arch_has_applicable(nd: uni.ArchHas, strict_client: bool = False) -> bool;
+def is_ref_field(has_var: uni.HasVar) -> tuple[bool, bool];
+def assignment_aug_op(nd: uni.Assignment) -> (str | None);
+def assignment_kt_op(nd: uni.Assignment) -> str;
+def return_type_includes(rt: uni.Expr, component_types: Sequence[str]) -> bool;
+
+def return_type_route_role(rt: uni.Expr) -> (str | None);
+def screen_meta_for_component(
+    name: str, return_type: (uni.Expr | None)
+) -> tuple[bool, (str | None)];
+
+def component_name_from_ability(
+    nd: uni.Ability, component_types: Sequence[str]
+) -> (str | None);
+
+def unwrap_ability_body(nd: uni.Ability) -> (list[uni.UniNode] | None);
+def scan_arch_has(
+    nd: uni.ArchHas, skip_existing: set[str], conv: LeafConverter
+) -> ArchHasScanResult;
+
+def scan_state_update(
+    nd: uni.Assignment,
+    conv: LeafConverter,
+    convert_value:
+        (Callable[[uni.Expr | uni.YieldExpr], (IntentLeaf | None)] | None) = None
+) -> (StateUpdate | None);
+
+def effect_from_ability(
+    nd: uni.Ability, body: list[IntentLeaf], deps: list[IntentLeaf]
+) -> Effect;

--- a/jac/jaclang/compiler/passes/ecmascript/intent/es_adapter.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/es_adapter.jac
@@ -1,0 +1,34 @@
+import jaclang.compiler.passes.ecmascript.estree as es;
+import jaclang.jac0core.unitree as uni;
+import type from jaclang.compiler.passes.ecmascript.framework_backend {
+    FrameworkBackend
+}
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
+    StateField,
+    RefField,
+    StateUpdate,
+    Effect,
+    AsyncBoundary
+}
+import type from jaclang.compiler.passes.ecmascript.view_ir { ViewElement }
+import type from jaclang.compiler.passes.ecmascript.esast_gen_pass { EsastGenPass }
+import from jaclang.compiler.passes.ecmascript.intent.collector { IntentCollector }
+import from jaclang.compiler.passes.ecmascript.intent.detection { ArchHasScanResult }
+
+obj EsIntentAdapter {
+    has pass_ref: EsastGenPass,
+        collector: IntentCollector;
+
+    def backend -> FrameworkBackend;
+    def lower_state_read(name: str) -> es.Expression;
+    def lower_state_field(nd: uni.UniNode, s: StateField) -> list[es.Statement];
+    def lower_ref_field(nd: uni.UniNode, r: RefField) -> list[es.Statement];
+    def lower_state_update(nd: uni.UniNode, u: StateUpdate) -> es.Expression;
+    def lower_effect(nd: uni.UniNode, e: Effect) -> list[es.Statement];
+    def lower_async_boundary(nd: uni.UniNode, a: AsyncBoundary) -> es.Expression;
+    def lower_view_symbols(nd: uni.UniNode, view: ViewElement) -> None;
+    def lower_view(view: ViewElement, sync_loc: any) -> es.Expression;
+    def apply_arch_has_scan(
+        nd: uni.UniNode, scan: ArchHasScanResult
+    ) -> list[es.Statement];
+}

--- a/jac/jaclang/compiler/passes/ecmascript/intent/es_leaves.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/es_leaves.jac
@@ -1,0 +1,5 @@
+import jaclang.compiler.passes.ecmascript.estree as es;
+import from typing { TypeAlias }
+
+glob IntentExpr: TypeAlias = es.Expression,
+     IntentStmt: TypeAlias = es.Statement;

--- a/jac/jaclang/compiler/passes/ecmascript/intent/impl/detection.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/impl/detection.impl.jac
@@ -1,0 +1,226 @@
+import jaclang.jac0core.unitree as uni;
+import from jaclang.jac0core.constant { CodeContext, Tokens as Tok }
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
+    IntentLeaf,
+    StateField,
+    RefField,
+    StateUpdate,
+    Effect
+}
+
+impl ref_head_name(expr: (uni.UniNode | None)) -> (str | None) {
+    cur = expr;
+    while True {
+        if isinstance(cur, uni.FuncCall) {
+            cur = cur.target;
+        } elif isinstance(cur, uni.AtomTrailer) {
+            cur = cur.target;
+        } else {
+            break;
+        }
+    }
+    return cur.value if isinstance(cur, uni.Name) else None;
+}
+
+impl arch_has_owner(nd: uni.ArchHas) -> (uni.UniNode | None) {
+    owner: (uni.UniNode | None) = nd.parent;
+    while owner is not None and not isinstance(owner, (uni.Ability, uni.Archetype)) {
+        owner = owner.parent;
+    }
+    return owner;
+}
+
+impl arch_has_applicable(nd: uni.ArchHas, strict_client: bool = False) -> bool {
+    owner = arch_has_owner(nd);
+    if isinstance(owner, uni.Archetype) {
+        return False;
+    }
+    if strict_client {
+        if not nd.in_client_context() {
+            return False;
+        }
+    } elif not nd.in_client_context() and owner is None {
+        return False;
+    }
+    return True;
+}
+
+impl is_ref_field(has_var: uni.HasVar) -> tuple[bool, bool] {
+    ref_ctor = (
+        isinstance(has_var.value, uni.FuncCall)
+        and ref_head_name(has_var.value.target) == 'Ref'
+    );
+    ref_typed = (
+        has_var.type_tag is not None and ref_head_name(has_var.type_tag.tag) == 'Ref'
+    );
+    return (ref_ctor, ref_typed);
+}
+
+impl assignment_aug_op(nd: uni.Assignment) -> (str | None) {
+    if nd.aug_op and nd.aug_op.name {
+        return ASSIGNMENT_AUG_OPS.get(nd.aug_op.name);
+    }
+    return None;
+}
+
+impl assignment_kt_op(nd: uni.Assignment) -> str {
+    if nd.aug_op and nd.aug_op.name {
+        return ASSIGNMENT_KT_OPS.get(nd.aug_op.name, '=');
+    }
+    return '=';
+}
+
+impl return_type_includes(rt: uni.Expr, component_types: Sequence[str]) -> bool {
+    if (
+        isinstance(rt, uni.BinaryExpr)
+        and isinstance(rt.op, uni.Token)
+        and rt.op.name == Tok.BW_OR.name
+    ) {
+        return (
+            return_type_includes(rt.left, component_types)
+            or return_type_includes(rt.right, component_types)
+        );
+    }
+    return isinstance(rt, uni.Name) and rt.value in component_types;
+}
+
+impl return_type_route_role(rt: uni.Expr) -> (str | None) {
+    if (
+        isinstance(rt, uni.BinaryExpr)
+        and isinstance(rt.op, uni.Token)
+        and rt.op.name == Tok.BW_OR.name
+    ) {
+        left_role = return_type_route_role(rt.left);
+        return left_role or return_type_route_role(rt.right);
+    }
+    if isinstance(rt, uni.Name) {
+        if rt.value == 'JsxPage' {
+            return 'page';
+        }
+        if rt.value == 'JsxLayout' {
+            return 'layout';
+        }
+    }
+    return None;
+}
+
+impl screen_meta_for_component(
+    name: str, return_type: (uni.Expr | None)
+) -> tuple[bool, (str | None)] {
+    if name in HOME_COMPONENT_NAMES {
+        return (True, "/");
+    }
+    if return_type is not None and return_type_route_role(return_type) == "page" {
+        return (True, None);
+    }
+    return (False, None);
+}
+
+impl component_name_from_ability(
+    nd: uni.Ability, component_types: Sequence[str]
+) -> (str | None) {
+    if nd.code_context != CodeContext.CLIENT or nd.is_method {
+        return None;
+    }
+    if not isinstance(nd.signature, uni.FuncSignature) {
+        return None;
+    }
+    if nd.signature.return_type is None {
+        return None;
+    }
+    if not return_type_includes(nd.signature.return_type, component_types) {
+        return None;
+    }
+    if nd.name_ref is None {
+        return None;
+    }
+    return nd.name_ref.sym_name;
+}
+
+impl unwrap_ability_body(nd: uni.Ability) -> (list[uni.UniNode] | None) {
+    body = nd.body;
+    if isinstance(body, uni.ImplDef) {
+        return list(body.body) if body.body else [];
+    }
+    if isinstance(body, list) {
+        return body;
+    }
+    return None;
+}
+
+impl scan_arch_has(
+    nd: uni.ArchHas, skip_existing: set[str], conv: LeafConverter
+) -> ArchHasScanResult {
+    result = ArchHasScanResult();
+    for has_var in nd.vars {
+        var_name = has_var.name.sym_name;
+        if var_name in skip_existing {
+            continue;
+        }
+        (ref_ctor, ref_typed) = is_ref_field(has_var);
+        if ref_ctor or ref_typed {
+            if ref_typed and not ref_ctor {
+                result.typed_ref_only.append(has_var);
+            }
+            init_expr: IntentLeaf = conv.null_expr;
+            if isinstance(has_var.value, uni.FuncCall) and has_var.value.params {
+                seed = has_var.value.params[0];
+                seed_expr = seed.value if isinstance(seed, uni.KWPair) else seed;
+                init_expr = conv.convert_ref_seed(seed_expr);
+            }
+            result.ref_fields.append(RefField(name=var_name, init_expr=init_expr));
+            skip_existing.add(var_name);
+            continue;
+        }
+        init_expr = conv.fallback_expr;
+        if has_var.value {
+            converted = conv.convert_expr(has_var.value);
+            if converted is not None {
+                init_expr = converted;
+            }
+        }
+        result.state_fields.append(StateField(name=var_name, init_expr=init_expr));
+        skip_existing.add(var_name);
+    }
+    return result;
+}
+
+impl scan_state_update(
+    nd: uni.Assignment,
+    conv: LeafConverter,
+    convert_value:
+        (Callable[[uni.Expr | uni.YieldExpr], (IntentLeaf | None)] | None) = None
+) -> (StateUpdate | None) {
+    if len(nd.target) != 1 or not isinstance(nd.target[0], uni.Name) {
+        return None;
+    }
+    name = nd.target[0].sym_name;
+    if name not in conv.reactive_vars {
+        return None;
+    }
+    if convert_value is not None {
+        if nd.value is None {
+            return None;
+        }
+        value_expr = convert_value(nd.value);
+    } elif nd.value is not None {
+        value_expr = conv.convert_assignment_value(nd, nd.value);
+    } else {
+        return None;
+    }
+    if value_expr is None {
+        return None;
+    }
+    return StateUpdate(name=name, value=value_expr, aug_op=assignment_aug_op(nd));
+}
+
+impl effect_from_ability(
+    nd: uni.Ability, body: list[IntentLeaf], deps: list[IntentLeaf]
+) -> Effect {
+    is_entry = (
+        isinstance(nd.signature, uni.EventSignature)
+        and nd.signature.event.name == Tok.KW_ENTRY
+    );
+    is_async = nd.is_async;
+    return Effect(body=body, deps=deps, is_entry=is_entry, is_async=is_async);
+}

--- a/jac/jaclang/compiler/passes/ecmascript/intent/impl/es_adapter.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/impl/es_adapter.impl.jac
@@ -1,0 +1,100 @@
+import jaclang.compiler.passes.ecmascript.estree as es;
+import jaclang.jac0core.unitree as uni;
+import type from jaclang.compiler.passes.ecmascript.framework_backend {
+    FrameworkBackend
+}
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
+    StateField,
+    RefField,
+    StateUpdate,
+    Effect,
+    AsyncBoundary
+}
+import type from jaclang.compiler.passes.ecmascript.view_ir { ViewElement }
+
+impl EsIntentAdapter.backend -> FrameworkBackend {
+    self.pass_ref._ensure_backend();
+    backend = self.pass_ref.backend;
+    if backend is None {
+        raise RuntimeError("EsastGenPass backend not initialized");
+    }
+    return backend;
+}
+
+impl EsIntentAdapter.lower_state_read(name: str) -> es.Expression {
+    return self.backend().lower_state_read(name);
+}
+
+impl EsIntentAdapter.lower_state_field(
+    nd: uni.UniNode, s: StateField
+) -> list[es.Statement] {
+    self.collector.record_state_field(s);
+    b = self.backend();
+    for sym in b.runtime_symbols(s) {
+        self.pass_ref._inject_runtime_import(sym, nd);
+    }
+    return b.lower_state_field(s);
+}
+
+impl EsIntentAdapter.lower_ref_field(
+    nd: uni.UniNode, r: RefField
+) -> list[es.Statement] {
+    self.collector.record_ref_field(r);
+    b = self.backend();
+    for sym in b.runtime_symbols(r) {
+        self.pass_ref._inject_runtime_import(sym, nd);
+    }
+    return b.lower_ref_field(r);
+}
+
+impl EsIntentAdapter.lower_state_update(
+    nd: uni.UniNode, u: StateUpdate
+) -> es.Expression {
+    self.collector.record_state_update(u);
+    return self.backend().lower_state_update(u);
+}
+
+impl EsIntentAdapter.lower_effect(nd: uni.UniNode, e: Effect) -> list[es.Statement] {
+    self.collector.record_effect(e);
+    b = self.backend();
+    for sym in b.runtime_symbols(e) {
+        self.pass_ref._inject_runtime_import(sym, nd);
+    }
+    return b.lower_effect(e);
+}
+
+impl EsIntentAdapter.lower_async_boundary(
+    nd: uni.UniNode, a: AsyncBoundary
+) -> es.Expression {
+    self.collector.record_async_boundary(a);
+    b = self.backend();
+    for sym in b.runtime_symbols(a) {
+        self.pass_ref._inject_runtime_import(sym, nd);
+    }
+    return b.lower_async_boundary(a);
+}
+
+impl EsIntentAdapter.lower_view_symbols(nd: uni.UniNode, view: ViewElement) -> None {
+    b = self.backend();
+    for sym in b.runtime_symbols(view) {
+        self.pass_ref._inject_runtime_import(sym, nd);
+    }
+}
+
+impl EsIntentAdapter.lower_view(view: ViewElement, sync_loc: any) -> es.Expression {
+    self.collector.record_view(view);
+    return self.backend().lower_view(view, sync_loc);
+}
+
+impl EsIntentAdapter.apply_arch_has_scan(
+    nd: uni.UniNode, scan: ArchHasScanResult
+) -> list[es.Statement] {
+    stmts: list[es.Statement] = [];
+    for r in scan.ref_fields {
+        stmts.extend(self.lower_ref_field(nd, r));
+    }
+    for s in scan.state_fields {
+        stmts.extend(self.lower_state_field(nd, s));
+    }
+    return stmts;
+}

--- a/jac/jaclang/compiler/passes/ecmascript/intent/impl/leaf_converter.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/impl/leaf_converter.impl.jac
@@ -1,0 +1,51 @@
+import jaclang.jac0core.unitree as uni;
+import jaclang.compiler.passes.ecmascript.estree as es;
+import from typing { cast }
+import from jaclang.compiler.passes.ecmascript.intent.semantics { IntentLeaf }
+
+impl LeafConverter.convert_ref_seed(nd: uni.UniNode) -> IntentLeaf {
+    expr = self.convert_expr(nd);
+    if expr is not None {
+        return expr;
+    }
+    return self.null_expr;
+}
+
+impl LeafConverter.convert_assignment_value(
+    nd: uni.Assignment, value_nd: (uni.UniNode | None)
+) -> (IntentLeaf | None) {
+    if value_nd is None {
+        return None;
+    }
+    return self.convert_expr(value_nd);
+}
+
+impl LeafConverter.convert_stmts(nodes: list[uni.UniNode]) -> list[IntentLeaf] {
+    return [];
+}
+
+impl EsastLeafConverter.convert_expr(nd: uni.UniNode) -> (IntentLeaf | None) {
+    if nd.gen.es_ast {
+        return cast(es.Expression, nd.gen.es_ast);
+    }
+    return None;
+}
+
+impl EsastLeafConverter.convert_assignment_value(
+    nd: uni.Assignment, value_nd: (uni.UniNode | None)
+) -> (IntentLeaf | None) {
+    if value_nd and value_nd.gen.es_ast {
+        return cast(es.Expression, value_nd.gen.es_ast);
+    }
+    if nd.aug_op {
+        return cast(es.Expression, es.Literal(value=0));
+    }
+    return self.fallback_expr;
+}
+
+impl EsastLeafConverter.convert_stmts(nodes: list[uni.UniNode]) -> list[IntentLeaf] {
+    if self.pass_inst is None {
+        return [];
+    }
+    return cast(list[IntentLeaf], self.pass_inst._collect_stmt_body(nodes));
+}

--- a/jac/jaclang/compiler/passes/ecmascript/intent/impl/session.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/impl/session.impl.jac
@@ -1,0 +1,107 @@
+import jaclang.jac0core.unitree as uni;
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
+    IntentLeaf,
+    StateUpdate
+}
+
+impl IntentSession._sync_converter_reactive_vars -> None {
+    self.converter.reactive_vars = self.reactive_vars;
+}
+
+impl IntentSession.enter_ability(nd: uni.Ability) -> None {
+    import from jaclang.compiler.passes.ecmascript.intent.detection {
+        component_name_from_ability,
+        screen_meta_for_component
+    }
+    self.reactive_vars_stack.append(self.reactive_vars);
+    self.reactive_vars = set(self.reactive_vars);
+    self.collector.reactive_vars = self.reactive_vars;
+    self._sync_converter_reactive_vars();
+    name = component_name_from_ability(nd, self.component_types);
+    if name is not None and isinstance(nd.signature, uni.FuncSignature) {
+        self.collector.enter_component(name);
+        rt = nd.signature.return_type;
+        if rt is not None {
+            (is_screen, route_path) = screen_meta_for_component(name, rt);
+            if is_screen {
+                self.collector.mark_screen(name, True, route_path);
+            }
+        }
+    }
+}
+
+impl IntentSession.pop_ability_scope -> None {
+    if self.reactive_vars_stack {
+        self.reactive_vars = self.reactive_vars_stack.pop();
+        self.collector.reactive_vars = self.reactive_vars;
+        self._sync_converter_reactive_vars();
+    } else {
+        self.reactive_vars = set();
+        self.collector.reactive_vars = self.reactive_vars;
+        self.converter.reactive_vars = set();
+    }
+}
+
+impl IntentSession.arch_has_skip_existing -> set[str] {
+    if self.skip_existing_policy == SkipExistingPolicy.MODULE {
+        return self.collector.existing_reactive_names();
+    }
+    return set();
+}
+
+impl IntentSession.scan_arch_has(nd: uni.ArchHas) -> (ArchHasScanResult | None) {
+    import from jaclang.compiler.passes.ecmascript.intent.detection {
+        arch_has_applicable,
+        scan_arch_has
+    }
+    if self.use_arch_has_dedup and id(nd) in self._recorded_arch_has {
+        return None;
+    }
+    if not arch_has_applicable(nd, strict_client=self.strict_arch_has) {
+        return None;
+    }
+    scan = scan_arch_has(
+        nd, skip_existing=self.arch_has_skip_existing(), conv=self.converter
+    );
+    if self.use_arch_has_dedup {
+        self._recorded_arch_has.add(id(nd));
+    }
+    return scan;
+}
+
+impl IntentSession.scan_state_update(nd: uni.Assignment) -> (StateUpdate | None) {
+    import from jaclang.compiler.passes.ecmascript.intent.detection {
+        scan_state_update
+    }
+    return scan_state_update(
+        nd,
+        self.converter,
+        convert_value=lambda (v: uni.Expr | uni.YieldExpr) { self.converter.convert_assignment_value(
+            nd, v
+        ); }
+    );
+}
+
+impl IntentSession.lower_state_update(
+    nd: uni.Assignment, update: StateUpdate
+) -> (IntentLeaf | None) {
+    return self.adapter.lower_state_update(nd, update);
+}
+
+impl IntentSession.record_and_lower_effect(nd: uni.Ability) -> list[IntentLeaf] {
+    import from jaclang.compiler.passes.ecmascript.intent.detection {
+        unwrap_ability_body,
+        effect_from_ability
+    }
+    inner = unwrap_ability_body(nd);
+    body_stmts: list[IntentLeaf] = [];
+    if inner {
+        body_stmts = self.converter.convert_stmts(inner);
+    }
+    deps: list[IntentLeaf] = [];
+    if self.pass_ref is not None and hasattr(self.pass_ref, 'effect_deps') {
+        deps = self.pass_ref.effect_deps(nd);
+    }
+    effect = effect_from_ability(nd, body_stmts, deps);
+    return self.adapter.lower_effect(nd, effect);
+}

--- a/jac/jaclang/compiler/passes/ecmascript/intent/intent_target_adapter.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/intent_target_adapter.jac
@@ -1,0 +1,16 @@
+import jaclang.jac0core.unitree as uni;
+import from jaclang.compiler.passes.ecmascript.intent.detection { ArchHasScanResult }
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
+    IntentLeaf,
+    StateUpdate,
+    Effect
+}
+
+obj IntentTargetAdapter {
+    def apply_arch_has_scan(
+        nd: uni.UniNode, scan: ArchHasScanResult
+    ) -> list[IntentLeaf];
+
+    def lower_state_update(nd: uni.UniNode, u: StateUpdate) -> (IntentLeaf | None);
+    def lower_effect(nd: uni.UniNode, e: Effect) -> list[IntentLeaf];
+}

--- a/jac/jaclang/compiler/passes/ecmascript/intent/leaf_converter.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/leaf_converter.jac
@@ -1,0 +1,29 @@
+import jaclang.jac0core.unitree as uni;
+import from jaclang.compiler.passes.ecmascript.intent.semantics { IntentLeaf }
+
+obj LeafConverter {
+    has null_expr: IntentLeaf,
+        fallback_expr: IntentLeaf,
+        reactive_vars: set[str] = set();
+
+    def convert_expr(nd: uni.UniNode) -> (IntentLeaf | None);
+    def convert_ref_seed(nd: uni.UniNode) -> IntentLeaf;
+    def convert_assignment_value(
+        nd: uni.Assignment, value_nd: (uni.UniNode | None)
+    ) -> (IntentLeaf | None);
+
+    def convert_stmts(nodes: list[uni.UniNode]) -> list[IntentLeaf];
+}
+
+import type from jaclang.compiler.passes.ecmascript.esast_gen_pass { EsastGenPass }
+
+obj EsastLeafConverter(LeafConverter) {
+    has pass_inst: (EsastGenPass | None) = None;
+
+    def convert_expr(nd: uni.UniNode) -> (IntentLeaf | None);
+    def convert_assignment_value(
+        nd: uni.Assignment, value_nd: (uni.UniNode | None)
+    ) -> (IntentLeaf | None);
+
+    def convert_stmts(nodes: list[uni.UniNode]) -> list[IntentLeaf];
+}

--- a/jac/jaclang/compiler/passes/ecmascript/intent/model.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/model.jac
@@ -1,0 +1,99 @@
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
+    StateField,
+    RefField,
+    StateUpdate,
+    Effect,
+    AsyncBoundary
+}
+import type from jaclang.compiler.passes.ecmascript.view_ir { ViewElement }
+
+obj IntentRoute {
+    has path: str = "/",
+        screen_name: str = "HomeScreen",
+        component: (str | None) = None;
+}
+
+obj IntentParam {
+    has name: str = "",
+        jac_type: str = "",
+        default_kt: (str | None) = None;
+}
+
+obj IntentComponent {
+    has name: str = "",
+        params: list[IntentParam] = [],
+        state: list[StateField] = [],
+        refs: list[RefField] = [],
+        effects: list[Effect] = [],
+        asyncs: list[AsyncBoundary] = [],
+        updates: list[StateUpdate] = [],
+        view: (ViewElement | None) = None,
+        is_screen: bool = False,
+        route_path: (str | None) = None;
+}
+
+obj IntentModule {
+    has components: dict[str, IntentComponent] = {},
+        current: (str | None) = None,
+        routes: list[IntentRoute] = [],
+        imports: list[str] = [],
+        package_name: str = "dev.jac.generated",
+        app_name: str = "Jac App",
+        backend_url: str = "",
+        diagnostics: list[str] = [],
+        interop_manifest: any = None;
+
+    def add_import(imp: str) {
+        if imp not in self.imports {
+            self.imports.append(imp);
+        }
+    }
+
+    def ensure_component(name: str) -> IntentComponent {
+        if name not in self.components {
+            self.components[name] = IntentComponent(name=name);
+        }
+        return self.components[name];
+    }
+
+    def current_component -> IntentComponent {
+        cname = self.current or "__root__";
+        return self.ensure_component(cname);
+    }
+
+    def add_diagnostic(msg: str) {
+        self.diagnostics.append(msg);
+    }
+
+    def merge_from(other: IntentModule) -> None {
+        if other is None or other is self {
+            return;
+        }
+        for (name, comp) in other.components.items() {
+            dst = self.ensure_component(name);
+            if comp.view is not None {
+                dst.view = comp.view;
+            }
+            dst.state.extend(comp.state);
+            dst.refs.extend(comp.refs);
+            dst.effects.extend(comp.effects);
+            dst.asyncs.extend(comp.asyncs);
+            dst.updates.extend(comp.updates);
+            if comp.is_screen {
+                dst.is_screen = True;
+            }
+            if comp.route_path {
+                dst.route_path = comp.route_path;
+            }
+            if comp.params {
+                dst.params = list(comp.params);
+            }
+        }
+        for imp in other.imports {
+            self.add_import(imp);
+        }
+        for diag in other.diagnostics {
+            self.add_diagnostic(diag);
+        }
+    }
+}

--- a/jac/jaclang/compiler/passes/ecmascript/intent/semantics.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/semantics.jac
@@ -1,0 +1,34 @@
+import jaclang.compiler.passes.ecmascript.estree as es;
+import from jaclang.compiler.passes.compose.kotlin_ast { KtNode }
+import from typing { TypeAlias }
+
+glob IntentLeaf: TypeAlias = es.Expression | KtNode;
+
+obj StateField {
+    has name: str,
+        init_expr: IntentLeaf;
+}
+
+obj RefField {
+    has name: str,
+        init_expr: IntentLeaf;
+}
+
+obj StateUpdate {
+    has name: str,
+        value: IntentLeaf,
+        aug_op: (str | None) = None;
+}
+
+obj Effect {
+    has body: list[IntentLeaf],
+        deps: list[IntentLeaf],
+        is_entry: bool = True,
+        is_async: bool = False;
+}
+
+obj AsyncBoundary {
+    has try_expr: IntentLeaf,
+        awaiting_expr: (IntentLeaf | None),
+        except_exprs: list[IntentLeaf];
+}

--- a/jac/jaclang/compiler/passes/ecmascript/intent/session.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/intent/session.jac
@@ -1,0 +1,39 @@
+import jaclang.jac0core.unitree as uni;
+import from jaclang.compiler.passes.ecmascript.intent.collector { IntentCollector }
+import from jaclang.compiler.passes.ecmascript.intent.detection { ArchHasScanResult }
+import from jaclang.compiler.passes.ecmascript.intent.intent_target_adapter {
+    IntentTargetAdapter
+}
+import from jaclang.compiler.passes.ecmascript.intent.leaf_converter { LeafConverter }
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
+    IntentLeaf,
+    StateUpdate
+}
+
+enum SkipExistingPolicy { NONE = "none", MODULE = "module" }
+
+obj IntentSession {
+    has collector: IntentCollector,
+        adapter: IntentTargetAdapter,
+        converter: LeafConverter,
+        pass_ref: any = None,
+        component_types: Sequence[str] = (),
+        strict_arch_has: bool = False,
+        use_arch_has_dedup: bool = True,
+        skip_existing_policy: SkipExistingPolicy = SkipExistingPolicy.NONE,
+        reactive_vars: set[str] = set(),
+        reactive_vars_stack: list[set[str]] = [],
+        _recorded_arch_has: set[int] = set();
+
+    def enter_ability(nd: uni.Ability) -> None;
+    def pop_ability_scope -> None;
+    def arch_has_skip_existing -> set[str];
+    def scan_arch_has(nd: uni.ArchHas) -> (ArchHasScanResult | None);
+    def scan_state_update(nd: uni.Assignment) -> (StateUpdate | None);
+    def lower_state_update(
+        nd: uni.Assignment, update: StateUpdate
+    ) -> (IntentLeaf | None);
+
+    def record_and_lower_effect(nd: uni.Ability) -> list[IntentLeaf];
+    def _sync_converter_reactive_vars -> None;
+}

--- a/jac/jaclang/compiler/passes/ecmascript/reactive_intent.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/reactive_intent.jac
@@ -1,30 +1,12 @@
-import jaclang.compiler.passes.ecmascript.estree as es;
-
-obj StateField {
-    has name: str,
-        init_expr: es.Expression;
+import from jaclang.compiler.passes.ecmascript.intent.semantics {
+    IntentLeaf,
+    StateField,
+    RefField,
+    StateUpdate,
+    Effect,
+    AsyncBoundary
 }
-
-obj RefField {
-    has name: str,
-        init_expr: es.Expression;
-}
-
-obj StateUpdate {
-    has name: str,
-        value: es.Expression,
-        aug_op: (str | None) = None;
-}
-
-obj Effect {
-    has body: list[es.Statement],
-        deps: list[es.Expression],
-        is_entry: bool = True,
-        is_async: bool = False;
-}
-
-obj AsyncBoundary {
-    has try_expr: es.Expression,
-        awaiting_expr: (es.Expression | None),
-        except_exprs: list[es.Expression];
+import from jaclang.compiler.passes.ecmascript.intent.es_leaves {
+    IntentExpr,
+    IntentStmt
 }

--- a/jac/jaclang/jac0core/compile_options.jac
+++ b/jac/jaclang/jac0core/compile_options.jac
@@ -19,6 +19,7 @@ obj CompileOptions {
         default_codespace: str = "",
         project_kind: str = "web",
         project_root: (str | None) = None,
+        client_framework: str = "",
         cancel_token: any = None;
 
     def nogc_enforced_for(mod_name: str) -> bool {

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -1428,17 +1428,23 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
          "Argument '{name}' for server function '{func}' is given both positionally and by keyword"
      ),
      E5081 = _err("E5081", Category.CODEGEN, "Unknown client framework '{framework}'"),
+     E5082 = _err(
+         "E5082",
+         Category.CODEGEN,
+         "Client code imports '{name}' from '{module}', but '{name}' has no client-side presence",
+         help="A plain import into client code can only reference client declarations; server `def:pub` endpoints bridge automatically over RPC. Make '{name}' a `def:pub` endpoint, mark it (or its module) client, or move it into client code."
+     ),
      E5083 = _err(
          "E5083",
          Category.CODEGEN,
          "na import targets collide on wasm artifact '{stem}.wasm': '{path}' vs '{other}'",
          help="Every `na import` target emits /static/<stem>.wasm named by its file stem, and set_na_env / __na_bind address the module by that stem, so two different native modules with the same basename would overwrite each other's artifact and bind to the wrong exports. Rename one of the files."
      ),
-     E5082 = _err(
-         "E5082",
+     E5085 = _err(
+         "E5085",
          Category.CODEGEN,
-         "Client code imports '{name}' from '{module}', but '{name}' has no client-side presence",
-         help="A plain import into client code can only reference client declarations; server `def:pub` endpoints bridge automatically over RPC. Make '{name}' a `def:pub` endpoint, mark it (or its module) client, or move it into client code."
+         "Client framework 'compose' is the Android (Jetpack Compose) surface and cannot be lowered through the web/ES client",
+         help="Compose codegen only runs under the Android target. To build for the web, remove `[client] framework = \"compose\"` (or the --client-framework compose override); to build the Compose app, use `jac start --client android`."
      ),
      E5084 = _err(
          "E5084",

--- a/jac/jaclang/jac0core/passes/ast_gen/impl/jsx_processor.impl.jac
+++ b/jac/jaclang/jac0core/passes/ast_gen/impl/jsx_processor.impl.jac
@@ -114,8 +114,9 @@ impl EsJsxProcessor.element(self: EsJsxProcessor, nd: uni.JsxElement) -> Express
     }
     view = ViewElement(tag=tag, attrs=attrs, children=children, jac_node=nd);
     self._view_by_node[id(nd)] = view;
-    self.pass_ref._ensure_backend();
-    return self.pass_ref.backend.lower_view(view, self.pass_ref.sync_loc);
+    return self.pass_ref.intent_session.adapter.lower_view(
+        view, self.pass_ref.sync_loc
+    );
 }
 
 impl EsJsxProcessor._lift_control_flow(

--- a/jac/jaclang/project/client_kind.jac
+++ b/jac/jaclang/project/client_kind.jac
@@ -50,3 +50,59 @@ def mobui_enforced_for(
     }
     return not mobui_module_exempt(mod_path, proj_root);
 }
+
+obj ClientSurface {
+    has framework: str = "react",
+        kind: str = "web",
+        project_root: (str | None) = None,
+        is_compose: bool = False,
+        is_mobui: bool = False;
+}
+
+def resolve_client_surface(
+    mod_path: str,
+    framework_override: str = "",
+    explicit_kind: str = "web",
+    explicit_root: (str | None) = None,
+) -> ClientSurface {
+    (kind, proj_root) = resolve_client_kind_context(
+        mod_path, explicit_kind, explicit_root
+    );
+    override = framework_override or "";
+    if override == "compose" {
+        framework = "compose";
+        is_compose = True;
+    } elif override {
+        framework = override;
+        is_compose = False;
+    } else {
+        cfg = _config_for(mod_path);
+        framework = (cfg.client.framework if (cfg and cfg.client) else "") or "react";
+        is_compose = compose_enforced_for(mod_path);
+    }
+    is_mobui = mobui_enforced_for(mod_path, explicit_kind, explicit_root);
+    return ClientSurface(
+        framework=framework,
+        kind=kind,
+        project_root=proj_root,
+        is_compose=is_compose,
+        is_mobui=is_mobui,
+    );
+}
+
+def compose_enforced_for(mod_path: str) -> bool {
+    cfg = _config_for(mod_path);
+    if not cfg or cfg.project_root is None {
+        return False;
+    }
+    framework = (cfg.client.framework if cfg.client else "") or "";
+    if framework != "compose" {
+        return False;
+    }
+    if not mod_path {
+        return False;
+    }
+    real_mod = os.path.normcase(os.path.realpath(mod_path));
+    real_root = os.path.normcase(os.path.realpath(str(cfg.project_root)));
+    return real_mod == real_root or real_mod.startswith(real_root + os.sep);
+}

--- a/jac/tests/compiler/passes/ecmascript/test_preact_backend.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_preact_backend.jac
@@ -46,11 +46,10 @@ def compile_fixture_with_backend(fixture_name: str, backend: object) -> str {
 test "react backend reports runtime symbols for reactive lowering" {
     backend = ReactBackend();
     init = es.Literal(value=0, raw="0");
-    assert backend.state_field_symbols(StateField(name="count", init_expr=init))
+    assert backend.runtime_symbols(StateField(name="count", init_expr=init))
         == ["useState"];
-    assert backend.ref_field_symbols(RefField(name="node", init_expr=init))
-        == ["useRef"];
-    assert backend.effect_symbols(
+    assert backend.runtime_symbols(RefField(name="node", init_expr=init)) == ["useRef"];
+    assert backend.runtime_symbols(
         Effect(body=[], deps=[], is_entry=True, is_async=False)
     )
         == ["useEffect"];
@@ -58,22 +57,22 @@ test "react backend reports runtime symbols for reactive lowering" {
     awaiting_only = AsyncBoundary(
         try_expr=try_expr, awaiting_expr=None, except_exprs=[]
     );
-    assert backend.async_boundary_symbols(awaiting_only) == ["JacAwaiting"];
+    assert backend.runtime_symbols(awaiting_only) == ["JacAwaiting"];
     with_except = AsyncBoundary(
         try_expr=try_expr,
         awaiting_expr=None,
         except_exprs=[es.Identifier(name="onErr")]
     );
-    assert backend.async_boundary_symbols(with_except)
+    assert backend.runtime_symbols(with_except)
         == ["JacAwaiting", "JacClientErrorBoundary"];
 }
 
 test "preact backend inherits hook symbol names from react" {
     backend = PreactBackend();
     init = es.Literal(value=0, raw="0");
-    assert backend.state_field_symbols(StateField(name="count", init_expr=init))
+    assert backend.runtime_symbols(StateField(name="count", init_expr=init))
         == ["useState"];
-    assert backend.effect_symbols(
+    assert backend.runtime_symbols(
         Effect(body=[], deps=[], is_entry=True, is_async=False)
     )
         == ["useEffect"];
@@ -155,27 +154,26 @@ test "vite_aliases returns empty for react and compat mapping for preact" {
     assert preact_aliases == {"react": "preact/compat", "react-dom": "preact/compat"};
 }
 
-test "preact async_boundary_symbols with except arms returns both symbols" {
+test "preact runtime_symbols for async_boundary with except arms returns both" {
     backend = PreactBackend();
     try_expr = es.Identifier(name="tryFn");
     awaiting_only = AsyncBoundary(
         try_expr=try_expr, awaiting_expr=None, except_exprs=[]
     );
-    assert backend.async_boundary_symbols(awaiting_only) == ["JacAwaiting"];
+    assert backend.runtime_symbols(awaiting_only) == ["JacAwaiting"];
     with_except = AsyncBoundary(
         try_expr=try_expr,
         awaiting_expr=None,
         except_exprs=[es.Identifier(name="onErr")]
     );
-    assert backend.async_boundary_symbols(with_except)
+    assert backend.runtime_symbols(with_except)
         == ["JacAwaiting", "JacClientErrorBoundary"];
 }
 
-test "preact ref_field_symbols inherits useRef from react" {
+test "preact runtime_symbols inherits useRef from react for refs" {
     backend = PreactBackend();
     init = es.Literal(value=0, raw="0");
-    assert backend.ref_field_symbols(RefField(name="node", init_expr=init))
-        == ["useRef"];
+    assert backend.runtime_symbols(RefField(name="node", init_expr=init)) == ["useRef"];
 }
 
 test "react client runtime shim imports no solid ecosystem package" {

--- a/jac/tests/compiler/passes/ecmascript/test_solid_backend.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_solid_backend.jac
@@ -74,15 +74,15 @@ test "resolve_active_backend reads solid from project config" {
 test "solid reports signals runtime symbols for reactive lowering" {
     backend = SolidBackend();
     init = es.Literal(value=0, raw="0");
-    assert backend.state_field_symbols(StateField(name="count", init_expr=init))
+    assert backend.runtime_symbols(StateField(name="count", init_expr=init))
         == ["createSignal"];
     # Refs are deferred on Solid — a `let` binding needs no import.
-    assert backend.ref_field_symbols(RefField(name="node", init_expr=init)) == [];
-    assert backend.effect_symbols(
+    assert backend.runtime_symbols(RefField(name="node", init_expr=init)) == [];
+    assert backend.runtime_symbols(
         Effect(body=[], deps=[], is_entry=True, is_async=False)
     )
         == ["createEffect"];
-    assert backend.effect_symbols(
+    assert backend.runtime_symbols(
         Effect(body=[], deps=[], is_entry=False, is_async=False)
     )
         == ["onCleanup"];
@@ -90,13 +90,13 @@ test "solid reports signals runtime symbols for reactive lowering" {
     awaiting_only = AsyncBoundary(
         try_expr=try_expr, awaiting_expr=None, except_exprs=[]
     );
-    assert backend.async_boundary_symbols(awaiting_only) == ["Suspense"];
+    assert backend.runtime_symbols(awaiting_only) == ["Suspense"];
     with_except = AsyncBoundary(
         try_expr=try_expr,
         awaiting_expr=None,
         except_exprs=[es.Identifier(name="onErr")]
     );
-    assert backend.async_boundary_symbols(with_except) == ["Suspense", "ErrorBoundary"];
+    assert backend.runtime_symbols(with_except) == ["Suspense", "ErrorBoundary"];
 }
 
 test "solid read seam lowers a reactive read to an accessor call" {

--- a/jac/tests/compiler/test_backend_purity.jac
+++ b/jac/tests/compiler/test_backend_purity.jac
@@ -78,10 +78,18 @@ glob FORBIDDEN: dict[str, str] = {
              "recorded InteropBinding"
          ),
          ("ecmascript/impl/esast_gen_pass.impl.jac", "type_tag.tag"): (
-             9,
+             8,
              "declaration-surface name reads: param/field type-name maps "
              "for interop payloads, Ref[...] head detection, and the W6005 "
              "Callable-over-RPC guard on endpoint params - the declared "
+             "annotation is the consumed fact, not a resolved type. The "
+             "has-var Ref-typed field detection moved to the shared intent "
+             "pipeline (intent/impl/detection.impl.jac)"
+         ),
+         ("ecmascript/intent/impl/detection.impl.jac", "type_tag.tag"): (
+             1,
+             "declaration-surface name read: is_ref_field tests whether a "
+             "has-var's declared annotation head is Ref[...] - the declared "
              "annotation is the consumed fact, not a resolved type"
          ),
          ("native/na_ir_gen_pass.impl/stmt.impl.jac", "symbol_utils"): (


### PR DESCRIPTION
Layer 1 of a 4-PR stack splitting #7808 (Android/Compose target) into reviewable layers. Extracts the backend-agnostic intent pipeline, esast hooks, and the foundational kotlin_ast/client_kind resolvers. JS backends byte-identical.