### PR TITLE
docs(native): describe the tuple-bind ownership rule that actually holds

### DIFF
--- a/jac/tests/compiler/passes/native/fixtures/rc_tuple_unpack_optional.jac
+++ b/jac/tests/compiler/passes/native/fixtures/rc_tuple_unpack_optional.jac
@@ -2,22 +2,26 @@
 
 Routing the unpack store through `_coerce_type` made two shapes compile
 that previously raised at codegen, so their refcount accounting needs a
-guard. `_codegen_tuple_unpack` gates its retain and its old-value release
-on `retain_fields` (false for a value tuple) and on the target alloca
-being a raw pointer, both decided before the coercion:
+guard. A heap tuple box owns one reference per managed field and its
+destructor releases them, so `_codegen_tuple_unpack` decides its retain by
+provenance rather than by the tuple's representation: a field loaded out of
+a box is always borrowed from the box's own reference, and a value-tuple
+element is borrowed unless it was recorded as owned. Whatever the target
+slot already held is released either way, reached through the optional
+payload when the slot is an optional rather than a raw pointer:
 
-  - `unpack_into_optional` binds borrowed fields of a boxed tuple into
-    `Res | None` locals. It takes neither the retain nor the old-release,
-    which is the correct move accounting here: releasing a tuple box does
-    not decrement its fields, and scope exit releases each payload once.
-    A future change that adds a retain on this path without also changing
-    the box release would leak both objects.
+  - `unpack_into_optional` binds two fields of a boxed tuple into
+    `Res | None` locals. Each bind retains the field it borrows, releasing
+    the `None` the local held is a no-op, the box release then runs the
+    destructor that drops the box's own reference to each field, and scope
+    exit releases each payload: one destruction per allocation. Dropping
+    the retain, or letting the box abandon its fields again, turns that
+    into an over-release or a leak respectively.
   - `unpack_optional_into_plain` overwrites two `Res` locals from optional
-    elements of a value tuple. The two overwritten originals are not
-    released. `unpack_plain_into_plain` is the same shape with no optional
-    anywhere and leaks identically, which is what pins the leak on the
-    pre-existing `retain_fields = not is_value` rule for value tuples
-    rather than on the optional coercion.
+    elements of a value tuple, and the two overwritten originals are
+    released at the store. `unpack_plain_into_plain` is the same shape with
+    no optional anywhere and must account identically, which is what keeps
+    the optional coercion from changing ownership on its own.
 
 `def drop` bumps a module glob so the tests count destructions exactly
 instead of reading freed memory.

