### PR TITLE
fix(compiler): re-knit star-import symbols when a stub loads from the JIR cache

### DIFF
--- a/jac/jaclang/jac0core/impl/program.impl.jac
+++ b/jac/jaclang/jac0core/impl/program.impl.jac
@@ -181,6 +181,7 @@ impl JacProgram.load_dependency_module(
     }
 
     mod: uni.Module;
+    from_jir_cache = False;
     if resolved_path in self.mod.hub {
         mod = self.mod.hub[resolved_path];
     } elif resolved_path in target_hub {
@@ -192,6 +193,7 @@ impl JacProgram.load_dependency_module(
         }
         if jir_mod is not None {
             mod = jir_mod;
+            from_jir_cache = True;
             if resolved_path.endswith('.pyi') and not mod.stub_only {
                 mod.stub_only = True;
             }
@@ -225,12 +227,55 @@ impl JacProgram.load_dependency_module(
         }
         target_hub[resolved_path] = mod;
         target_program.hub_cache_stamp(resolved_path);
+        if from_jir_cache {
+            self._relink_absorbed_imports(mod);
+        }
     }
 
     if importer_path is not None {
         self.record_dependency(importer_path, resolved_path);
     }
     return mod;
+}
+
+impl JacProgram._relink_absorbed_imports(self: JacProgram, mod: uni.Module) -> None {
+    import from pathlib { Path }
+    import from jaclang.jac0core.constant { SymbolAccess }
+    import from jaclang.jac0core.passes.sym_tab_build_pass { find_python_scope_node_of }
+    for imp in mod.get_all_sub_nodes(uni.Import) {
+        if not imp.is_absorb or not imp.items {
+            continue;
+        }
+        path_node = imp.items[0];
+        if not isinstance(path_node, uni.ModulePath) {
+            continue;
+        }
+        scope = find_python_scope_node_of(imp);
+        if scope is None {
+            continue;
+        }
+        src_path = path_node.resolve_relative_path();
+        if not src_path or not Path(src_path).exists() {
+            continue;
+        }
+        src_mod = self.load_dependency_module(src_path);
+        for sym in src_mod.names_in_scope.values() {
+            if sym.access != SymbolAccess.PRIVATE and sym.defn {
+                scope.def_insert(
+                    sym.defn[0], single_decl='import absorb', imported=True
+                );
+            }
+        }
+        for overload_syms in src_mod.names_in_scope_overload.values() {
+            for sym in overload_syms {
+                if sym.access != SymbolAccess.PRIVATE and sym.defn {
+                    scope.def_insert(
+                        sym.defn[0], single_decl='import absorb', imported=True
+                    );
+                }
+            }
+        }
+    }
 }
 
 impl JacProgram._get_compiler(self: JacProgram) -> JacCompiler {

--- a/jac/jaclang/jac0core/program.jac
+++ b/jac/jaclang/jac0core/program.jac
@@ -54,6 +54,7 @@ class JacProgram {
         use_str: (str | None) = None
     ) -> uni.Module;
 
+    def _relink_absorbed_imports(self: JacProgram, mod: uni.Module) -> None;
     def _search_hubs(self: JacProgram) -> list[dict[(str, uni.Module)]];
     def find_module(self: JacProgram, path: str) -> (uni.Module | None);
     def get_bytecode(self: JacProgram, full_target: str) -> (types.CodeType | None);

--- a/jac/tests/compiler/test_importer.jac
+++ b/jac/tests/compiler/test_importer.jac
@@ -540,6 +540,63 @@ test "stub module cache key is source focused" {
     }
 }
 
