### PR TITLE
refactor(compiler): finish the #7951 seam consolidation and shed dead residue

### DIFF
--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
@@ -548,23 +548,7 @@ impl NaIRGenPass._register_imported_struct_types -> None {
             continue;
         }
 
-        imported_mod = self.prog.mod.hub.get(full_path);
-        if imported_mod is None {
-            imported_mod = self.prog.mod.hub.get(abs_key);
-        }
-
-        if imported_mod is None and os.path.isfile(full_path) {
-            _saved_opts = self.prog._compile_options;
-            try {
-                imported_mod = self.prog.compile(
-                    full_path, no_cgen=True, symtab_ir_only=True
-                );
-            } except Exception {
-                imported_mod = None;
-            } finally {
-                self.prog._compile_options = _saved_opts;
-            }
-        }
+        imported_mod = self._load_native_import_dep(full_path);
         if imported_mod is None {
             continue;
         }
@@ -680,6 +664,25 @@ impl NaIRGenPass._ensure_imported_module_inferred(imported_mod: uni.Module) -> N
     } finally {
         self.prog._compile_options = _saved_opts;
     }
+}
+
+impl NaIRGenPass._load_native_import_dep(full_path: str) -> (uni.Module | None) {
+    import os;
+    imported_mod = self.prog.mod.hub.get(full_path);
+    if imported_mod is None {
+        imported_mod = self.prog.mod.hub.get(os.path.abspath(full_path));
+    }
+    if imported_mod is None and os.path.isfile(full_path) {
+        _saved_opts = self.prog._compile_options;
+        try {
+            imported_mod = self.prog.load_dependency_module(full_path);
+        } except Exception {
+            imported_mod = None;
+        } finally {
+            self.prog._compile_options = _saved_opts;
+        }
+    }
+    return imported_mod;
 }
 
 impl NaIRGenPass._extract_import_module_name(imp: uni.Import) -> (str | None) {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/generics.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/generics.impl.jac
@@ -367,22 +367,7 @@ impl NaIRGenPass._find_source_ability(
     if full_path is None {
         return None;
     }
-    imported_mod = self.prog.mod.hub.get(full_path);
-    if imported_mod is None {
-        imported_mod = self.prog.mod.hub.get(os.path.abspath(full_path));
-    }
-    if imported_mod is None and os.path.isfile(full_path) {
-        _saved_opts = self.prog._compile_options;
-        try {
-            imported_mod = self.prog.compile(
-                full_path, no_cgen=True, symtab_ir_only=True
-            );
-        } except Exception {
-            imported_mod = None;
-        } finally {
-            self.prog._compile_options = _saved_opts;
-        }
-    }
+    imported_mod = self._load_native_import_dep(full_path);
     if imported_mod is None {
         return None;
     }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -685,6 +685,7 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _register_imported_struct_types -> None;
     def _permuted_walk_order(mods: list) -> list;
     def _ensure_imported_module_inferred(imported_mod: uni.Module) -> None;
+    def _load_native_import_dep(full_path: str) -> (uni.Module | None);
     def _extract_import_module_name(imp: uni.Import) -> (str | None);
     def _walk_imported_module_types(imported_mod: uni.Module) -> None;
     def _walk_imported_module_type_names(imported_mod: uni.Module) -> None;

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/imported.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/imported.impl.jac
@@ -60,13 +60,9 @@ impl TypeEvaluator.get_type_of_module_item(node_: uni.ModuleItem) -> types.TypeB
                         return binding.type;
                     }
                     mod = self._import_module_from_path(
-                        path_str, importer_path=self._resolve_importer_path(node_)
+                        path_str, importer_path=resolve_importer_path_from_node(node_)
                     );
 
-                    is_subpackage_init = (
-                        path.name.startswith("__init__")
-                        and path.parent.name == item_name
-                    );
                     is_parent_init = (
                         path.name.startswith("__init__")
                         and path.parent.name != item_name
@@ -175,7 +171,7 @@ impl TypeEvaluator._resolve_star_import_symbol(
             candidate = resolved[-1];
             if candidate and Path(candidate).exists() {
                 submod = self._import_module_from_path(
-                    candidate, importer_path=self._resolve_importer_path(mod)
+                    candidate, importer_path=resolve_importer_path_from_node(mod)
                 );
             }
         }
@@ -264,7 +260,7 @@ impl TypeEvaluator.get_type_of_module(node_: uni.ModulePath) -> types.TypeBase {
                 continue;
             }
             mod: uni.Module = self._import_module_from_path(
-                mod_path, importer_path=self._resolve_importer_path(node_)
+                mod_path, importer_path=resolve_importer_path_from_node(node_)
             );
             mod_type = types.ModuleType(
                 mod_name=npath.value,
@@ -367,11 +363,6 @@ impl TypeEvaluator.forget_module(resolved_path: str) -> None {
     if resolved_path in self._module_type_cache {
         del (self._module_type_cache[resolved_path], );
     }
-}
-
-impl TypeEvaluator._resolve_importer_path(ast_node: uni.UniNode) -> (str | None) {
-    import from jaclang.compiler.symbol_utils { resolve_importer_path_from_node }
-    return resolve_importer_path_from_node(ast_node);
 }
 
 impl TypeEvaluator.get_type_of_symbol(symbol: uni.Symbol) -> TypeBase {

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -1409,15 +1409,12 @@ impl TypeEvaluator._get_type_of_expression_core(
                 }
                 if isinstance(base_type, types.TypeVarType) {
                     if base_type.constraints {
-                        any_subscriptable = False;
                         for constraint_type in base_type.constraints {
                             if isinstance(constraint_type, types.ClassType) {
                                 result = self.get_type_of_magic_method_call(
                                     constraint_type, "__getitem__", [expr.right], None
                                 );
-                                if result {
-                                    any_subscriptable = True;
-                                } else {
+                                if not result {
                                     self.emit_diag(
                                         E1040, expr, type=str(constraint_type)
                                     );
@@ -3485,53 +3482,32 @@ impl TypeEvaluator._load_stub_module(path: str) -> uni.Module {
     }
 
     resolved_path = str(Path(path).resolve());
-    compiler = self.program._get_compiler();
-    target_program = compiler._resolve_program(resolved_path, self.program);
-    target_hub = target_program.mod.hub;
-
-    if resolved_path in self.program.mod.hub {
-        mod = self.program.mod.hub[resolved_path];
-        if mod.parent_scope is None and mod is not self.builtins_module {
-            mod.parent_scope = self.builtins_module;
-        }
-        return mod;
-    }
-    if resolved_path in target_hub {
-        mod = target_hub[resolved_path];
-        if mod.parent_scope is None and mod is not self.builtins_module {
-            mod.parent_scope = self.builtins_module;
-        }
-        return mod;
-    }
-
-    memoized = _stub_module_memo.get(resolved_path);
-    if memoized is not None and memoized[0] == os.path.getmtime(path) {
-        mod = memoized[1];
-        target_hub[resolved_path] = mod;
-        target_program.hub_cache_stamp(resolved_path);
-        if mod.parent_scope is None and mod is not self.builtins_module {
-            mod.parent_scope = self.builtins_module;
-        }
-        return mod;
-    }
-
     use_str: (str | None) = None;
-    if path.endswith("builtins.pyi") {
-        file_content = read_file_with_encoding(path);
-        if "def chunks(" not in file_content {
-            _ck_anchor = "    def copy(self) -> list[_T]: ...";
-            if _ck_anchor in file_content {
-                file_content = file_content.replace(
-                    _ck_anchor,
-                    _ck_anchor
-                        + "\n    # Jac extension: chunked iteration views"
-                        + " (`for c in &xs.chunks(n)`).\n"
-                        + "    def chunks(self, n: int, /) -> list[list[_T]]: ...",
-                    1
-                );
+    if self.program.find_module(resolved_path) is None {
+        memoized = _stub_module_memo.get(resolved_path);
+        if memoized is not None and memoized[0] == os.path.getmtime(path) {
+            target_program = self.program._get_compiler()._resolve_program(
+                resolved_path, self.program
+            );
+            target_program.mod.hub[resolved_path] = memoized[1];
+            target_program.hub_cache_stamp(resolved_path);
+        } elif path.endswith("builtins.pyi") {
+            file_content = read_file_with_encoding(path);
+            if "def chunks(" not in file_content {
+                _ck_anchor = "    def copy(self) -> list[_T]: ...";
+                if _ck_anchor in file_content {
+                    file_content = file_content.replace(
+                        _ck_anchor,
+                        _ck_anchor
+                            + "\n    # Jac extension: chunked iteration views"
+                            + " (`for c in &xs.chunks(n)`).\n"
+                            + "    def chunks(self, n: int, /) -> list[list[_T]]: ...",
+                        1
+                    );
+                }
             }
+            use_str = file_content;
         }
-        use_str = file_content;
     }
 
     mod = self.program.load_dependency_module(path, use_str=use_str);

--- a/jac/jaclang/compiler/type_system/type_evaluator.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.jac
@@ -11,8 +11,6 @@ import from jaclang.jac0core.constant {
     SymbolAccess,
     OwnershipKind,
 }
-import from jaclang.compiler.passes.main.pyast_load_pass { PyastBuildPass }
-import from jaclang.jac0core.passes.sym_tab_build_pass { SymTabBuildPass }
 import from jaclang.compiler.type_system { types }
 import from jaclang.jac0core.helpers { read_file_with_encoding }
 import type from jaclang.jac0core.program { JacProgram }
@@ -20,7 +18,10 @@ import type from jaclang.jac0core.program { JacProgram }
 import from jaclang.compiler.type_system { operations }
 import from jaclang.compiler.type_system { type_utils }
 import from jaclang.compiler.type_system { properties }
-import from jaclang.compiler.symbol_utils { int_subscript_suffix }
+import from jaclang.compiler.symbol_utils {
+    int_subscript_suffix,
+    resolve_importer_path_from_node,
+}
 import from jaclang.compiler.type_system { enum_utils }
 import from jaclang.compiler.type_system.types { TypeBase }
 import from jaclang.compiler.type_system.ts_decl_parser {
@@ -34,7 +35,6 @@ import from jaclang.compiler.type_system.ts_decl_parser {
 
 import from jaclang.jac0core.diagnostics {
     DiagnosticInfo,
-    E1001,
     E1010,
     E1023,
     E1030,
@@ -64,9 +64,6 @@ import from jaclang.jac0core.diagnostics {
     E1073,
     E1080,
     E1081,
-    E1096,
-    E1097,
-    E1098,
     E1099,
     E1100,
     E1101,
@@ -216,7 +213,6 @@ obj TypeEvaluator {
         path: str, importer_path: (str | None) = None
     ) -> uni.Module;
 
-    def _resolve_importer_path(ast_node: uni.UniNode) -> (str | None);
     def forget_module(resolved_path: str) -> None;
     def _resolve_from_path(from_mod: uni.ModulePath) -> Path;
     def _resolve_client_npm_module(node_: uni.ModulePath) -> (str | None);

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -128,7 +128,6 @@ impl JacCompiler.get_bytecode(
 ) -> (types.CodeType | None) {
     actual_program = self._resolve_program(full_target, target_program);
     (rebuild, no_precompile) = cache_mode();
-    symtab_only_recovery = False;
 
     if (
         (not rebuild)
@@ -143,7 +142,6 @@ impl JacCompiler.get_bytecode(
         and not actual_program.mod.hub[full_target].gen.py_bytecode
     ) {
         actual_program.invalidate_module(full_target);
-        symtab_only_recovery = True;
     } elif (
         (not rebuild)
         and (full_target in actual_program.mod.hub)
@@ -208,7 +206,6 @@ impl JacCompiler.get_bytecode(
             } else {
                 cache_path.unlink(missing_ok=True);
                 actual_program.invalidate_module(full_target);
-                symtab_only_recovery = True;
             }
         } except Exception {
             ;
@@ -219,20 +216,17 @@ impl JacCompiler.get_bytecode(
     precompiled_bc = self._get_precompiled_jir_bytecode(full_target, allow_unsealed);
     if precompiled_bc is not None {
         try {
-            import from jaclang.jac0core.jir { write_precompiled_jir, FLAG_PRECOMPILED }
-            jir_bytes = write_precompiled_jir(
-                precompiled_bc, compute_module_key(full_target), FLAG_PRECOMPILED
-            );
-            cache_path.parent.mkdir(parents=True, exist_ok=True);
-
-            import os as _os;
-            tmp_path = cache_path.with_suffix(f'.{_os.getpid()}.tmp');
-            try {
-                tmp_path.write_bytes(jir_bytes);
-                tmp_path.rename(cache_path);
-            } finally {
-                tmp_path.unlink(missing_ok=True);
+            import from jaclang.jac0core.jir {
+                write_precompiled_jir,
+                FLAG_PRECOMPILED,
+                atomic_write_jir,
             }
+            atomic_write_jir(
+                cache_path,
+                write_precompiled_jir(
+                    precompiled_bc, compute_module_key(full_target), FLAG_PRECOMPILED
+                )
+            );
         } except Exception {
             ;
         }
@@ -782,7 +776,6 @@ impl JacCompiler.compile(
     use_str: (str | None) = None,
     options: CompileOptions = CompileOptions()
 ) -> uni.Module {
-    import from pathlib { Path as _WrapPath }
     import from jaclang.jac0core.codeinfo {
         get_effective_default_codespace_override,
         set_effective_default_codespace

--- a/jac/jaclang/jac0core/impl/jir_passes.impl.jac
+++ b/jac/jaclang/jac0core/impl/jir_passes.impl.jac
@@ -5,7 +5,7 @@ import zlib;
 impl JirWriter.write_module(
     module: Module, sections: (dict[int, bytes] | None) = None
 ) -> bytes {
-    import from jaclang.jac0core.jir { HEADER_FMT, HEADER_SIZE, MAGIC, FORMAT_VERSION }
+    import from jaclang.jac0core.jir { HEADER_FMT, MAGIC, FORMAT_VERSION }
     import from importlib.metadata { version as pkg_version }
 
     self._assign_ids(module);
@@ -86,7 +86,7 @@ impl JirWriter._get_node_id(ir_node: (UniNode | None)) -> int {
 }
 
 impl JirWriter._write_node(buf: bytearray, ir_node: UniNode) -> None {
-    import from jaclang.jac0core.unitree { UniScopeNode, UniCFGNode, NameAtom, Symbol }
+    import from jaclang.jac0core.unitree { UniScopeNode, UniCFGNode, NameAtom }
     import from jaclang.jac0core.unitree { ContextAwareNode }
     import from jaclang.jac0core.constant { CodeContext }
 
@@ -904,8 +904,7 @@ impl JirReader._read_node(data: (bytes | memoryview), pos: int, idx: int) -> int
 impl JirReader._read_scope_overlay(
     data: (bytes | memoryview), pos: int, scope_node: UniScopeNode
 ) -> int {
-    import from jaclang.jac0core.unitree { UniScopeNode, Symbol, InheritedSymbolTable }
-    import from jaclang.jac0core.constant { SymbolAccess }
+    import from jaclang.jac0core.unitree { UniScopeNode, InheritedSymbolTable }
 
     assert self._pool is not None;
 
@@ -1132,8 +1131,6 @@ impl JirReader._read_name_atom_overlay(
 
 impl JirReader._read_link_table(data: (bytes | memoryview), pos: int) -> int {
     import from jaclang.jac0core.unitree { UniScopeNode, NameAtom, AstSymbolNode }
-
-    nodes = self._nodes;
 
     (count, pos) = _read_varint(data, pos);
     for _ in range(count) {

--- a/jac/jaclang/jac0core/impl/program.impl.jac
+++ b/jac/jaclang/jac0core/impl/program.impl.jac
@@ -2,7 +2,6 @@ impl JacProgram.init(
     self: JacProgram, main_mod: (uni.ProgramModule | None) = None
 ) -> None {
     self.mod: uni.ProgramModule = main_mod or uni.ProgramModule();
-    self.py_raise_map: dict[(str, str)] = {};
     self.mtir_map: dict[(str, Info)] = {};
     self.errors_had: list[Alert] = [];
     self.warnings_had: list[Alert] = [];
@@ -192,9 +191,6 @@ impl JacProgram.load_dependency_module(
         }
         if jir_mod is not None {
             mod = jir_mod;
-            if resolved_path.endswith('.pyi') and not mod.stub_only {
-                mod.stub_only = True;
-            }
         } elif resolved_path.endswith('.pyi') {
             import ast as py_ast;
             import from jaclang.compiler.passes.main.pyast_load_pass { PyastBuildPass }

--- a/jac/jaclang/jac0core/jir.jac
+++ b/jac/jaclang/jac0core/jir.jac
@@ -512,6 +512,17 @@ def read_module_jir_cache(source_path: str) -> (object | None) {
     }
 }
 
+def atomic_write_jir(cache_path: Path, jir_bytes: bytes) {
+    cache_path.parent.mkdir(parents=True, exist_ok=True);
+    tmp_path = cache_path.with_suffix(f'.{os.getpid()}.tmp');
+    try {
+        tmp_path.write_bytes(jir_bytes);
+        tmp_path.rename(cache_path);
+    } finally {
+        tmp_path.unlink(missing_ok=True);
+    }
+}
+
 def write_module_jir_cache(
     source_path: str, mod: object, extra_sections: (dict[int, bytes] | None) = None
 ) -> bool {
@@ -521,15 +532,11 @@ def write_module_jir_cache(
     if not jir_cacheable_source_path(resolved_path) {
         return False;
     }
-    if resolved_path.endswith('.pyi') and not mod.stub_only {
-        mod.stub_only = True;
-    }
     try {
         cache_path = get_module_cache_path(resolved_path);
         if is_module_cache_valid(resolved_path, cache_path) {
             return False;
         }
-        cache_path.parent.mkdir(parents=True, exist_ok=True);
         writer = JirWriter();
         sections: dict[int, bytes] = {
             SEC_MODKEY: module_cache_key(resolved_path).encode('utf-8')
@@ -543,14 +550,7 @@ def write_module_jir_cache(
         if bc is not None and SEC_BYTECODE not in sections {
             sections[SEC_BYTECODE] = bc;
         }
-        jir_bytes = writer.write_module(mod, sections=sections);
-        tmp_path = cache_path.with_suffix(f'.{os.getpid()}.tmp');
-        try {
-            tmp_path.write_bytes(jir_bytes);
-            tmp_path.rename(cache_path);
-        } finally {
-            tmp_path.unlink(missing_ok=True);
-        }
+        atomic_write_jir(cache_path, writer.write_module(mod, sections=sections));
         return True;
     } except Exception {
         return False;

--- a/jac/jaclang/jac0core/jir_passes.jac
+++ b/jac/jaclang/jac0core/jir_passes.jac
@@ -103,21 +103,15 @@ obj JirWriter {
     has _pool: _StringPool postinit,
         _node_ids: dict[int, int] postinit,
         _nodes: list[object] postinit,
-        _buf: bytearray postinit,
         _parent_scope_links: list[tuple[int, int]] postinit,
-        _name_of_links: list[tuple[int, int]] postinit,
-        _overload_entries: list[tuple[int, str, list[int]]] postinit,
-        _inherited_scope_entries: list[tuple[int, int, bool, list[str]]] postinit;
+        _name_of_links: list[tuple[int, int]] postinit;
 
     def postinit {
         self._pool = _StringPool();
         self._node_ids = {};
         self._nodes = [];
-        self._buf = bytearray();
         self._parent_scope_links = [];
         self._name_of_links = [];
-        self._overload_entries = [];
-        self._inherited_scope_entries = [];
     }
 
     def write_module(
@@ -137,8 +131,7 @@ obj JirWriter {
 }
 
 obj JirReader {
-    has _skip_loc: bool = True,
-        _source_path: str = "",
+    has _source_path: str = "",
         _module_source: (Source | None) = None,
         _pool: (_StringPool | None) = None,
         _nodes: list[object] postinit,

--- a/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
@@ -208,16 +208,10 @@ impl SymTabBuildPass._exit_import_absorb(
     import_all_module_path_node: uni.ModulePath = nd.items[0];
     import_all_module_path = import_all_module_path_node.resolve_relative_path();
     module: (uni.Module | None) = None;
-    if (import_all_module_path in self.prog.mod.hub) {
-        module = self.prog.mod.hub[import_all_module_path];
-    } else {
-        try {
-            module = self.prog.compile(
-                import_all_module_path, no_cgen=True, type_check=False
-            );
-        } except Exception {
-            return;
-        }
+    try {
+        module = self.prog.load_dependency_module(import_all_module_path);
+    } except Exception {
+        return;
     }
     self._bind_import_path_symbols(import_all_module_path_node);
     if module {

--- a/jac/jaclang/jac0core/program.jac
+++ b/jac/jaclang/jac0core/program.jac
@@ -17,7 +17,6 @@ with entry {
 
 class JacProgram {
     has mod: uni.ProgramModule,
-        py_raise_map: dict[(str, str)],
         mtir_map: dict[(str, Info)],
         errors_had: list[Alert],
         warnings_had: list[Alert],

--- a/release_notes/unreleased/jaclang/8018.refactor.md
+++ b/release_notes/unreleased/jaclang/8018.refactor.md
@@ -1,0 +1,1 @@
+Dependency-module loading now flows through `JacProgram.load_dependency_module` everywhere (`import absorb`, native import walk, stub loading), fixing raw-key hub misses and skipped freshness checks, and the JIR writer/reader shed dead fields, write-only locals, and unused imports.


### PR DESCRIPTION
## Summary

Follow-up to #7951. That PR introduced `JacProgram.load_dependency_module` as the single seam for dependency loading; this one finishes the consolidation and removes the dead residue around it.

- Route the remaining hand-rolled dependency loads through the seam:
  - `import absorb` (`sym_tab_build_pass`): its raw-key hub probe missed resolved-key entries (entry compiles store resolved keys), never freshness-checked, and never recorded dependency edges. Absorb targets now get invalidation, JIR cache participation, and dependency recording.
  - The two byte-identical import-walk blocks in the native IR-gen pass collapse into one `_load_native_import_dep` helper that calls the seam (the two-key hub probe is kept to avoid symlink-aliasing regressions).
  - `_load_stub_module`: the pre-seam hub preamble is gone (its early returns bypassed freshness invalidation for stale stubs); the stub memo is now a pure hub-seeder and the seam owns all precedence, with a single exit doing the `parent_scope` wiring once.
- Remove dead code: the write-only `symtab_only_recovery` flag in `get_bytecode` (the bytecode-less-cache branch already unlinks and invalidates inline); `JirWriter._buf`/`_overload_entries`/`_inherited_scope_entries` and `JirReader._skip_loc`; write-only `JacProgram.py_raise_map`; the redundant `stub_only` re-setters on both sides of the `.pyi` cache (the field round-trips via the Module node spec and the parse path already sets it); the `_resolve_importer_path` delegate (call sites now use `symbol_utils.resolve_importer_path_from_node` directly); write-only locals (`is_subpackage_init`, `any_subscriptable`, `_read_link_table`'s `nodes` alias); unused imports (`PyastBuildPass`/`SymTabBuildPass`, `_WrapPath`, writer-side `HEADER_SIZE`, stray `Symbol`/`SymbolAccess`, and diagnostic codes `E1001`/`E1096`/`E1097`/`E1098`).
- Extract `atomic_write_jir` so `write_module_jir_cache` and `get_bytecode`'s precompiled path share one tmp-write-rename implementation.

Net -76 lines with no intended behavior change beyond the two probe-key/freshness fixes described above. The `TypeEvaluator` import in `get_inference_sched` is intentionally untouched: it is a load-bearing availability probe for the `except ImportError` fallback.

## Test plan

- [x] `pytest tests/compiler/test_importer.jac` (22 passed)
- [x] `pytest tests/langserve/test_lazy_jir_lsp.jac` (6 passed)
- [x] `pytest tests/compiler/passes/main/test_import_pass.jac` (7 passed, covers absorb)
- [x] `pytest tests/compiler/passes/native/test_native_star_reexport.jac` (5 passed, covers the native import walk)
- [x] `pytest tests/compiler/passes/main/test_checker_bugs.jac` (57 passed)
- [x] `jac fmt --check --lintfix` clean on all touched files
- [ ] CI green on upstream