--- a/jac/tests/compiler/passes/native/test_native_rc_ownership.jac
+++ b/jac/tests/compiler/passes/native/test_native_rc_ownership.jac
@@ -210,16 +210,18 @@ def call_counting_drops(eng: object, name: str, a: int, b: int) -> tuple[int, in
 
 test "tuple unpack into an optional slot destroys each object exactly once" {
     # Two Res are allocated and bound into `Res | None` locals through the
-    # coerced store. The unpack takes neither a retain nor an old-value
-    # release, which balances: releasing the tuple box does not decrement
-    # its fields, and scope exit releases each payload once. Adding a
-    # retain here without changing the box release leaks both.
+    # coerced store. Each bind retains the field it borrows from the box,
+    # the box release runs the destructor that drops the box's own
+    # reference to each field, and scope exit releases each payload: one
+    # destruction per allocation. The two ways to get this wrong land on
+    # either side of 2, so the count discriminates between them.
     (eng, _) = compile_native("rc_tuple_unpack_optional.jac");
     (value, drops) = call_counting_drops(eng, "unpack_into_optional", 3, 4);
     assert value == 34 , f"Expected 34, got {value}";
     assert drops == 2 , (
         f"2 allocations must produce 2 drops, got {drops} "
-        f"(0 would mean the payloads leaked, 4 an over-release)"
+        f"(0 means the box abandoned its fields, more than 2 that the bind "
+        f"skipped its retain and each payload was released twice)"
     );
 }
 
@@ -227,9 +229,11 @@ test "tuple unpack from an optional element costs no more than the plain one" {
     # Both fixtures allocate 4 Res and overwrite two locals through a value
     # tuple; `unpack_plain_into_plain` has no optional anywhere. They must
     # drop the same number, i.e. the optional coercion adds no leak of its
-    # own. Both currently drop 2 rather than 4: value-tuple unpack skips the
-    # old-value release (`retain_fields = not is_value`), which predates
-    # this change and is reachable without any optional.
+    # own. Both drop 4: the store releases what each target slot held for a
+    # value tuple exactly as for a boxed one, reaching the overwritten
+    # original through the optional payload when the slot is an optional.
+    # Asserting the two are equal rather than naming a constant is what let
+    # this survive the accounting change that moved both from 2 to 4.
     (eng, _) = compile_native("rc_tuple_unpack_optional.jac");
     (opt_value, opt_drops) = call_counting_drops(
         eng, "unpack_optional_into_plain", 3, 4


### PR DESCRIPTION
Follow-up to #8004, which merged while this documentation commit was still in
review. #8004 deleted the `retain_fields = not is_value` rule and gave heap
tuple boxes a destructor that releases their fields, but three descriptions of
the old rule survived in #7982's fixture and tests. Their assertions kept
passing, so nothing went red; the prose was simply false.

## What was wrong

```
jac/tests/compiler/passes/native/fixtures/rc_tuple_unpack_optional.jac:6
    on `retain_fields` (false for a value tuple) and on the target alloca
jac/tests/compiler/passes/native/fixtures/rc_tuple_unpack_optional.jac:19
    pre-existing `retain_fields = not is_value` rule for value tuples
jac/tests/compiler/passes/native/test_native_rc_ownership.jac:231
    # old-value release (`retain_fields = not is_value`), which predates
```

The fixture docstring also asserted that "releasing a tuple box does not
decrement its fields" and that the optional unpack "takes neither the retain
nor the old-release". Both were true before #8004 and are false after it. The
second test's comment claimed both shapes "currently drop 2 rather than 4";
they now drop 4.

## What they say now

The rule in force: a heap tuple box owns one reference per managed field and
its destructor releases them; the unpack retains by provenance (a field loaded
out of a box is always borrowed from the box's own reference, a value-tuple
element is borrowed unless recorded owned); and the target slot's previous
contents are released for both tuple representations, reached through the
optional payload when the slot is an optional rather than a raw pointer.

## The assertion message

`"tuple unpack into an optional slot destroys each object exactly once"` still
measures 2, but for a different reason than when it was written: previously no
retain, no release, and a box that abandoned its fields; now a retain per bind,
a destructor that drops the box's reference, and a release at scope exit. The
count is unchanged, so the test passed for a reason its message no longer
described.

The message now names the count each failure mode actually produces, and that
is measured rather than asserted. Removing the box destructor:

```
E   AssertionError: 2 allocations must produce 2 drops, got 0 (0 means the box
    abandoned its fields, more than 2 that the bind skipped its retain and each
    payload was released twice)
FAILED test_native_rc_ownership.jac::tuple unpack into an optional slot
    destroys each object exactly once
1 failed, 13 passed
```

The sibling test needed no rewording beyond its comment: it asserts
`opt_drops == plain_drops` rather than a constant, which is exactly what let it
survive both sides moving from 2 to 4.

## Scope

Comments and docstrings only, no behavior change, no `jac/jaclang/` files (so
no release-note fragment).

```
PYTEST_XDIST_AUTO_NUM_WORKERS=2 jac test \
  jac/tests/compiler/passes/native/test_native_rc_ownership.jac \
  jac/tests/compiler/test_compile_options.jac      # 33 passed
```
