### PR TITLE
fix(scale): fail loud when microservice route resolution fails, so a config error can no longer silently start a monolith

### DIFF
--- a/jac/jaclang/scale/plugin.jac
+++ b/jac/jaclang/scale/plugin.jac
@@ -91,7 +91,15 @@ def scale_start(
             import from jaclang.scale.runtime.realizer.local_realizer { LocalRealizer }
             realizer = LocalRealizer(ms_config=ms_config);
             should_serve_ms = realizer.should_serve(enabled);
-        } except Exception {
+        } except ValueError as e {
+            console.error(f"Microservice configuration invalid: {e}", emoji=False);
+            return 1;
+        } except Exception as e {
+            console.error(
+                f"Microservice mode unavailable "
+                f"({type(e).__name__}: {e}); starting as a monolith.",
+                emoji=False
+            );
             realizer = None;
             should_serve_ms = False;
         }

--- a/jac/jaclang/scale/tests/microservices/test_ms_config_failloud.jac
+++ b/jac/jaclang/scale/tests/microservices/test_ms_config_failloud.jac
@@ -1,0 +1,63 @@
+"""A microservice config error must stop `jac start`, not silently start the
+app as a monolith. The route-name guard raises ValueError for a route that
+collides with a gateway builtin; before the fix, scale_start swallowed every
+exception from route resolution and fell through to single-process serving
+with no output at all."""
+
+import os;
+import shutil;
+import subprocess;
+import tempfile;
+import from pathlib { Path }
+import from jaclang.scale.runtime.context.util { jac_executable }
+
+
+def _bad_route_project -> Path {
+    project_dir = Path(tempfile.mkdtemp(prefix="jac-ms-failloud-"));
+    (project_dir / "jac.toml").write_text(
+        '[project]\n'
+        'name = "failloud"\n'
+        'entry-point = "main.jac"\n'
+        '\n'
+        '[scale.microservices.routes]\n'
+        'admin = ""\n',
+        encoding="utf-8"
+    );
+    (project_dir / "main.jac").write_text("with entry {}\n", encoding="utf-8");
+    (project_dir / "admin.jac").write_text("with entry {}\n", encoding="utf-8");
+    return project_dir;
+}
+
+
+def _local_env -> dict[str, str] {
+    env = os.environ.copy();
+    for key in ["JAC_SV_SIBLING", "JAC_SV_NAME", "JAC_SV_ROUTES"] {
+        env.pop(key, None);
+    }
+    return env;
+}
+
+
+test "a reserved route name stops startup loudly instead of serving a monolith" {
+    project_dir = _bad_route_project();
+    try {
+        result = subprocess.run(
+            [jac_executable(), "start", "main.jac"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_dir),
+            env=_local_env(),
+            timeout=90
+        );
+    } finally {
+        shutil.rmtree(project_dir, ignore_errors=True);
+    }
+
+    combined = result.stdout + result.stderr;
+    assert result.returncode == 1 , (
+        f"expected exit 1 on an invalid route config, got rc={result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    );
+    assert "Microservice configuration invalid" in combined;
+    assert "collides" in combined;
+}

--- a/release_notes/unreleased/jaclang/8007.bugfix.md
+++ b/release_notes/unreleased/jaclang/8007.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Invalid microservice config stops startup**: a route-name or prefix error now exits with a clear message instead of silently starting the app as a single process.


### PR DESCRIPTION

## What this changes

`scale_start` wrapped route resolution and realizer construction in a bare
`except Exception` that reset state and fell through to monolith mode with
no output at any log level. A typo'd route, or a route named `admin`,
produced a working single-process app and no indication that microservice
mode was requested and refused.

- `ValueError` (configuration errors, e.g. the route-name guard) now stops
  startup: clean console error plus exit 1.
- Any other failure logs the exception class and message at error level
  before falling back to monolith mode; the fallback remains only for
  genuinely optional machinery.

Class note: this is one instance of #7900 theme 1 (silent fallback at a
decision point). The same pattern in `_load_ms_cfg` is tracked by #7915's
related list; this PR fixes the startup-topology instance.

## Validation

- New CLI-subprocess regression test test_ms_config_failloud (1): a real
  `jac start` in a temp project with a reserved route name. Against
  baseline plugin.jac the test FAILS by serving a monolith until the 90s
  subprocess timeout kills it (the exact defect); with the fix it passes in
  ~52s (rig timing).
- test_fleet_pod_optout (3) passing on the rig alongside it.
- NOT run: the full scale suite.

## Known follow-ups

- `plugin.jac` sets `JAC_SCALE_RUNTIME=1` unconditionally at the top of
  `scale_start`, before any mode decision, and children inherit it (the
  issue's "Related" note) - separate fix.

Closes #7905. Part of #7900.