### PR TITLE
draft: 0.34 backport of #8777 and #8655 (preview validation only, do not merge)

### DIFF
--- a/.github/workflows/experimental-image.yml
+++ b/.github/workflows/experimental-image.yml
@@ -98,8 +98,13 @@ jobs:
       # expressions, and the token value itself must not sit in env.
       DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
     steps:
-      # Only the Dockerfile is needed; the binaries carry the PR's code.
+      # The Dockerfile must come from the PR too: it stages a runtime the
+      # binary has to support, and that differs by generation (0.36 added the
+      # embedded Postgres `jac db fetch` step). Taking it from the default
+      # branch builds main's Dockerfile against a backport's binary.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: refs/pull/${{ needs.resolve.outputs.pr }}/head
 
       - name: Fail if publishing secrets are missing (org repo)
         if: github.repository == 'jaseci-labs/jac' && (env.DOCKERHUB_USERNAME == '' || env.DOCKERHUB_TOKEN_SET != 'true')

--- a/jac/jaclang/scale/deploy/target/kubernetes/target.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/target.jac
@@ -191,6 +191,11 @@ obj KubernetesTarget(KubernetesTargetBase) {
                 "under [scale.kubernetes] in jac.toml."
             );
         }
+        import from jaclang.scale.injector.binary { deploy_generation_refusal }
+        refusal = deploy_generation_refusal(app_config.code_folder);
+        if refusal {
+            return DeploymentResult(success=False, message=refusal);
+        }
         if self.logger {
             self.logger.info(
                 f"Deploying app '{app_name}' to Kubernetes",

--- a/jac/jaclang/scale/injector/binary.jac
+++ b/jac/jaclang/scale/injector/binary.jac
@@ -276,6 +276,46 @@ def resolve_deploy_version(project_dir: str, channel: str) -> str {
 }
 
 
+def deploy_generation_refusal(
+    project_dir: str, channel: str = "", offline: bool = False
+) -> str {
+    import from jaclang.cli.cli { jac_version }
+    import from jaclang.project.config { JacConfig, find_project_root }
+    import from jaclang.scale.config.dev_config { Channel, resolve_dev_channel }
+    channel = channel or resolve_dev_channel(project_dir).value;
+    if offline {
+        found = find_project_root(Path(project_dir));
+        pinned = (
+            _exact_of(str(JacConfig.load(found[1]).project.jac_version or ""))
+                if found is not None and channel == Channel.STABLE.value
+                else ""
+        );
+    } else {
+        try {
+            pinned = resolve_deploy_version(project_dir, channel);
+        } except RuntimeError {
+            return "";
+        }
+    }
+    running = jac_version().strip();
+    if not pinned or not running {
+        return "";
+    }
+    (pin_major, pin_minor, _) = _ver_key(pinned);
+    (run_major, run_minor, _) = _ver_key(running);
+    if (pin_major, pin_minor) == (run_major, run_minor) {
+        return "";
+    }
+    return (
+        f"this deployer is jac {running} and cannot deploy an app pinned to "
+        f"{pinned}. the deploying jac renders the manifests and provisions the "
+        "database, so a different minor line stands up a backend the pod "
+        f"cannot use. upgrade the deployer, or pin [project] jac-version to "
+        f"{run_major}.{run_minor}."
+    );
+}
+
+
 def reset_deploy_version_cache {
     _deploy_version_memo.clear();
 }
@@ -408,6 +448,14 @@ def download_release_binary(
 }
 
 
+def _write_cache_atomic(cache_file: Path, payload: bytes) {
+    cache_file.parent.mkdir(parents=True, exist_ok=True);
+    tmp = cache_file.with_name(f"{cache_file.name}.{os.getpid()}.tmp");
+    tmp.write_bytes(payload);
+    tmp.replace(cache_file);
+}
+
+
 def _fetch_verified_asset(
     url: str, checksum_url: str, cache_file: Path, what: str
 ) -> bytes {
@@ -445,10 +493,7 @@ def _fetch_verified_asset(
             );
         }
         try {
-            cache_file.parent.mkdir(parents=True, exist_ok=True);
-            tmp = cache_file.with_suffix(f".{os.getpid()}.tmp");
-            tmp.write_bytes(payload);
-            tmp.rename(cache_file);
+            _write_cache_atomic(cache_file, payload);
         } except Exception as e {
             logger.warning(f"Could not cache the downloaded {what} ({e}).");
         }
@@ -476,11 +521,7 @@ def host_toolchain_path(project_dir: str, channel: str = "") -> str {
     payload = download_release_binary(channel, arch, version, plat);
     path = _binary_cache_path(channel, arch, plat, version);
     if not path.is_file() {
-        path.parent.mkdir(parents=True, exist_ok=True);
-        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp");
-        tmp.write_bytes(payload);
-        tmp.chmod(0o755);
-        tmp.replace(path);
+        _write_cache_atomic(path, payload);
     }
     path.chmod(0o755);
     logger.info(f"Host build steps for this deploy run the pinned jac {version}.");

--- a/jac/jaclang/scale/injector/binary.jac
+++ b/jac/jaclang/scale/injector/binary.jac
@@ -316,6 +316,37 @@ def deploy_generation_refusal(
 }
 
 
+glob SCALE_DEPLOY_MIN: tuple[int, int] = (0, 37);
+
+
+def pinned_deploy_version(project_dir: str, channel: str = "") -> str {
+    import from jaclang.scale.config.dev_config { resolve_dev_channel }
+    channel = channel or resolve_dev_channel(project_dir).value;
+    try {
+        return resolve_deploy_version(project_dir, channel);
+    } except RuntimeError {
+        return "";
+    }
+}
+
+
+def pinned_deploy_argv(
+    jac_bin: str, pinned: str, filename: str, target: str, enable_tls: bool = False
+) -> list[str] {
+    (major, minor, _) = _ver_key(pinned);
+    argv = (
+        [jac_bin, "scale", "deploy", filename]
+            if (major, minor) >= SCALE_DEPLOY_MIN
+            else [jac_bin, "start", filename, "--scale"]
+    );
+    argv.extend(["--target", target]);
+    if enable_tls {
+        argv.append("--enable-tls");
+    }
+    return argv;
+}
+
+
 def reset_deploy_version_cache {
     _deploy_version_memo.clear();
 }

--- a/jac/jaclang/scale/injector/bundle.jac
+++ b/jac/jaclang/scale/injector/bundle.jac
@@ -57,6 +57,8 @@ glob _EXCLUDE_ENV: set[str] = {
          "JAC_EXECUTABLE"
      };
 
+glob _EXCLUDE_ENV_PREFIXES: tuple[str, ...] = ("JAC_SV_", );
+
 
 def is_excluded(rel: Path) -> bool {
     parts = rel.parts;
@@ -198,7 +200,7 @@ def release_binary_env -> dict[str, str] {
     return {
         k: v
         for (k, v) in os.environ.items()
-        if k not in _EXCLUDE_ENV
+        if k not in _EXCLUDE_ENV and not k.startswith(_EXCLUDE_ENV_PREFIXES)
     };
 }
 

--- a/jac/jaclang/scale/injector/bundle.jac
+++ b/jac/jaclang/scale/injector/bundle.jac
@@ -53,7 +53,8 @@ glob _EXCLUDE_ENV: set[str] = {
          "PYTHONHOME",
          "JAC_LLVM_SHIM",
          "JAC_DEV_SOURCE",
-         "JAC_NO_PRECOMPILE"
+         "JAC_NO_PRECOMPILE",
+         "JAC_EXECUTABLE"
      };
 
 

--- a/jac/jaclang/scale/memory/impl/memory_hierarchy.main.impl.jac
+++ b/jac/jaclang/scale/memory/impl/memory_hierarchy.main.impl.jac
@@ -1,3 +1,4 @@
+import os;
 def _carries_topology_index(anchor: Anchor) -> bool {
     return isinstance(anchor, NodeAnchor) and anchor.topology_index_data is not None;
 }
@@ -67,6 +68,13 @@ impl ScaleTieredMemory.postinit -> None {
             import from jaclang.cli.console { console }
             logger.debug("  ✔ Using MongoDB for persistence", style="muted");
         } except Exception { }
+    } elif os.environ.get('KUBERNETES_SERVICE_HOST', '').strip() {
+        raise RuntimeError(
+            'no MongoDB resolved in a cluster, and the local store here would '
+            'be per-replica and lost on restart. point the deploy at a '
+            'database, or set [scale.kubernetes] mongodb_enabled = false to '
+            'declare this app needs none.'
+        );
     } else {
         self.l3 = SqliteMemory(
             path=get_scale_config().get_database_config()['shelf_db_path']

--- a/jac/jaclang/scale/runtime/realizer/kubernetes_realizer.jac
+++ b/jac/jaclang/scale/runtime/realizer/kubernetes_realizer.jac
@@ -9,8 +9,53 @@ import from jaclang.scale.config.app_config { AppConfig }
 import from jaclang.scale.runtime.discovery.route_policy { format_route_origin_lines }
 
 
+glob DELEGATED_ENV: str = "JAC_SCALE_PINNED_DEPLOY";
+
+
+def pinned_deploy_argv(
+    jac_bin: str, filename: str, target: str, enable_tls: bool = False
+) -> list[str] {
+    argv = [jac_bin, "scale", "deploy", filename, "--target", target];
+    if enable_tls {
+        argv.append("--enable-tls");
+    }
+    return argv;
+}
+
+
 obj KubernetesRealizer {
     has ms_config: dict[str, any];
+
+    def _deploy_on_pinned_jac(
+        filename: str, target: str, enable_tls: bool, dry_run: bool
+    ) -> (int | None) {
+        import subprocess;
+        import from jaclang.scale.injector.binary { host_toolchain_path }
+        import from jaclang.scale.injector.bundle { release_binary_env }
+        if dry_run or os.environ.get(DELEGATED_ENV) == "1" {
+            return None;
+        }
+        pinned = host_toolchain_path(os.path.dirname(filename) or ".");
+        if not pinned {
+            return None;
+        }
+        console.print(
+            "Deploying with the jac release this app pins, not the one "
+            f"running this deploy ({pinned})."
+        );
+        env = release_binary_env();
+        env[DELEGATED_ENV] = "1";
+        code = subprocess.run(
+            pinned_deploy_argv(pinned, filename, target, enable_tls), env=env
+        ).returncode;
+        if code != 0 {
+            console.error(
+                f"The deploy ran on the pinned jac ({pinned}) and exited {code}.",
+                emoji=False
+            );
+        }
+        return code;
+    }
 
     def realize(
         filename: str,
@@ -65,10 +110,22 @@ obj KubernetesRealizer {
                 );
             }
         }
+        delegated = self._deploy_on_pinned_jac(filename, target, enable_tls, dry_run);
+        if delegated is not None {
+            return delegated;
+        }
         if not os.path.exists(filename) {
             raise FileNotFoundError(f"File not found: '{filename}'");
         }
         code_folder = os.path.dirname(filename) or '.';
+        if dry_run {
+            import from jaclang.scale.injector.binary { deploy_generation_refusal }
+            refusal = deploy_generation_refusal(code_folder, offline=True);
+            if refusal {
+                console.error(refusal, emoji=False);
+                return 2;
+            }
+        }
         dotenv_path = os.path.join(code_folder, '.env');
         load_dotenv(dotenv_path);
         scale_config = get_scale_config();

--- a/jac/jaclang/scale/runtime/realizer/kubernetes_realizer.jac
+++ b/jac/jaclang/scale/runtime/realizer/kubernetes_realizer.jac
@@ -12,17 +12,6 @@ import from jaclang.scale.runtime.discovery.route_policy { format_route_origin_l
 glob DELEGATED_ENV: str = "JAC_SCALE_PINNED_DEPLOY";
 
 
-def pinned_deploy_argv(
-    jac_bin: str, filename: str, target: str, enable_tls: bool = False
-) -> list[str] {
-    argv = [jac_bin, "scale", "deploy", filename, "--target", target];
-    if enable_tls {
-        argv.append("--enable-tls");
-    }
-    return argv;
-}
-
-
 obj KubernetesRealizer {
     has ms_config: dict[str, any];
 
@@ -30,12 +19,17 @@ obj KubernetesRealizer {
         filename: str, target: str, enable_tls: bool, dry_run: bool
     ) -> (int | None) {
         import subprocess;
-        import from jaclang.scale.injector.binary { host_toolchain_path }
+        import from jaclang.scale.injector.binary {
+            host_toolchain_path,
+            pinned_deploy_argv,
+            pinned_deploy_version
+        }
         import from jaclang.scale.injector.bundle { release_binary_env }
         if dry_run or os.environ.get(DELEGATED_ENV) == "1" {
             return None;
         }
-        pinned = host_toolchain_path(os.path.dirname(filename) or ".");
+        project_dir = os.path.dirname(filename) or ".";
+        pinned = host_toolchain_path(project_dir);
         if not pinned {
             return None;
         }
@@ -46,7 +40,10 @@ obj KubernetesRealizer {
         env = release_binary_env();
         env[DELEGATED_ENV] = "1";
         code = subprocess.run(
-            pinned_deploy_argv(pinned, filename, target, enable_tls), env=env
+            pinned_deploy_argv(
+                pinned, pinned_deploy_version(project_dir), filename, target, enable_tls
+            ),
+            env=env
         ).returncode;
         if code != 0 {
             console.error(

--- a/jac/jaclang/scale/tests/data/test_memory_hierarchy.jac
+++ b/jac/jaclang/scale/tests/data/test_memory_hierarchy.jac
@@ -1805,3 +1805,33 @@ test "RedisBackend loads carry a field-hash snapshot (L2 parity with L3 loads)" 
         "field mutations on an L2-loaded anchor must be derivable"
     );
 }
+
+
+test "in a cluster with no mongo, persistence fails instead of going pod-local" {
+    # #8766: the fallback wrote to a SqliteMemory file on the pod filesystem,
+    # one per replica, gone on restart, announced at debug. Off-cluster that
+    # fallback is the point, so the refusal is scoped to a pod.
+    import from jaclang.scale.memory.memory_hierarchy { ScaleTieredMemory }
+    prior = os.environ.get("KUBERNETES_SERVICE_HOST");
+    prior_uri = os.environ.get("MONGODB_URI");
+    os.environ["KUBERNETES_SERVICE_HOST"] = "10.96.0.1";
+    os.environ.pop("MONGODB_URI", None);
+    raised = False;
+    try {
+        ScaleTieredMemory(base_path=".", target_path="main.jac");
+    } except RuntimeError as e {
+        raised = "per-replica" in str(e);
+    } except Exception {
+        raised = False;
+    } finally {
+        if prior is None {
+            os.environ.pop("KUBERNETES_SERVICE_HOST", None);
+        } else {
+            os.environ["KUBERNETES_SERVICE_HOST"] = prior;
+        }
+        if prior_uri is not None {
+            os.environ["MONGODB_URI"] = prior_uri;
+        }
+    }
+    assert raised , ("a pod with no database silently took a per-replica local store");
+}

--- a/jac/jaclang/scale/tests/test_version_pin.jac
+++ b/jac/jaclang/scale/tests/test_version_pin.jac
@@ -432,6 +432,11 @@ test "delegating runs the pinned binary with this deploy, and forwards its resul
     );
     stub.chmod(0o755);
     os.environ["JAC_DEV_SOURCE"] = d;
+    # A deployer running inside a jac-scale pod carries JAC_SV_*, which names
+    # ITS OWN services. jac-scale falls back to JAC_SV_ROUTES whenever the app
+    # declares none, so a leaked one deploys the deployer's fleet into the
+    # target namespace.
+    os.environ["JAC_SV_ROUTES"] = '{"builder_sv": "/api/builder_sv"}';
     err = io.StringIO();
     with unittest.mock.patch.object(
         binary_mod, "host_toolchain_path", return_value=str(stub)
@@ -443,6 +448,7 @@ test "delegating runs the pinned binary with this deploy, and forwards its resul
         );
     }
     os.environ.pop("JAC_DEV_SOURCE", None);
+    os.environ.pop("JAC_SV_ROUTES", None);
     assert rc == 7 , f"the child exited 7; the deploy reported {rc}";
     argv = (Path(d) / "argv").read_text().split();
     assert argv == [
@@ -456,6 +462,10 @@ test "delegating runs the pinned binary with this deploy, and forwards its resul
     assert f"{DELEGATED_ENV}=1" in env , "the child can delegate again and fork forever";
     assert "JAC_DEV_SOURCE" not in env , (
         "the child inherited the parent's dev source and would run its code"
+    );
+    assert "JAC_SV_ROUTES" not in env , (
+        "the child inherited the deployer's own service routes and would "
+        "deploy the deployer's fleet into the app's namespace"
     );
     assert "7" in err.getvalue() , "a failed delegated deploy said nothing";
 }

--- a/jac/jaclang/scale/tests/test_version_pin.jac
+++ b/jac/jaclang/scale/tests/test_version_pin.jac
@@ -14,10 +14,10 @@ import from jaclang.scale.deploy.target.kubernetes.kubernetes_config {
     KubernetesConfig
 }
 import from jaclang.scale.deploy.target.kubernetes.target { KubernetesTarget }
+import from jaclang.scale.injector.binary { pinned_deploy_argv }
 import from jaclang.scale.runtime.realizer.kubernetes_realizer {
     DELEGATED_ENV,
-    KubernetesRealizer,
-    pinned_deploy_argv
+    KubernetesRealizer
 }
 import from pathlib { Path }
 
@@ -415,6 +415,7 @@ test "the child is handed every deploy parameter that can reach it" {
     };
     forwarded = set(inspect.signature(pinned_deploy_argv).parameters) - {
         "jac_bin",
+        "pinned",
         "filename"
     };
     assert accepted - forwarded == {"dry_run", "show_yaml"} , (
@@ -434,6 +435,8 @@ test "delegating runs the pinned binary with this deploy, and forwards its resul
     err = io.StringIO();
     with unittest.mock.patch.object(
         binary_mod, "host_toolchain_path", return_value=str(stub)
+    ), unittest.mock.patch.object(
+        binary_mod, "pinned_deploy_version", return_value="0.34.17"
     ), redirect_stderr(err) {
         rc = KubernetesRealizer(ms_config={})._deploy_on_pinned_jac(
             f"{d}/main.jac", "kubernetes", False, False
@@ -443,9 +446,9 @@ test "delegating runs the pinned binary with this deploy, and forwards its resul
     assert rc == 7 , f"the child exited 7; the deploy reported {rc}";
     argv = (Path(d) / "argv").read_text().split();
     assert argv == [
-        "scale",
-        "deploy",
+        "start",
         f"{d}/main.jac",
+        "--scale",
         "--target",
         "kubernetes"
     ] , argv;
@@ -455,4 +458,28 @@ test "delegating runs the pinned binary with this deploy, and forwards its resul
         "the child inherited the parent's dev source and would run its code"
     );
     assert "7" in err.getvalue() , "a failed delegated deploy said nothing";
+}
+
+
+test "the deploy verb follows the pinned release, not the deployer" {
+    # `jac start` was removed in 0.37 and `jac scale deploy` did not exist
+    # before it, so a single hardcoded verb is wrong for one side or the other.
+    for (pinned, expected) in [
+        ("0.34.17", ["start", "app.jac", "--scale"]),
+        ("0.35.1", ["start", "app.jac", "--scale"]),
+        ("0.36.1", ["start", "app.jac", "--scale"]),
+        ("0.37.1", ["scale", "deploy", "app.jac"]),
+        ("1.0.0", ["scale", "deploy", "app.jac"])
+    ] {
+        argv = pinned_deploy_argv("jac", pinned, "app.jac", "kubernetes");
+        assert argv == ["jac"] + expected + ["--target", "kubernetes"] , (
+            f"{pinned} would be deployed with {argv}"
+        );
+    }
+    assert "--enable-tls" in pinned_deploy_argv(
+        "jac", "0.34.17", "app.jac", "kubernetes", True
+    );
+    assert "--enable-tls" in pinned_deploy_argv(
+        "jac", "0.37.1", "app.jac", "kubernetes", True
+    );
 }

--- a/jac/jaclang/scale/tests/test_version_pin.jac
+++ b/jac/jaclang/scale/tests/test_version_pin.jac
@@ -3,7 +3,22 @@ import tempfile;
 import unittest.mock;
 import jaclang.scale.injector.binary as binary_mod;
 import from jaclang.scale.injector.binary { _exact_of, _resolve_target_version }
+import inspect;
+import io;
+import os;
+import from contextlib { redirect_stderr }
+import from jaclang.cli.cli { jac_version }
 import from jaclang.project.config { JacConfig }
+import from jaclang.scale.config.app_config { AppConfig }
+import from jaclang.scale.deploy.target.kubernetes.kubernetes_config {
+    KubernetesConfig
+}
+import from jaclang.scale.deploy.target.kubernetes.target { KubernetesTarget }
+import from jaclang.scale.runtime.realizer.kubernetes_realizer {
+    DELEGATED_ENV,
+    KubernetesRealizer,
+    pinned_deploy_argv
+}
 import from pathlib { Path }
 
 glob REPO: str = "jaseci-labs/jac";
@@ -338,4 +353,106 @@ test "the preflight needs the pod binary and the host sealing binary" {
     ) {
         assert binary_mod.preflight_pod_runtime(d, "stable", "x86_64") == "0.34.3";
     }
+}
+
+
+def _pin_offset(delta: int) -> str {
+    (major, minor, _) = binary_mod._ver_key(jac_version().strip());
+    return _project(
+        f'[project]\nname = "x"\njac-version = "=={major}.{minor + delta}.0"\n'
+    );
+}
+
+
+test "a deploy is refused when the pin is a minor line off the deployer" {
+    # The pin picks the pod image and the seal; the deploying jac renders the
+    # manifests and provisions the database. #8766: nothing compared the two.
+    running = jac_version().strip();
+    assert binary_mod.deploy_generation_refusal(_pin_offset(0), "stable") == "";
+    refusal = binary_mod.deploy_generation_refusal(_pin_offset(1), "stable");
+    assert running in refusal , f"{refusal!a} must name the deployer";
+    assert "mongo" not in refusal.lower() and "postgres" not in refusal.lower();
+    assert binary_mod.deploy_generation_refusal(_pin_offset(-1), "stable") != "";
+    assert binary_mod.deploy_generation_refusal(
+        _project('[project]\nname = "x"\n'), "stable"
+    ) == "";
+    assert binary_mod.deploy_generation_refusal(_pin_offset(1), "dev") == "";
+}
+
+
+test "a jac.toml it cannot read refuses the deploy instead of allowing it" {
+    # Returning "" reads as "no refusal", so a blanket except would let the
+    # cross-generation deploy through on a config nobody could parse.
+    broken = _project('[project\nname = "x"\n');
+    raised = False;
+    try {
+        binary_mod.deploy_generation_refusal(broken, "stable");
+    } except Exception {
+        raised = True;
+    }
+    assert raised , "an unreadable jac.toml was treated as no pin";
+}
+
+
+test "a cross-generation deploy is refused before the cluster is contacted" {
+    cfg = KubernetesConfig.from_dict(
+        KubernetesConfig, {"app_name": "x", "namespace": "default"}
+    );
+    result = KubernetesTarget(config=cfg, microservices_config={}).deploy(
+        AppConfig(code_folder=_pin_offset(1), file_name="main.jac")
+    );
+    assert result.success is False , "a cross-generation deploy must not proceed";
+    assert jac_version().strip() in result.message;
+}
+
+
+test "the child is handed every deploy parameter that can reach it" {
+    # dry_run never delegates and show_yaml is read only inside that branch, so
+    # neither can change a delegated deploy. Anything else must be forwarded.
+    accepted = set(inspect.signature(KubernetesRealizer.realize).parameters) - {
+        "self",
+        "filename"
+    };
+    forwarded = set(inspect.signature(pinned_deploy_argv).parameters) - {
+        "jac_bin",
+        "filename"
+    };
+    assert accepted - forwarded == {"dry_run", "show_yaml"} , (
+        f"realize() takes {sorted(accepted)}, the child gets {sorted(forwarded)}"
+    );
+}
+
+
+test "delegating runs the pinned binary with this deploy, and forwards its result" {
+    d = tempfile.mkdtemp();
+    stub = Path(d) / "jac";
+    stub.write_text(
+        "#!/bin/sh\n" f'printf "%s\\n" "$@" > {d}/argv\n' f"env > {d}/env\n" "exit 7\n"
+    );
+    stub.chmod(0o755);
+    os.environ["JAC_DEV_SOURCE"] = d;
+    err = io.StringIO();
+    with unittest.mock.patch.object(
+        binary_mod, "host_toolchain_path", return_value=str(stub)
+    ), redirect_stderr(err) {
+        rc = KubernetesRealizer(ms_config={})._deploy_on_pinned_jac(
+            f"{d}/main.jac", "kubernetes", False, False
+        );
+    }
+    os.environ.pop("JAC_DEV_SOURCE", None);
+    assert rc == 7 , f"the child exited 7; the deploy reported {rc}";
+    argv = (Path(d) / "argv").read_text().split();
+    assert argv == [
+        "scale",
+        "deploy",
+        f"{d}/main.jac",
+        "--target",
+        "kubernetes"
+    ] , argv;
+    env = (Path(d) / "env").read_text();
+    assert f"{DELEGATED_ENV}=1" in env , "the child can delegate again and fork forever";
+    assert "JAC_DEV_SOURCE" not in env , (
+        "the child inherited the parent's dev source and would run its code"
+    );
+    assert "7" in err.getvalue() , "a failed delegated deploy said nothing";
 }


### PR DESCRIPTION
Validation branch, not for merge.

Backports #8777 (cross-generation deploy guards + pinned-release delegation) and #8655 (JAC_EXECUTABLE scrub, shared cache write) onto `release/jaclang-0.34.17`, so a jacBuilder PR preview can run them on the 0.34 line where the reported bug lives.

Two things differ from main, because the 0.34 tree spells them differently:

- the running version comes from `jac_version()`, not `resolve_cli_version()`
- the in-cluster persistence guard is rewritten. 0.34's silent fallback is a `SqliteMemory` file on the pod filesystem, not an embedded Postgres, and `ScaleTieredMemory` must have a backend, so refusing means raising rather than returning `None`. That is a behaviour change on a maintenance line and wants its own review before it ships anywhere real.

The previous contents of this branch (the runner-pool memory fix) are preserved at `backup/8038-runner-pool-fix`.