### PR TITLE
feat(native): native_stdlib_root helper + dylib type binding

### DIFF
--- a/jac/jaclang/compiler/passes/native/llvm/binding/dylib.jac
+++ b/jac/jaclang/compiler/passes/native/llvm/binding/dylib.jac
@@ -1,11 +1,27 @@
 import from ctypes { c_void_p, c_char_p, c_bool, POINTER }
 import from jaclang.compiler.passes.native.llvm.binding { ffi }
 import from jaclang.compiler.passes.native.llvm.binding.common { _encode_string }
+
+glob _dylib_types_ready: bool = False;
+
+def _ensure_dylib_types -> None {
+    if _dylib_types_ready {
+        return;
+    }
+    ffi.lib.LLVMPY_AddSymbol.argtypes = [c_char_p, c_void_p];
+    ffi.lib.LLVMPY_SearchAddressOfSymbol.argtypes = [c_char_p];
+    ffi.lib.LLVMPY_SearchAddressOfSymbol.restype = c_void_p;
+    ffi.lib.LLVMPY_LoadLibraryPermanently.argtypes = [c_char_p, POINTER(c_char_p)];
+    ffi.lib.LLVMPY_LoadLibraryPermanently.restype = c_bool;
+    _dylib_types_ready = True;
+}
+
 """
     Get the in-process address of symbol named *name*.
     An integer is returned, or None if the symbol isn't found.
     """
 def address_of_symbol(name: Any) -> object {
+    _ensure_dylib_types();
     return ffi.lib.LLVMPY_SearchAddressOfSymbol(_encode_string(name));
 }
 
@@ -14,6 +30,7 @@ def address_of_symbol(name: Any) -> object {
     it usable (e.g. callable) from LLVM-compiled functions.
     """
 def add_symbol(name: Any, address: Any) -> object {
+    _ensure_dylib_types();
     ffi.lib.LLVMPY_AddSymbol(_encode_string(name), c_void_p(address));
 }
 
@@ -21,18 +38,10 @@ def add_symbol(name: Any, address: Any) -> object {
     Load an external library
     """
 def load_library_permanently(filename: Any) -> object {
+    _ensure_dylib_types();
     with ffi.OutputString() as outerr {
         if ffi.lib.LLVMPY_LoadLibraryPermanently(_encode_string(filename), outerr) {
             raise RuntimeError(str(outerr));
         }
     }
 }
-
-with entry {
-    ffi.lib.LLVMPY_AddSymbol.argtypes = [c_char_p, c_void_p];
-    ffi.lib.LLVMPY_SearchAddressOfSymbol.argtypes = [c_char_p];
-    ffi.lib.LLVMPY_SearchAddressOfSymbol.restype = c_void_p;
-    ffi.lib.LLVMPY_LoadLibraryPermanently.argtypes = [c_char_p, POINTER(c_char_p)];
-    ffi.lib.LLVMPY_LoadLibraryPermanently.restype = c_bool;
-}
-

--- a/jac/jaclang/jac0core/codeinfo.jac
+++ b/jac/jaclang/jac0core/codeinfo.jac
@@ -176,8 +176,10 @@ def native_stdlib_root -> (str | None) {
     if not jaclang?.__file__ {
         return None;
     }
-    root = os.path.join(os.path.dirname(jaclang.__file__), "runtimelib", "na_stdlib");
-    return root if os.path.isdir(root) else None;
+    stdlib_root = os.path.join(
+        os.path.dirname(jaclang.__file__), "runtimelib", "na_stdlib"
+    );
+    return stdlib_root if os.path.isdir(stdlib_root) else None;
 }
 
 def is_native_by_location(file_path: str) -> bool {
@@ -223,12 +225,12 @@ def is_client_by_location(file_path: str) -> bool {
 
 def is_bundled_native_module(module_name: str) -> bool {
     import os;
-    root = native_stdlib_root();
-    if root is None or not module_name {
+    stdlib_root = native_stdlib_root();
+    if stdlib_root is None or not module_name {
         return False;
     }
     path_name = module_name.lstrip('.').replace('.', os.sep);
-    return _native_variant_path(os.path.join(root, path_name)) is not None;
+    return _native_variant_path(os.path.join(stdlib_root, path_name)) is not None;
 }
 
 def native_target_os -> str {


### PR DESCRIPTION
Split out from #7808 — orthogonal native-LLVM pathway helpers (native_stdlib_root, used by na_compile_pass; _ensure_dylib_types). Independent of the Android/Compose stack (#7892).