+test "JIR-cached stub re-knits star imports with overloads" {
+    # Regression: symbols a stub absorbs via `from X import *` have their defn
+    # nodes in the foreign module's AST, which JIR serialization can only mark
+    # EXTERNAL_REF; on read the reader dropped them, so a warm-cached facade
+    # stub (e.g. os/path.pyi) lost every re-exported name and its overload
+    # chain -- os.path.abspath(str) then failed E1053 against the first
+    # overload only.
+    absorb_dir = tempfile.mkdtemp(prefix="jac_absorb_knit_", dir=_test_tmp_dir);
+    base_file = os.path.join(absorb_dir, "knit_base.pyi");
+    facade_file = os.path.join(absorb_dir, "knit_facade.pyi");
+    with open(base_file, "w") as f {
+        f.write(
+            "from typing import overload\n"
+                + "@overload\n"
+                + "def probe(x: int) -> int: ...\n"
+                + "@overload\n"
+                + "def probe(x: str) -> str: ...\n"
+        );
+    }
+    with open(facade_file, "w") as f {
+        f.write("from knit_base import *\n");
+    }
+    past = time.time() - 2;
+    os.utime(base_file, (past, past));
+    os.utime(facade_file, (past, past));
+    try {
+        prog1 = JacProgram();
+        fresh = prog1.load_dependency_module(facade_file);
+        assert fresh.sym_tab.lookup("probe") is not None , (
+            "fresh facade stub must absorb probe"
+        );
+        assert fresh.names_in_scope_overload.get("probe") , (
+            "fresh facade stub must absorb probe's overload chain"
+        );
+        assert get_module_cache_path(facade_file).exists() , (
+            "facade stub should be JIR cached after first load"
+        );
+
+        prog2 = JacProgram();
+        cached = prog2.load_dependency_module(facade_file);
+        assert cached.sym_tab.lookup("probe") is not None , (
+            "JIR-cached facade stub lost its absorbed symbols"
+        );
+        assert cached.names_in_scope_overload.get("probe") , (
+            "JIR-cached facade stub lost its absorbed overload chain"
+        );
+    } finally {
+        for p in (base_file, facade_file) {
+            os.unlink(p);
+            cp = get_module_cache_path(p);
+            if cp.exists() {
+                cp.unlink();
+            }
+        }
+    }
+}
+
 test "get_bytecode busts in-memory hub when .impl.jac changes" {
     # Regression: in a persistent process, editing a .impl.jac annex left a
     # stale in-memory module in mod.hub; get_bytecode returned it with no


### PR DESCRIPTION
## The gap

Symbols a stub absorbs via `from X import *` carry defn nodes that live in the foreign module's AST. JIR serialization can only mark those `EXTERNAL_REF`, and `JirReader._read_symbol` drops any symbol with no resolvable defns — so a warm-cached facade stub comes back as an empty shell. `os/path.pyi` is exactly that shape (`from posixpath import *`): on the second `jac check` of anything using `os.path`, attribute resolution falls through to the star-walk, which finds the target symbol but not its overload chain, and `os.path.abspath(a_str)` fails E1053 against the `PathLike[AnyStr]` overload alone.

Introduced by #7951 (lazy JIR dependency loading for .pyi stubs). It is invisible on a cold cache and appears on the next run, which is why CI's restored JIR caches make jac-check red or green per run rather than per commit.

## Repro on main at 18247e967

```
import os;

def probe(a: str) -> str {
    return os.path.abspath(a);
}
```

`jac check` passes on the first run (cold module cache), then fails every warm run:

```
error[E1053]: Cannot assign str to parameter 'path' of type PathLike[AnyStr]
```

Bisected to e1d124380; minimal failing cache state is `os/__init__.pyi` + `os/path.pyi` + `posixpath.pyi` all served from JIR.

## The fix

`JacProgram.load_dependency_module` re-runs the absorb knit after any JIR-cache hit: for each `is_absorb` import in the loaded module it resolves the source module (through `load_dependency_module` itself, so sources ride their own caches) and re-copies public symbols and overload entries exactly as `SymTabBuildPass._exit_import_absorb` does on a fresh build. The hub insertion happens before the knit so stub cycles terminate.

## Test

`test_importer.jac` gains a regression test: a facade stub star-importing an `@overload` pair must retain the absorbed symbol and its overload chain after a warm-cache reload by a fresh `JacProgram`. Fails on main today (`1 failed, 22 passed`), passes with the fix (`23 passed`).