### PR TITLE
ci: dev-source lane for test jobs; binary rebuilds only on launcher changes

### DIFF
--- a/.github/actions/setup-jac-dev/action.yml
+++ b/.github/actions/setup-jac-dev/action.yml
@@ -65,10 +65,14 @@ runs:
       run: echo "XDG_CACHE_HOME=$GITHUB_WORKSPACE/.jac-xdg" >> "$GITHUB_ENV"
 
     # Rare path (launcher/build/native-pin PRs): full sealed build, the same
-    # cost every job paid before the dev lane existed.
+    # cost every job paid before the dev lane existed -- minus the neovim
+    # editor closure (ninja: false), which tests never open and whose Lua
+    # dependency rides the flakiest fetch in the build (lua.org).
     - name: Fall back to the full sealed setup
       if: steps.hostbin.outputs.cache-hit != 'true' || steps.shim.outputs.cache-hit != 'true'
       uses: ./.github/actions/setup-jac
+      with:
+        ninja: "false"
 
     # Seed/refresh the host entry after a fallback build. Saved from every
     # branch: the key only moves on launcher/build/native changes, so churn is

--- a/.github/actions/setup-jac-dev/action.yml
+++ b/.github/actions/setup-jac-dev/action.yml
@@ -1,0 +1,112 @@
+name: Set up jac (dev lane)
+description: >
+  Make a HOST jac binary available and run THIS checkout's compiler through the
+  repo's `[dev] jaclang_source` loop instead of the sealed payload. Any sealed
+  binary whose launcher/runtime inputs match works as the host -- its bundled
+  jaclang is bypassed at runtime -- so the host cache key deliberately ignores
+  jac/jaclang/**: compiler edits keep hitting one stable entry and PRs never
+  rebuild the binary. Callers must clear JAC_NO_DEV_SOURCE at the job level
+  (env: JAC_NO_DEV_SOURCE: "") for the dev loop to engage.
+
+  The dev path serves EVERYTHING from the checkout, so the gitignored pieces a
+  sealed payload would bundle must be materialized here: the LLVMPY shim (the
+  compile schedule ctypes-loads it at import time -- no payload fallback) and
+  the typeshed stdlib stubs. Both restore from the same cache entries
+  setup-jac maintains (keys must match it verbatim). A host-binary or shim
+  miss (a launcher/build/native-pin PR) falls back to the full setup-jac
+  sealed build -- exactly today's cost, on the rare PRs that need it.
+runs:
+  using: composite
+  steps:
+    - name: Restore host jac binary
+      id: hostbin
+      uses: actions/cache/restore@v4
+      with:
+        path: jac/zig-out/bin/jac
+        key: jac-hostbin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/build.zig', 'jac/build.zig.zon', 'jac/launcher/**', 'jac/native/**') }}
+
+    # Key mirrors setup-jac's shim cache verbatim so both lanes share entries.
+    - name: Restore LLVMPY shim into the checkout
+      id: shim
+      uses: actions/cache/restore@v4
+      with:
+        path: jac/jaclang/compiler/passes/native/llvm/libjacllvm.*
+        key: jac-shim-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/native/**', 'jac/build.zig', 'jac/launcher/llvm_release.zig') }}
+
+    # Key mirrors setup-jac's typeshed cache verbatim.
+    - name: Restore typeshed stdlib stubs
+      id: typeshed
+      uses: actions/cache/restore@v4
+      with:
+        path: jac/jaclang/vendor/typeshed/stdlib
+        key: typeshed-stdlib-${{ hashFiles('jac/jaclang/vendor/typeshed/PIN', 'jac/jaclang/vendor/typeshed/TARBALL_SHA256', 'jac/launcher/payload.zig') }}
+
+    # Two-tier JIR compile cache: the global tier (redirected via
+    # XDG_CACHE_HOME below) plus the project tier. Every .jir embeds a
+    # content-addressed module key (source sha256 + jaclang version + codegen
+    # fingerprint), so a stale restore can only miss, never mis-serve -- which
+    # is what makes restore-keys safe: any prior tree turns the from-source
+    # compiler bootstrap into a delta compile of just the edited modules.
+    - name: Restore JIR compile caches
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          .jac-xdg/jac/jir
+          jac/.jac/cache
+        key: jac-jir-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
+        restore-keys: |
+          jac-jir-${{ runner.os }}-${{ runner.arch }}-
+
+    # The runtime honors XDG_CACHE_HOME for its cache root; point it at the
+    # restored tree so compile work accumulates there instead of a job-local
+    # HOME that jobs routinely isolate with mktemp.
+    - name: Point the runtime cache at the restored tree
+      shell: bash
+      run: echo "XDG_CACHE_HOME=$GITHUB_WORKSPACE/.jac-xdg" >> "$GITHUB_ENV"
+
+    # Rare path (launcher/build/native-pin PRs): full sealed build, the same
+    # cost every job paid before the dev lane existed.
+    - name: Fall back to the full sealed setup
+      if: steps.hostbin.outputs.cache-hit != 'true' || steps.shim.outputs.cache-hit != 'true'
+      uses: ./.github/actions/setup-jac
+
+    # Seed/refresh the host entry after a fallback build. Saved from every
+    # branch: the key only moves on launcher/build/native changes, so churn is
+    # near-zero, and PR-scoped saves let the PR's own later pushes hit.
+    - name: Save host binary cache
+      if: steps.hostbin.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: jac/zig-out/bin/jac
+        key: jac-hostbin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/build.zig', 'jac/build.zig.zon', 'jac/launcher/**', 'jac/native/**') }}
+
+    - name: Set up Zig 0.16.0 (typeshed fetch fallback)
+      if: steps.hostbin.outputs.cache-hit == 'true' && steps.typeshed.outputs.cache-hit != 'true'
+      uses: mlugg/setup-zig@v2
+      with:
+        version: 0.16.0
+        use-cache: false
+
+    - name: Materialize typeshed stdlib stubs
+      if: steps.hostbin.outputs.cache-hit == 'true' && steps.typeshed.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: jac
+      # -Dno-ninja: materializing stubs must not drag in the editor closure.
+      run: zig build -Dno-ninja fetch-typeshed --summary all
+
+    # The fallback path's setup-jac already put jac on PATH.
+    - name: Put jac on PATH
+      if: steps.hostbin.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        mkdir -p "$HOME/.jacbin"
+        ln -sf "$GITHUB_WORKSPACE/jac/zig-out/bin/jac" "$HOME/.jacbin/jac"
+        echo "$HOME/.jacbin" >> "$GITHUB_PATH"
+
+    # Compiles the checkout's compiler into the restored JIR cache (a delta
+    # compile after a restore-keys hit). Kept as its own step so the dev-loop
+    # bootstrap cost is visible in the job timeline, and so a broken dev loop
+    # fails here rather than mid-suite.
+    - name: Warm the dev-loop compiler cache
+      shell: bash
+      run: jac --version

--- a/.github/actions/setup-jac-dev/action.yml
+++ b/.github/actions/setup-jac-dev/action.yml
@@ -73,6 +73,9 @@ runs:
       uses: ./.github/actions/setup-jac
       with:
         ninja: "false"
+        # The dev loop bypasses the bundled compiler, so the ~24-min payload
+        # JIR precompile would be pure waste on this path.
+        skip-precompile: "true"
 
     # Seed/refresh the host entry after a fallback build. Saved from every
     # branch: the key only moves on launcher/build/native changes, so churn is

--- a/.github/actions/setup-jac/action.yml
+++ b/.github/actions/setup-jac/action.yml
@@ -190,15 +190,13 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true' && steps.shim-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: jac
-      # Configuring the build graph without -Dno-ninja fetches the neovim +
-      # Lua closure (incl. the flaky lua.org tarball) even though this step
-      # only needs the LLVM slice -- honor the ninja input here too.
-      run: |
-        NINJA_ARG=()
-        if [ "${{ inputs.ninja }}" != "true" ]; then
-          NINJA_ARG=(-Dno-ninja)
-        fi
-        zig build "${NINJA_ARG[@]}" fetch-llvm --summary all
+      # -Dno-ninja unconditionally: fetching the LLVM slice is
+      # editor-independent (exactly like fetch-typeshed below), and
+      # configuring the graph without it drags the neovim + Lua closure
+      # (incl. the flaky lua.org tarball) into a step that cannot retry.
+      # The fused build still configures ninja itself, inside the retried
+      # build step.
+      run: zig build -Dno-ninja fetch-llvm --summary all
 
     - name: Fetch typeshed stdlib stubs
       if: steps.typeshed-cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup-jac/action.yml
+++ b/.github/actions/setup-jac/action.yml
@@ -12,6 +12,17 @@ description: >
   a miss). Exact-key match only (no restore-keys), so a stale binary can never
   be served -- which is why this is safe even though zig's own incremental cache
   stays disabled (it doesn't reliably invalidate on a jaclang/payload change).
+inputs:
+  ninja:
+    description: >
+      Fuse the neovim editor closure into the binary. The closure's Lua
+      dependency is fetched from lua.org on a cold package store -- the
+      flakiest fetch in the whole build -- and test workloads never open the
+      editor, so dev-lane fallbacks pass "false" to skip it entirely. A
+      no-ninja binary is never saved to the shared jac-bin cache (release
+      flows restore that key and must get the fused editor).
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
@@ -198,7 +209,11 @@ runs:
           cp jaclang/compiler/passes/native/llvm/libjacllvm.* .shim-build/
           SHIM_ARG=(-Dshim-bin=".shim-build/$(ls .shim-build | head -1)")
         fi
-        zig build "${SHIM_ARG[@]}" --summary all
+        NINJA_ARG=()
+        if [ "${{ inputs.ninja }}" != "true" ]; then
+          NINJA_ARG=(-Dno-ninja)
+        fi
+        zig build "${NINJA_ARG[@]}" "${SHIM_ARG[@]}" --summary all
 
     # Seed the shared binary cache from main only (see the note by the restore
     # step). Saved after the build so both the binary and the materialized
@@ -206,7 +221,8 @@ runs:
     - name: Save jac binary cache (main only)
       if: >-
         github.ref == 'refs/heads/main' &&
-        steps.cache.outputs.cache-hit != 'true'
+        steps.cache.outputs.cache-hit != 'true' &&
+        inputs.ninja == 'true'
       uses: actions/cache/save@v4
       with:
         path: |

--- a/.github/actions/setup-jac/action.yml
+++ b/.github/actions/setup-jac/action.yml
@@ -23,6 +23,14 @@ inputs:
       flows restore that key and must get the fused editor).
     required: false
     default: "true"
+  skip-precompile:
+    description: >
+      Skip the payload JIR precompile (~24 min cold). Only sane for dev-lane
+      fallbacks, whose runtime bypasses the bundled compiler entirely via the
+      [dev] jaclang_source loop; a skip-precompile binary is never saved to
+      the shared jac-bin cache.
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -182,7 +190,15 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true' && steps.shim-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: jac
-      run: zig build fetch-llvm --summary all
+      # Configuring the build graph without -Dno-ninja fetches the neovim +
+      # Lua closure (incl. the flaky lua.org tarball) even though this step
+      # only needs the LLVM slice -- honor the ninja input here too.
+      run: |
+        NINJA_ARG=()
+        if [ "${{ inputs.ninja }}" != "true" ]; then
+          NINJA_ARG=(-Dno-ninja)
+        fi
+        zig build "${NINJA_ARG[@]}" fetch-llvm --summary all
 
     - name: Fetch typeshed stdlib stubs
       if: steps.typeshed-cache.outputs.cache-hit != 'true'
@@ -213,7 +229,20 @@ runs:
         if [ "${{ inputs.ninja }}" != "true" ]; then
           NINJA_ARG=(-Dno-ninja)
         fi
-        zig build "${NINJA_ARG[@]}" "${SHIM_ARG[@]}" --summary all
+        PRE_ARG=()
+        if [ "${{ inputs.skip-precompile }}" = "true" ]; then
+          PRE_ARG=(-Dskip-precompile)
+        fi
+        # Retried: the cold-store fetches (lua.org especially) time out
+        # transiently, and one flake otherwise costs a whole run.
+        for attempt in 1 2 3; do
+          if zig build "${NINJA_ARG[@]}" "${PRE_ARG[@]}" "${SHIM_ARG[@]}" --summary all; then
+            exit 0
+          fi
+          echo "zig build failed (attempt $attempt); retrying in 30s"
+          sleep 30
+        done
+        exit 1
 
     # Seed the shared binary cache from main only (see the note by the restore
     # step). Saved after the build so both the binary and the materialized
@@ -222,7 +251,8 @@ runs:
       if: >-
         github.ref == 'refs/heads/main' &&
         steps.cache.outputs.cache-hit != 'true' &&
-        inputs.ninja == 'true'
+        inputs.ninja == 'true' &&
+        inputs.skip-precompile != 'true'
       uses: actions/cache/save@v4
       with:
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -783,6 +783,18 @@ jobs:
     - name: Set up jac (dev lane)
       uses: ./.github/actions/setup-jac-dev
 
+    - name: Set up Zig 0.16.0 (vendor the wasm floor)
+      uses: mlugg/setup-zig@v2
+      with:
+        version: 0.16.0
+        use-cache: false
+
+    - name: Vendor wasm libc floor
+      working-directory: jac
+      # On a host-cache hit no zig build runs, so the na->wasm floor that
+      # test_wasm_build exercises must be materialized explicitly.
+      run: zig build -Dno-ninja vendor-wasm-libc --summary all
+
     - name: Run native Mach-O linker regression tests
       run: |
         jac test jac/tests/compiler/passes/native/test_shared_lib.jac
@@ -839,6 +851,12 @@ jobs:
 
     - name: Set up jac (dev lane)
       uses: ./.github/actions/setup-jac-dev
+
+    - name: Set up Zig 0.16.0 (vendor cross musl)
+      uses: mlugg/setup-zig@v2
+      with:
+        version: 0.16.0
+        use-cache: false
 
     - name: Vendor cross musl (aarch64)
       working-directory: jac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
               - 'jac/**'
               - '.github/workflows/ci.yml'
               - '.github/actions/setup-jac/**'
+              - '.github/actions/setup-jac-dev/**'
             scale:
               - 'jac/jaclang/scale/**'
             byllm:
@@ -72,6 +73,15 @@ jobs:
 
       - name: Set up jac (build the binary once, cached)
         uses: ./.github/actions/setup-jac
+
+      # Seed the dev-lane host cache with the same sealed binary under a key
+      # that ignores jac/jaclang/** (the dev lane bypasses the payload compiler
+      # at runtime), so compiler-only PRs keep hitting one stable entry.
+      - name: Save host binary cache (dev lane)
+        uses: actions/cache/save@v4
+        with:
+          path: jac/zig-out/bin/jac
+          key: jac-hostbin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/build.zig', 'jac/build.zig.zon', 'jac/launcher/**', 'jac/native/**') }}
 
       # On a binary-cache hit the build (and its typeshed fetch) is skipped;
       # fetch-typeshed is a cheap idempotent materializer either way.
@@ -150,26 +160,19 @@ jobs:
 
   # Compiler half of the full repo suite, via the binary's own test runner.
   test-compiler:
-    needs: [changes, build-jac]
+    needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Dev lane: the compiler under test is THIS checkout via the repo's
+    # [dev] jaclang_source loop; the cached host binary never rebuilds on
+    # compiler PRs. Sealed-path coverage: build-jac's smoke per PR plus the
+    # full sealed sweep in nightly.yml.
+    env:
+      JAC_NO_DEV_SOURCE: ""
     steps:
       - uses: actions/checkout@v5
-      - name: Restore typeshed stdlib stubs into the checkout
-        uses: actions/download-artifact@v4
-        with:
-          name: typeshed-stdlib
-          path: jac/jaclang/vendor/typeshed/stdlib
-      - name: Download the jac binary
-        uses: actions/download-artifact@v4
-        with:
-          name: jac-binary
-          path: bin
-      - name: Put jac on PATH
-        # upload-artifact strips the executable bit; restore it.
-        run: |
-          chmod +x "$PWD/bin/jac"
-          echo "$PWD/bin" >> "$GITHUB_PATH"
+      - name: Set up jac (dev lane)
+        uses: ./.github/actions/setup-jac-dev
       - name: Set up Node.js (ES backend for the equivalence suite)
         uses: actions/setup-node@v4
         with:
@@ -221,12 +224,25 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$rc"
 
+      # Refresh the shared JIR cache the dev lane restores (content-addressed
+      # entries: a stale tree can only miss, never mis-serve). One seeder job
+      # bounds pool churn; PR-scoped saves cover the PR's own later pushes,
+      # main saves seed every branch.
+      - name: Save JIR compile caches
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .jac-xdg/jac/jir
+            jac/.jac/cache
+          key: jac-jir-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
+
   # Native lowering unavailable (LLVM shim absent): user programs must compile
   # cleanly in the server codespace with zero scheduling errors and no
   # native-demotion fallback. This path never runs elsewhere in CI because
   # every other job builds or bundles the shim (#7871 workstream H).
   test-no-llvm:
-    needs: [changes, build-jac]
+    needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -248,11 +264,22 @@ jobs:
           echo "$out" | grep -qx '42'
           ! echo "$out" | grep -q 'scheduling error'
           ! echo "$out" | grep -q 'preferred native but did not lower'
-      - name: Restore typeshed stdlib stubs into the checkout
-        uses: actions/download-artifact@v4
+      - name: Restore typeshed stdlib stubs (shared cache)
+        id: typeshed
+        uses: actions/cache/restore@v4
         with:
-          name: typeshed-stdlib
           path: jac/jaclang/vendor/typeshed/stdlib
+          key: typeshed-stdlib-${{ hashFiles('jac/jaclang/vendor/typeshed/PIN', 'jac/jaclang/vendor/typeshed/TARBALL_SHA256', 'jac/launcher/payload.zig') }}
+      - name: Set up Zig 0.16.0 (typeshed fetch fallback)
+        if: steps.typeshed.outputs.cache-hit != 'true'
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+          use-cache: false
+      - name: Materialize typeshed stdlib stubs
+        if: steps.typeshed.outputs.cache-hit != 'true'
+        working-directory: jac
+        run: zig build -Dno-ninja fetch-typeshed --summary all
       - name: No-LLVM compile (typeshed present, shim absent)
         working-directory: jac
         run: |
@@ -268,20 +295,16 @@ jobs:
 
   # Everything except the compiler tests.
   test-runtime:
-    needs: [changes, build-jac]
+    needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Dev lane: run THIS checkout's compiler (see test-compiler).
+    env:
+      JAC_NO_DEV_SOURCE: ""
     steps:
       - uses: actions/checkout@v5
-      - name: Download the jac binary
-        uses: actions/download-artifact@v4
-        with:
-          name: jac-binary
-          path: bin
-      - name: Put jac on PATH
-        run: |
-          chmod +x "$PWD/bin/jac"
-          echo "$PWD/bin" >> "$GITHUB_PATH"
+      - name: Set up jac (dev lane)
+        uses: ./.github/actions/setup-jac-dev
       - name: Set up Node.js (JS backend tests)
         uses: actions/setup-node@v4
         with:
@@ -318,6 +341,9 @@ jobs:
   # satisfy branch protection); it restores the same binary cache itself.
   jac-check:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Dev lane: run THIS checkout's compiler (see test-compiler).
+    env:
+      JAC_NO_DEV_SOURCE: ""
     permissions:
       contents: write
     steps:
@@ -349,8 +375,8 @@ jobs:
           echo "Changed .jac files in this PR:"
           cat changed-jac.txt || true
 
-      - name: Set up jac (build the binary)
-        uses: ./.github/actions/setup-jac
+      - name: Set up jac (dev lane)
+        uses: ./.github/actions/setup-jac-dev
 
       - name: Install plugin deps so jac check resolves scale/byllm imports
         # Pins mirror jac/jaclang/project/capabilities.jac.
@@ -518,6 +544,9 @@ jobs:
     # On push to main, only worth running when docs changed.
     if: ${{ github.event_name != 'push' || needs.changes.outputs.docs == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Dev lane: run THIS checkout's compiler (see test-compiler).
+    env:
+      JAC_NO_DEV_SOURCE: ""
     steps:
       - uses: actions/checkout@v5
         with:
@@ -559,8 +588,8 @@ jobs:
             exit 1
           fi
 
-      - name: Set up jac (build the binary)
-        uses: ./.github/actions/setup-jac
+      - name: Set up jac (dev lane)
+        uses: ./.github/actions/setup-jac-dev
 
       - name: Validate Jac code blocks in the docs corpus
         run: jac run scripts/validate_docs_code.jac
@@ -577,9 +606,12 @@ jobs:
         run: bash scripts/check-release-notes.sh
 
   test-solid-and-desktop:
-    needs: [changes, build-jac]
+    needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.desktop == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Dev lane: run THIS checkout's compiler (see test-compiler).
+    env:
+      JAC_NO_DEV_SOURCE: ""
     steps:
     - name: Check out code
       uses: actions/checkout@v5
@@ -594,18 +626,8 @@ jobs:
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
 
-    - name: Download the jac binary (build-jac artifact)
-      uses: actions/download-artifact@v4
-      with:
-        name: jac-binary
-        path: jac/zig-out/bin
-
-    - name: Put jac on PATH
-      # upload-artifact strips the executable bit; restore it. The artifact
-      # lands at jac/zig-out/bin, where setup-jac would have built it.
-      run: |
-        chmod +x "$PWD/jac/zig-out/bin/jac"
-        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
+    - name: Set up jac (dev lane)
+      uses: ./.github/actions/setup-jac-dev
 
     - name: Run Solid jsdom runtime test
       env:
@@ -616,8 +638,10 @@ jobs:
       run: jac test jac/tests/runtimelib/client/test_desktop_binding.jac
 
   test-client:
-    needs: build-jac
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Dev lane: run THIS checkout's compiler (see test-compiler).
+    env:
+      JAC_NO_DEV_SOURCE: ""
     steps:
     - name: Check out code
       uses: actions/checkout@v5
@@ -632,18 +656,8 @@ jobs:
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
 
-    - name: Download the jac binary (build-jac artifact)
-      uses: actions/download-artifact@v4
-      with:
-        name: jac-binary
-        path: jac/zig-out/bin
-
-    - name: Put jac on PATH
-      # upload-artifact strips the executable bit; restore it. The artifact
-      # lands at jac/zig-out/bin, where setup-jac would have built it.
-      run: |
-        chmod +x "$PWD/jac/zig-out/bin/jac"
-        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
+    - name: Set up jac (dev lane)
+      uses: ./.github/actions/setup-jac-dev
 
     - name: Set environment for testing
       run: echo "TEST_ENV=true" >> $GITHUB_ENV
@@ -668,27 +682,20 @@ jobs:
         jac test -vv jac/tests/runtimelib/client/test_inprocess_dispatch.jac
 
   test-packages-and-docs:
-    needs: [changes, build-jac]
+    needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.byllm == 'true' || needs.changes.outputs.docs == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Dev lane: run THIS checkout's compiler (see test-compiler).
+    env:
+      JAC_NO_DEV_SOURCE: ""
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
         submodules: true
 
-    - name: Download the jac binary (build-jac artifact)
-      uses: actions/download-artifact@v4
-      with:
-        name: jac-binary
-        path: jac/zig-out/bin
-
-    - name: Put jac on PATH
-      # upload-artifact strips the executable bit; restore it. The artifact
-      # lands at jac/zig-out/bin, where setup-jac would have built it.
-      run: |
-        chmod +x "$PWD/jac/zig-out/bin/jac"
-        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
+    - name: Set up jac (dev lane)
+      uses: ./.github/actions/setup-jac-dev
 
     - name: Install byllm deps + test deps
       run: |
@@ -710,14 +717,17 @@ jobs:
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: macos-latest
+    # Dev lane: run THIS checkout's compiler (see test-compiler).
+    env:
+      JAC_NO_DEV_SOURCE: ""
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
         submodules: true
 
-    - name: Set up jac (build the binary)
-      uses: ./.github/actions/setup-jac
+    - name: Set up jac (dev lane)
+      uses: ./.github/actions/setup-jac-dev
 
     - name: Run native Mach-O linker regression tests
       run: |
@@ -749,6 +759,9 @@ jobs:
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: ubuntu-latest
+    # Dev lane: run THIS checkout's compiler (see test-compiler).
+    env:
+      JAC_NO_DEV_SOURCE: ""
     steps:
     - name: Check out code
       uses: actions/checkout@v5
@@ -760,8 +773,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends qemu-user-static libc6-arm64-cross
 
-    - name: Set up jac (build the binary)
-      uses: ./.github/actions/setup-jac
+    - name: Set up jac (dev lane)
+      uses: ./.github/actions/setup-jac-dev
 
     - name: Vendor cross musl (aarch64)
       working-directory: jac
@@ -804,25 +817,17 @@ jobs:
         run: zig build -Dno-ninja test --summary all
 
   test-cef-build:
-    needs: build-jac
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Dev lane: run THIS checkout's compiler (see test-compiler).
+    env:
+      JAC_NO_DEV_SOURCE: ""
     steps:
     - uses: actions/checkout@v5
       with:
         submodules: true
 
-    - name: Download the jac binary (build-jac artifact)
-      uses: actions/download-artifact@v4
-      with:
-        name: jac-binary
-        path: jac/zig-out/bin
-
-    - name: Put jac on PATH
-      # upload-artifact strips the executable bit; restore it. The artifact
-      # lands at jac/zig-out/bin, where setup-jac would have built it.
-      run: |
-        chmod +x "$PWD/jac/zig-out/bin/jac"
-        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
+    - name: Set up jac (dev lane)
+      uses: ./.github/actions/setup-jac-dev
 
     - name: Build dispatch shim and subprocess binary
       working-directory: jac/jaclang/runtimelib/client/targets/desktop/native/cef
@@ -1602,6 +1607,7 @@ jobs:
       - test-client
       - test-packages-and-docs
       - test-native-macos
+      - test-native-aarch64
       - test-launcher
       - test-cef-build
       - test-scale

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,19 +160,30 @@ jobs:
 
   # Compiler half of the full repo suite, via the binary's own test runner.
   test-compiler:
-    needs: changes
+    needs: [changes, build-jac]
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Dev lane: the compiler under test is THIS checkout via the repo's
-    # [dev] jaclang_source loop; the cached host binary never rebuilds on
-    # compiler PRs. Sealed-path coverage: build-jac's smoke per PR plus the
-    # full sealed sweep in nightly.yml.
-    env:
-      JAC_NO_DEV_SOURCE: ""
+    # Sealed lane: this suite spawns `jac` subprocesses with isolated env/HOME
+    # (serve/client/cli tests). Under the dev lane each such spawn would
+    # recompile the checkout compiler from source into its cold cache -- a
+    # from-source build per spawn -- so these suites test the sealed artifact.
     steps:
       - uses: actions/checkout@v5
-      - name: Set up jac (dev lane)
-        uses: ./.github/actions/setup-jac-dev
+      - name: Restore typeshed stdlib stubs into the checkout
+        uses: actions/download-artifact@v4
+        with:
+          name: typeshed-stdlib
+          path: jac/jaclang/vendor/typeshed/stdlib
+      - name: Download the jac binary
+        uses: actions/download-artifact@v4
+        with:
+          name: jac-binary
+          path: bin
+      - name: Put jac on PATH
+        # upload-artifact strips the executable bit; restore it.
+        run: |
+          chmod +x "$PWD/bin/jac"
+          echo "$PWD/bin" >> "$GITHUB_PATH"
       - name: Set up Node.js (ES backend for the equivalence suite)
         uses: actions/setup-node@v4
         with:
@@ -224,18 +235,6 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$rc"
 
-      # Refresh the shared JIR cache the dev lane restores (content-addressed
-      # entries: a stale tree can only miss, never mis-serve). One seeder job
-      # bounds pool churn; PR-scoped saves cover the PR's own later pushes,
-      # main saves seed every branch.
-      - name: Save JIR compile caches
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            .jac-xdg/jac/jir
-            jac/.jac/cache
-          key: jac-jir-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
 
   # Native lowering unavailable (LLVM shim absent): user programs must compile
   # cleanly in the server codespace with zero scheduling errors and no
@@ -295,16 +294,24 @@ jobs:
 
   # Everything except the compiler tests.
   test-runtime:
-    needs: changes
+    needs: [changes, build-jac]
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Dev lane: run THIS checkout's compiler (see test-compiler).
-    env:
-      JAC_NO_DEV_SOURCE: ""
+    # Sealed lane: this suite spawns `jac` subprocesses with isolated env/HOME
+    # (serve/client/cli tests). Under the dev lane each such spawn would
+    # recompile the checkout compiler from source into its cold cache -- a
+    # from-source build per spawn -- so these suites test the sealed artifact.
     steps:
       - uses: actions/checkout@v5
-      - name: Set up jac (dev lane)
-        uses: ./.github/actions/setup-jac-dev
+      - name: Download the jac binary
+        uses: actions/download-artifact@v4
+        with:
+          name: jac-binary
+          path: bin
+      - name: Put jac on PATH
+        run: |
+          chmod +x "$PWD/bin/jac"
+          echo "$PWD/bin" >> "$GITHUB_PATH"
       - name: Set up Node.js (JS backend tests)
         uses: actions/setup-node@v4
         with:
@@ -536,6 +543,19 @@ jobs:
 
           exit 0
 
+      # Refresh the shared JIR cache the dev lane restores (content-addressed
+      # entries: a stale tree can only miss, never mis-serve). One Linux
+      # seeder job bounds pool churn; PR-scoped saves cover the PR's own
+      # later pushes, main saves seed every branch.
+      - name: Save JIR compile caches
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .jac-xdg/jac/jir
+            jac/.jac/cache
+          key: jac-jir-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
+
   # Required check ("Contribution Checks" is the branch-protection context
   # name): independent of build-jac for the same reason as jac-check.
   contribution-checks:
@@ -606,12 +626,13 @@ jobs:
         run: bash scripts/check-release-notes.sh
 
   test-solid-and-desktop:
-    needs: changes
+    needs: [changes, build-jac]
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.desktop == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Dev lane: run THIS checkout's compiler (see test-compiler).
-    env:
-      JAC_NO_DEV_SOURCE: ""
+    # Sealed lane: this suite spawns `jac` subprocesses with isolated env/HOME
+    # (serve/client/cli tests). Under the dev lane each such spawn would
+    # recompile the checkout compiler from source into its cold cache -- a
+    # from-source build per spawn -- so these suites test the sealed artifact.
     steps:
     - name: Check out code
       uses: actions/checkout@v5
@@ -626,8 +647,18 @@ jobs:
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
 
-    - name: Set up jac (dev lane)
-      uses: ./.github/actions/setup-jac-dev
+    - name: Download the jac binary (build-jac artifact)
+      uses: actions/download-artifact@v4
+      with:
+        name: jac-binary
+        path: jac/zig-out/bin
+
+    - name: Put jac on PATH
+      # upload-artifact strips the executable bit; restore it. The artifact
+      # lands at jac/zig-out/bin, where setup-jac would have built it.
+      run: |
+        chmod +x "$PWD/jac/zig-out/bin/jac"
+        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
 
     - name: Run Solid jsdom runtime test
       env:
@@ -638,10 +669,12 @@ jobs:
       run: jac test jac/tests/runtimelib/client/test_desktop_binding.jac
 
   test-client:
+    needs: build-jac
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Dev lane: run THIS checkout's compiler (see test-compiler).
-    env:
-      JAC_NO_DEV_SOURCE: ""
+    # Sealed lane: this suite spawns `jac` subprocesses with isolated env/HOME
+    # (serve/client/cli tests). Under the dev lane each such spawn would
+    # recompile the checkout compiler from source into its cold cache -- a
+    # from-source build per spawn -- so these suites test the sealed artifact.
     steps:
     - name: Check out code
       uses: actions/checkout@v5
@@ -656,8 +689,18 @@ jobs:
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
 
-    - name: Set up jac (dev lane)
-      uses: ./.github/actions/setup-jac-dev
+    - name: Download the jac binary (build-jac artifact)
+      uses: actions/download-artifact@v4
+      with:
+        name: jac-binary
+        path: jac/zig-out/bin
+
+    - name: Put jac on PATH
+      # upload-artifact strips the executable bit; restore it. The artifact
+      # lands at jac/zig-out/bin, where setup-jac would have built it.
+      run: |
+        chmod +x "$PWD/jac/zig-out/bin/jac"
+        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
 
     - name: Set environment for testing
       run: echo "TEST_ENV=true" >> $GITHUB_ENV
@@ -682,20 +725,31 @@ jobs:
         jac test -vv jac/tests/runtimelib/client/test_inprocess_dispatch.jac
 
   test-packages-and-docs:
-    needs: changes
+    needs: [changes, build-jac]
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.byllm == 'true' || needs.changes.outputs.docs == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Dev lane: run THIS checkout's compiler (see test-compiler).
-    env:
-      JAC_NO_DEV_SOURCE: ""
+    # Sealed lane: byllm's MTIR integration tests key registries off the
+    # sealed module identity (dev-source loading keys them differently), and
+    # the suite spawns env-isolated `jac` subprocesses (see test-compiler's
+    # sealed-lane note).
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
         submodules: true
 
-    - name: Set up jac (dev lane)
-      uses: ./.github/actions/setup-jac-dev
+    - name: Download the jac binary (build-jac artifact)
+      uses: actions/download-artifact@v4
+      with:
+        name: jac-binary
+        path: jac/zig-out/bin
+
+    - name: Put jac on PATH
+      # upload-artifact strips the executable bit; restore it. The artifact
+      # lands at jac/zig-out/bin, where setup-jac would have built it.
+      run: |
+        chmod +x "$PWD/jac/zig-out/bin/jac"
+        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
 
     - name: Install byllm deps + test deps
       run: |
@@ -750,6 +804,16 @@ jobs:
         # seam gets a per-OS floor (see test_prim_equivalence.jac).
         PYTEST_ADDOPTS: -k "shutil or path or textwrap or keyword"
       run: jac test jac/jaclang/compiler/tests/test_prim_equivalence.jac
+
+    # macOS JIR seeder (jac-check seeds the Linux tier).
+    - name: Save JIR compile caches
+      if: always()
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          .jac-xdg/jac/jir
+          jac/.jac/cache
+        key: jac-jir-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
 
   # aarch64 cross lane (#7626 C1): cross-compile with the in-house ELF linker
   # (MOVW_UABS relocation family) + arch-parameterized vendored musl, run the

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,3 +132,54 @@ jobs:
             exit 1
           fi
           echo "PASS: jac removed"
+
+  # PR CI's test jobs run the dev lane ([dev] jaclang_source: the checkout's
+  # compiler over a cached host binary), and build-jac smokes the sealed boot
+  # per PR. This is the deep sealed-path guard: the full suite against a real
+  # sealed binary, daily, so payload-only regressions (frozen bootstrap, JIR
+  # image boot, bundled deps) cannot ride a green dev-lane PR for long.
+  sealed-suite:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 3 * * *' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      JAC_NO_DEV_SOURCE: "1"
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        submodules: true
+
+    - name: Set up jac (sealed binary)
+      uses: ./.github/actions/setup-jac
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Set up Bun
+      uses: oven-sh/setup-bun@v2
+
+    - name: Set up Zig 0.16.0 (vendor static-musl runtime)
+      uses: mlugg/setup-zig@v2
+      with:
+        version: 0.16.0
+        use-cache: false
+
+    - name: Vendor static-musl runtime
+      working-directory: jac
+      run: zig build -Dno-ninja vendor-musl --summary all
+
+    - name: Full suite against the sealed binary
+      working-directory: jac
+      run: |
+        set -uxo pipefail
+        WORK="$(mktemp -d)"
+        HOME="$WORK" JAC_TEST_JOBS=auto jac test tests/ | tee /tmp/sealed.log
+        rc=${PIPESTATUS[0]}
+        {
+          echo "## sealed full-suite result"
+          echo '```'
+          grep -E '^(FAILED|ERROR)|passed|failed' /tmp/sealed.log | tail -40 || true
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+        exit "$rc"


### PR DESCRIPTION
## What this changes

The sealed `jac` binary is two layers: a launcher/runtime **host** (Zig stub, bundled CPython, LLVM shim, bun) and a sealed **jaclang payload**. CI cached them as one unit keyed on `jac/jaclang/**` with saves gated to main, so every compiler-touching PR missed the binary cache, rebuilt it in up to 5 independent jobs (re-paid on every push), and gated 11 more jobs behind the build-jac artifact.

This PR splits CI into two lanes.

**Dev lane** (jac-check, contribution-checks, test-cef-build, test-no-llvm, test-native-macos, test-native-aarch64): a new `setup-jac-dev` action restores a host binary from a cache keyed **only** on `build.zig` + `build.zig.zon` + `launcher/**` + `native/**`, then runs this checkout's compiler through the repo's existing `[dev] jaclang_source` loop (the loop every contributor runs locally). Compiler edits never invalidate the host entry. The action also restores the LLVM shim + typeshed (same entries `setup-jac` maintains) and a content-addressed JIR compile cache with restore-keys. On a host/shim miss it falls back to `setup-jac` with two new inputs: `ninja: false` (tests never open the fused editor, and the editor's Lua dependency rides the flakiest fetch in the build) and `skip-precompile: true` (the dev loop never boots the bundled compiler, so the ~24-min payload JIR precompile would be pure waste). Neither flavor is ever saved to the shared `jac-bin` cache that release flows restore.

**Sealed lane** (build-jac, test-compiler, test-runtime, test-client, test-solid-and-desktop, test-packages-and-docs, test-scale, test-scale-k8s, k8s-real-e2e, test-jac-pack-smoke): unchanged binary handling. The test suites stay sealed for a reason found while validating: their tests spawn `jac` subprocesses with scrubbed env/fresh HOME, and under the dev loop each isolated spawn recompiles the checkout compiler from source until the runner dies. byllm additionally keys MTIR registries off sealed module identity. A new nightly `sealed-suite` job runs the full sweep against a real sealed binary daily.

Robustness fixes that fell out of validation, useful beyond this PR:
- `fetch-llvm` now configures `-Dno-ninja` unconditionally (it is editor-independent, exactly like `fetch-typeshed`); previously merely configuring it fetched the neovim + Lua closure in a step that could not retry.
- The `setup-jac` build step retries up to 3x on transient fetch timeouts.
- `test-native-aarch64` is now in `Everything Passed`'s `needs:` (it ran on every core PR while gating nothing).
- `test-no-llvm` restores typeshed from the shared cache instead of the build-jac artifact, so it no longer waits on the build at all.

## Validation on this PR's runs

All dev-lane jobs green across the last two runs, in the worst possible environment: the Actions outage left the Blacksmith cache store empty, so every restore missed and every fallback ran cold, exercising the entire fallback path end to end. Cold-fallback job times: jac-check 6.0 min, contribution-checks 5.4, test-cef-build 4.9, test-native-aarch64 7.5, test-no-llvm 1.2 (no build-jac wait). Steady state (host + JIR caches warm) drops setup to seconds; those caches seed on the first post-merge main run.

**Known blocker, not this PR**: `build-jac` (sealed lane, binary handling untouched here) fails because lua.org is timing out and the emptied caches force full builds -- main's own CI is currently red for the same reason. The retry added here gives it three attempts; it will pass once lua.org answers or the zig package store re-seeds. The durable fix is vendoring/mirroring the Lua tarball so lua.org is never load-bearing -- a follow-up worth doing separately. Note this PR shrinks PR-time lua.org exposure from 5 jobs to 1.
