### PR TITLE
feat(cl-test): per-module npm stub overrides via [test.npm-stubs]

### DIFF
--- a/jac/jaclang/cli/docs/reference/config/index.md
+++ b/jac/jaclang/cli/docs/reference/config/index.md
@@ -331,6 +331,34 @@ When `directory` is set, `jac test` with no file argument collects tests only
 from that directory (resolved against the project root), so application modules
 whose top-level `with entry` runs on import are not pulled into test collection.
 
+#### [test.npm-stubs]
+
+Client (`cl`) tests run under bun in a sealed temp directory with no
+`node_modules`, so every npm import is rewritten to a universal Proxy stub that
+absorbs any call and returns nothing. That keeps imports from crashing, but a
+test that needs a dependency to *behave* -- return a value, record a call --
+needs a real module instead. Map the import spec to one:
+
+```toml
+[test.npm-stubs]
+vscode = "tests/mocks/vscode.js"        # plain JavaScript
+"@scope/telemetry" = "tests/mocks/telemetry.jac"   # or Jac
+```
+
+Paths are relative to the `jac.toml` that declares them. A mapped spec resolves
+to that module; anything unmapped keeps the Proxy stub, so this is purely
+additive to existing suites.
+
+A `.jac` mock is compiled through the ordinary client pipeline, so `:pub` is
+what makes a name importable from the test. Because placement is inferred, a
+mock holding no client-only syntax lands in the server codespace and compiles
+to no JS -- pin it alongside the mapping:
+
+```toml
+[placement.pins]
+"tests.mocks.telemetry" = "client"
+```
+
 ---
 
 ### [format]

--- a/jac/jaclang/cli/docs/reference/config/index.md
+++ b/jac/jaclang/cli/docs/reference/config/index.md
@@ -349,6 +349,12 @@ Paths are relative to the `jac.toml` that declares them. A mapped spec resolves
 to that module; anything unmapped keeps the Proxy stub, so this is purely
 additive to existing suites.
 
+Inside a mock, npm specs are rewritten in every static form -- `import x from
+"pkg"`, a side-effect `import "pkg/theme.css"`, and `export ... from "pkg"` --
+so a mock can pull in stylesheets and re-export from other packages the way
+ordinary JavaScript does. Dynamic `import("pkg")` is not rewritten and will
+fail to resolve.
+
 A `.jac` mock is compiled through the ordinary client pipeline, so `:pub` is
 what makes a name importable from the test. Because placement is inferred, a
 mock holding no client-only syntax lands in the server codespace and compiles

--- a/jac/jaclang/cli/docs/reference/testing.md
+++ b/jac/jaclang/cli/docs/reference/testing.md
@@ -212,6 +212,28 @@ A `test` block runs in the codespace its surrounding context compiles to, so tes
 
 All of them report through the same `jac test` pass/fail pipeline, and the CLI options above apply uniformly. A test in a native-placed module compiles to native code and runs with native semantics -- a failing `assert` reports the failing source location (`file:line`). See [Native Compilation -- Testing](language/native-pathway.md#testing) for native-specific details and limitations.
 
+### Mocking npm Modules in Client Tests
+
+Client tests run in a sealed temp directory with no `node_modules`, so every npm import is rewritten to a universal Proxy stub. The stub absorbs any call and returns nothing, which keeps imports from crashing but cannot give a test a value to assert on.
+
+To make a dependency behave, map its import spec to a real module in `jac.toml`:
+
+```toml
+[test.npm-stubs]
+vscode = "tests/mocks/vscode.js"
+```
+
+```jac
+import from "vscode" { window }
+
+test "prompts with the configured interpreters" {
+    picked = await window.showQuickPick(["3.11", "3.12"]);
+    assert picked == "3.12";
+}
+```
+
+Mocks can be written in JavaScript or in Jac, and anything left unmapped keeps the Proxy stub. See [`[test.npm-stubs]`](config/index.md#testnpm-stubs) for path resolution and for pinning a Jac mock to the client codespace.
+
 ---
 
 ## Test Output

--- a/jac/jaclang/project/config.jac
+++ b/jac/jaclang/project/config.jac
@@ -74,7 +74,8 @@ obj TestConfig {
         filter: str = "",
         verbose: bool = False,
         fail_fast: bool = False,
-        max_failures: int = 0;
+        max_failures: int = 0,
+        npm_stubs: dict[str, str] = {};
 }
 
 obj ServeConfig {

--- a/jac/jaclang/project/impl/config.impl.jac
+++ b/jac/jaclang/project/impl/config.impl.jac
@@ -1183,12 +1183,16 @@ impl _parse_toml_data(
     }
     if "test" in data {
         test_data = data["test"];
+        raw_stubs = test_data.get("npm-stubs", test_data.get("npm_stubs", {}));
         config.test = TestConfig(
             directory=test_data.get("directory", ""),
             filter=test_data.get("filter", ""),
             verbose=test_data.get("verbose", False),
             fail_fast=test_data.get("fail_fast", False),
-            max_failures=test_data.get("max_failures", 0)
+            max_failures=test_data.get("max_failures", 0),
+            npm_stubs={
+                str(spec): str(path) for (spec, path) in dict(raw_stubs or {}).items()
+            }
         );
     }
     if "serve" in data {

--- a/jac/jaclang/runtimelib/cl_test_runner.jac
+++ b/jac/jaclang/runtimelib/cl_test_runner.jac
@@ -74,7 +74,11 @@ def _compile_runtime_js -> str;
 
 def _compile_runtime_core_js -> str;
 
-def _stub_npm_imports(js_sources: list[str]) -> tuple[list, str, bool];
+def _point_at_staged_runtime(js: str) -> str;
+
+def _stub_npm_imports(
+    entry_js: str, staged: dict[str, str]
+) -> tuple[str, dict[str, str], str, bool];
 
 def _build_harness(
     module_js: str, tests: list, api_base_url: str = "", storage: (dict | None) = None

--- a/jac/jaclang/runtimelib/cl_test_runner.jac
+++ b/jac/jaclang/runtimelib/cl_test_runner.jac
@@ -12,6 +12,11 @@ glob _RESULT_SENTINEL: str = "__JAC_CL_TEST_RESULTS__",
      _IMPORT_FROM = re.compile(
          r"import\s+(?P<clause>[^;]*?)\s+from\s+[\"'](?P<spec>[^\"']+)[\"']\s*;?"
      ),
+     _EXPORT_FROM = re.compile(
+         r"export\s+(?P<clause>\*(?:\s+as\s+[A-Za-z_$][\w$]*)?|\{[^}]*\})"
+         r"\s*from\s*[\"'](?P<spec>[^\"']+)[\"']\s*;?"
+     ),
+     _BARE_IMPORT = re.compile(r"import\s+[\"'](?P<spec>[^\"']+)[\"']\s*;?"),
      _NAMED_BINDING = re.compile(r"([A-Za-z_$][\w$]*)\s*(?:as\s+[A-Za-z_$][\w$]*)?"),
      _PRELUDE_TEMPLATE: str = """
 // --- jac cl test prelude (injected by cl_test_runner) ---

--- a/jac/jaclang/runtimelib/cl_test_runner.jac
+++ b/jac/jaclang/runtimelib/cl_test_runner.jac
@@ -6,6 +6,7 @@ glob _COLOR_CACHE: dict[(str, bool)] = {};
 
 glob _RESULT_SENTINEL: str = "__JAC_CL_TEST_RESULTS__",
      _NPM_STUB_FILE: str = "__jac_npm_stub.js",
+     _MOCK_PREFIX: str = "__jac_mock_",
      _SERVER_ENTRY_NAMES: tuple = ("server.jac", "main.jac"),
      _IMPORT_LINE = re.compile(r"^\s*import\b.*?;?\s*$", re.MULTILINE),
      _IMPORT_FROM = re.compile(
@@ -76,8 +77,16 @@ def _compile_runtime_core_js -> str;
 
 def _point_at_staged_runtime(js: str) -> str;
 
+def _mock_stub_name(spec: str) -> str;
+
+def _resolve_npm_mocks(source_path: (str | None)) -> dict[str, str];
+
+def _stage_npm_mocks(
+    mocks: dict[str, str]
+) -> tuple[dict[str, str], dict[str, str], dict[str, str]];
+
 def _stub_npm_imports(
-    entry_js: str, staged: dict[str, str]
+    entry_js: str, staged: dict[str, str], mocks: dict[str, str]
 ) -> tuple[str, dict[str, str], str, bool];
 
 def _build_harness(

--- a/jac/jaclang/runtimelib/impl/cl_test_runner.impl.jac
+++ b/jac/jaclang/runtimelib/impl/cl_test_runner.impl.jac
@@ -144,17 +144,16 @@ impl _stub_npm_imports(
         return (not spec.startswith(".")) and (spec != "@jac/runtime");
     }
 
-    def repl(mobj: any) -> str {
-        spec = mobj.group("spec");
-        if not is_npm(spec) {
-            return mobj.group(0);
-        }
-        clause = mobj.group("clause").strip();
+    def target(spec: str) -> str {
         mock_file = mocks.get(spec);
         if mock_file {
-            return 'import ' + clause + ' from "./' + mock_file + '";';
+            return mock_file;
         }
         state["changed"] = True;
+        return _NPM_STUB_FILE;
+    }
+
+    def collect_named(clause: str) {
         brace = re.search(r"\{([^}]*)\}", clause);
         if brace {
             for ident in _NAMED_BINDING.findall(brace.group(1)) {
@@ -163,18 +162,56 @@ impl _stub_npm_imports(
                 }
             }
         }
-
-        head = clause.split("{")[0].split(",")[0].strip();
-        if head and (not head.startswith("*")) {
-            state["needs_default"] = True;
-        }
-        return 'import ' + clause + ' from "./' + _NPM_STUB_FILE + '";';
     }
 
-    rewritten_entry = _IMPORT_FROM.sub(repl, entry_js);
+    def repl_import(mobj: any) -> str {
+        spec = mobj.group("spec");
+        if not is_npm(spec) {
+            return mobj.group(0);
+        }
+        clause = mobj.group("clause").strip();
+        dest = target(spec);
+        if dest == _NPM_STUB_FILE {
+            collect_named(clause);
+            head = clause.split("{")[0].split(",")[0].strip();
+            if head and (not head.startswith("*")) {
+                state["needs_default"] = True;
+            }
+        }
+        return 'import ' + clause + ' from "./' + dest + '";';
+    }
+
+    def repl_export(mobj: any) -> str {
+        spec = mobj.group("spec");
+        if not is_npm(spec) {
+            return mobj.group(0);
+        }
+        clause = mobj.group("clause").strip();
+        dest = target(spec);
+        if dest == _NPM_STUB_FILE {
+            collect_named(clause);
+        }
+        return 'export ' + clause + ' from "./' + dest + '";';
+    }
+
+    def repl_bare(mobj: any) -> str {
+        spec = mobj.group("spec");
+        if not is_npm(spec) {
+            return mobj.group(0);
+        }
+        return 'import "./' + target(spec) + '";';
+    }
+
+    def rewrite(js: str) -> str {
+        rewritten = _IMPORT_FROM.sub(repl_import, js);
+        rewritten = _EXPORT_FROM.sub(repl_export, rewritten);
+        return _BARE_IMPORT.sub(repl_bare, rewritten);
+    }
+
+    rewritten_entry = rewrite(entry_js);
     rewritten_staged: dict[str, str] = {};
     for (staged_name, staged_js) in staged.items() {
-        rewritten_staged[staged_name] = _IMPORT_FROM.sub(repl, staged_js);
+        rewritten_staged[staged_name] = rewrite(staged_js);
     }
 
     lines = ["const __jacNpmStub = new Proxy(function () {}, {"];

--- a/jac/jaclang/runtimelib/impl/cl_test_runner.impl.jac
+++ b/jac/jaclang/runtimelib/impl/cl_test_runner.impl.jac
@@ -59,8 +59,83 @@ impl _point_at_staged_runtime(js: str) -> str {
     );
 }
 
+impl _mock_stub_name(spec: str) -> str {
+    import hashlib;
+    safe = "".join([ch if (ch.isalnum() or ch == "_") else "_" for ch in spec]);
+    digest = hashlib.sha1(spec.encode("utf-8")).hexdigest()[:8];
+    return f"{_MOCK_PREFIX}{safe[:40]}_{digest}.js";
+}
+
+impl _resolve_npm_mocks(source_path: (str | None)) -> dict[str, str] {
+    if not source_path {
+        return {};
+    }
+    import from jaclang.project.config { JacConfig }
+
+    start = Path(source_path).resolve().parent;
+    config = JacConfig.discover(start_path=start);
+    if config is None {
+        return {};
+    }
+    declared = config.test.npm_stubs or {};
+    if not declared {
+        return {};
+    }
+    base_dir = start if config.toml_path is None else config.toml_path.parent;
+
+    resolved: dict[str, str] = {};
+    for (spec, rel) in declared.items() {
+        cand = Path(rel);
+        if not cand.is_absolute() {
+            cand = base_dir / cand;
+        }
+        if cand.suffix not in (".js", ".jac") {
+            raise RuntimeError(
+                f"[test.npm-stubs] '{spec}' points at '{rel}': an npm stub "
+                "must be a .js or .jac module"
+            );
+        }
+        if not cand.is_file() {
+            raise RuntimeError(
+                f"[test.npm-stubs] '{spec}' points at '{rel}', which does not "
+                f"exist (resolved against {base_dir} to {cand})"
+            );
+        }
+        resolved[spec] = str(cand.resolve());
+    }
+    return resolved;
+}
+
+impl _stage_npm_mocks(
+    mocks: dict[str, str]
+) -> tuple[dict[str, str], dict[str, str], dict[str, str]] {
+    spec_files: dict[str, str] = {};
+    mock_files: dict[str, str] = {};
+    merged_imports: dict[str, str] = {};
+
+    for (spec, path) in mocks.items() {
+        if path.endswith(".jac") {
+            (js, _mock_tests, mock_imports, _mock_server) = compile_cl_module(path);
+            if not js.strip() {
+                raise RuntimeError(
+                    f"[test.npm-stubs] '{spec}' -> {path} compiled to no client "
+                    "code, so it cannot stand in for an npm module; pin it with "
+                    "a [placement.pins] entry setting it to 'client'"
+                );
+            }
+            merged_imports.update(mock_imports);
+        } else {
+            js = Path(path).read_text(encoding="utf-8");
+        }
+        name = _mock_stub_name(spec);
+        spec_files[spec] = name;
+        mock_files[name] = js;
+    }
+    return (spec_files, mock_files, merged_imports);
+}
+
 impl _stub_npm_imports(
-    entry_js: str, staged: dict[str, str]
+    entry_js: str, staged: dict[str, str], mocks: dict[str, str]
 ) -> tuple[str, dict[str, str], str, bool] {
     named: set = set();
     state = {"needs_default": False, "changed": False};
@@ -74,8 +149,12 @@ impl _stub_npm_imports(
         if not is_npm(spec) {
             return mobj.group(0);
         }
-        state["changed"] = True;
         clause = mobj.group("clause").strip();
+        mock_file = mocks.get(spec);
+        if mock_file {
+            return 'import ' + clause + ' from "./' + mock_file + '";';
+        }
+        state["changed"] = True;
         brace = re.search(r"\{([^}]*)\}", clause);
         if brace {
             for ident in _NAMED_BINDING.findall(brace.group(1)) {
@@ -455,9 +534,15 @@ impl _run_harness(
             );
         }
 
+        (mock_specs, mock_files, mock_imports) = _stage_npm_mocks(
+            _resolve_npm_mocks(source_path)
+        );
+
         staged: dict[str, str] = {};
 
-        if ("@jac/runtime" in imports) or ("@jac/runtime" in dep_imports) {
+        if ("@jac/runtime" in imports)
+            or ("@jac/runtime" in dep_imports)
+            or ("@jac/runtime" in mock_imports) {
             import from jaclang.runtimelib.client_surface {
                 prepend_active_runtime_globals
             }
@@ -466,6 +551,9 @@ impl _run_harness(
             );
             for dep_name in list(dep_files.keys()) {
                 dep_files[dep_name] = _point_at_staged_runtime(dep_files[dep_name]);
+            }
+            for mock_name in list(mock_files.keys()) {
+                mock_files[mock_name] = _point_at_staged_runtime(mock_files[mock_name]);
             }
 
             runtime_js = _compile_runtime_js();
@@ -484,8 +572,19 @@ impl _run_harness(
         for (dep_name, dep_js) in dep_files.items() {
             staged[dep_name] = dep_js;
         }
+        for (mock_name, mock_js) in mock_files.items() {
+            if mock_name in staged {
+                raise RuntimeError(
+                    f"cl test harness cannot stage npm stub '{mock_name}': the "
+                    "name is already taken in the work dir"
+                );
+            }
+            staged[mock_name] = mock_js;
+        }
 
-        (module_js, staged, stub_js, changed) = _stub_npm_imports(module_js, staged);
+        (module_js, staged, stub_js, changed) = _stub_npm_imports(
+            module_js, staged, mock_specs
+        );
         if changed {
             staged[_NPM_STUB_FILE] = stub_js;
         }

--- a/jac/jaclang/runtimelib/impl/cl_test_runner.impl.jac
+++ b/jac/jaclang/runtimelib/impl/cl_test_runner.impl.jac
@@ -53,10 +53,17 @@ impl _compile_runtime_core_js -> str {
     return js;
 }
 
-impl _stub_npm_imports(js_sources: list[str]) -> tuple[list, str, bool] {
+impl _point_at_staged_runtime(js: str) -> str {
+    return js.replace('"@jac/runtime"', '"./jac_runtime.js"').replace(
+        "'@jac/runtime'", "'./jac_runtime.js'"
+    );
+}
+
+impl _stub_npm_imports(
+    entry_js: str, staged: dict[str, str]
+) -> tuple[str, dict[str, str], str, bool] {
     named: set = set();
     state = {"needs_default": False, "changed": False};
-    rewritten = [];
 
     def is_npm(spec: str) -> bool {
         return (not spec.startswith(".")) and (spec != "@jac/runtime");
@@ -85,8 +92,10 @@ impl _stub_npm_imports(js_sources: list[str]) -> tuple[list, str, bool] {
         return 'import ' + clause + ' from "./' + _NPM_STUB_FILE + '";';
     }
 
-    for src in js_sources {
-        rewritten.append(_IMPORT_FROM.sub(repl, src));
+    rewritten_entry = _IMPORT_FROM.sub(repl, entry_js);
+    rewritten_staged: dict[str, str] = {};
+    for (staged_name, staged_js) in staged.items() {
+        rewritten_staged[staged_name] = _IMPORT_FROM.sub(repl, staged_js);
     }
 
     lines = ["const __jacNpmStub = new Proxy(function () {}, {"];
@@ -99,7 +108,7 @@ impl _stub_npm_imports(js_sources: list[str]) -> tuple[list, str, bool] {
         lines.append(f"export const {name} = __jacNpmStub;");
     }
     stub_js = "\n".join(lines) + "\n";
-    return (rewritten, stub_js, state["changed"]);
+    return (rewritten_entry, rewritten_staged, stub_js, state["changed"]);
 }
 
 impl _build_harness(
@@ -445,67 +454,44 @@ impl _run_harness(
                 module_js, str(entry.parent), str(entry)
             );
         }
+
+        staged: dict[str, str] = {};
+
         if ("@jac/runtime" in imports) or ("@jac/runtime" in dep_imports) {
             import from jaclang.runtimelib.client_surface {
                 prepend_active_runtime_globals
             }
-            runtime_js = _compile_runtime_js();
-
-            module_js = prepend_active_runtime_globals(module_js);
-
-            module_js = module_js.replace('"@jac/runtime"', '"./jac_runtime.js"');
-            module_js = module_js.replace("'@jac/runtime'", "'./jac_runtime.js'");
+            module_js = _point_at_staged_runtime(
+                prepend_active_runtime_globals(module_js)
+            );
             for dep_name in list(dep_files.keys()) {
-                dep_files[dep_name] = dep_files[dep_name].replace(
-                    '"@jac/runtime"', '"./jac_runtime.js"'
-                ).replace(
-                    "'@jac/runtime'", "'./jac_runtime.js'"
-                );
+                dep_files[dep_name] = _point_at_staged_runtime(dep_files[dep_name]);
             }
 
-            import re;
-            core_js = None;
+            runtime_js = _compile_runtime_js();
             core_match = re.search(
                 r'from\s+[\'\"]([^\'\"]*client_runtime_core\.js)[\'\"]', runtime_js
             );
             if core_match {
-                core_js = _compile_runtime_core_js();
                 runtime_js = runtime_js.replace(
                     core_match.group(1), "./client_runtime_core.js"
                 );
+                staged["client_runtime_core.js"] = _compile_runtime_core_js();
             }
-
-            dep_names = sorted(dep_files.keys());
-            sources = [module_js, runtime_js];
-            if core_js is not None {
-                sources.append(core_js);
-            }
-            for dep_name in dep_names {
-                sources.append(dep_files[dep_name]);
-            }
-            (rewritten, stub_js, changed) = _stub_npm_imports(sources);
-            module_js = rewritten[0];
-            runtime_js = rewritten[1];
-            fixed_count = 2;
-            if core_js is not None {
-                core_js = rewritten[2];
-                fixed_count = 3;
-            }
-            for (i, dep_name) in enumerate(dep_names) {
-                dep_files[dep_name] = rewritten[fixed_count + i];
-            }
-            if changed {
-                (work_dir / _NPM_STUB_FILE).write_text(stub_js, encoding="utf-8");
-            }
-            (work_dir / "jac_runtime.js").write_text(runtime_js, encoding="utf-8");
-            if core_js is not None {
-                (work_dir / "client_runtime_core.js").write_text(
-                    core_js, encoding="utf-8"
-                );
-            }
+            staged["jac_runtime.js"] = runtime_js;
         }
+
         for (dep_name, dep_js) in dep_files.items() {
-            (work_dir / dep_name).write_text(dep_js, encoding="utf-8");
+            staged[dep_name] = dep_js;
+        }
+
+        (module_js, staged, stub_js, changed) = _stub_npm_imports(module_js, staged);
+        if changed {
+            staged[_NPM_STUB_FILE] = stub_js;
+        }
+
+        for (staged_name, staged_js) in staged.items() {
+            (work_dir / staged_name).write_text(staged_js, encoding="utf-8");
         }
 
         harness = _build_harness(

--- a/jac/tests/runtimelib/client/fixtures/cl_npm/test_npm_only.jac
+++ b/jac/tests/runtimelib/client/fixtures/cl_npm/test_npm_only.jac
@@ -1,0 +1,15 @@
+"""Client test whose only foreign dependency is an npm package.
+
+Nothing here talks to a backend, so the module never imports `@jac/runtime`.
+The runner still has to neutralize the `fake-npm-pkg` import, because the
+harness runs in a sealed temp dir with no `node_modules` for bun to resolve
+it against.
+"""
+
+import from "fake-npm-pkg" { helper }
+
+test "an npm import is neutralized without a backend" {
+    # `helper` resolves to the universal Proxy stub; calling it must not throw.
+    helper();
+    assert 1 + 1 == 2;
+}

--- a/jac/tests/runtimelib/client/fixtures/cl_npm_forms/jac.toml
+++ b/jac/tests/runtimelib/client/fixtures/cl_npm_forms/jac.toml
@@ -1,0 +1,7 @@
+[project]
+name = "cl-npm-forms-fixture"
+version = "0.0.0"
+description = "Fixture project for npm specs that appear outside `import ... from`"
+
+[test.npm-stubs]
+"fake-widgets" = "mocks/widgets.js"

--- a/jac/tests/runtimelib/client/fixtures/cl_npm_forms/mocks/widgets.js
+++ b/jac/tests/runtimelib/client/fixtures/cl_npm_forms/mocks/widgets.js
@@ -1,0 +1,10 @@
+// A mock written the way JavaScript is actually written: it pulls in a
+// stylesheet purely for side effect, and re-exports a helper from another
+// package. Neither line is an `import ... from`, so neither used to be
+// rewritten -- bun then failed to resolve both specs from this very file.
+
+import "fake-widgets/theme.css";
+
+export { helper } from "fake-helper";
+
+export const widget = { id: () => "w1" };

--- a/jac/tests/runtimelib/client/fixtures/cl_npm_forms/test_forms.jac
+++ b/jac/tests/runtimelib/client/fixtures/cl_npm_forms/test_forms.jac
@@ -1,0 +1,19 @@
+"""Client test whose mock uses npm specs outside `import ... from`.
+
+The mock imports a stylesheet for side effect and re-exports a name from a
+second, unmapped package. Both specs have to be rewritten for bun to resolve
+them out of the sealed work dir.
+"""
+
+import from "fake-widgets" { widget, helper }
+
+test "a mock survives a side-effect import and a re-export" {
+    assert widget.id() == "w1";
+}
+
+test "a name re-exported from an unmapped package lands on the proxy" {
+    # `helper` comes from the mock, which re-exports it from a package with no
+    # mapping of its own -- so it resolves to the Proxy and must not throw.
+    helper();
+    assert 1 + 1 == 2;
+}

--- a/jac/tests/runtimelib/client/fixtures/cl_npm_mock/jac.toml
+++ b/jac/tests/runtimelib/client/fixtures/cl_npm_mock/jac.toml
@@ -1,0 +1,16 @@
+[project]
+name = "cl-npm-mock-fixture"
+version = "0.0.0"
+description = "Fixture project exercising cl test runner npm stub overrides"
+
+# Modules substituted for npm packages when this project's client tests run.
+# Paths are relative to this file.
+[test.npm-stubs]
+"fake-editor" = "mocks/editor.js"
+"@fake/telemetry" = "mocks/telemetry.jac"
+
+# telemetry.jac holds no client-only syntax of its own, so inference would
+# place it in the server codespace. Pin it, the way any Jac module destined
+# for the browser is pinned.
+[placement.pins]
+"mocks.telemetry" = "client"

--- a/jac/tests/runtimelib/client/fixtures/cl_npm_mock/mocks/editor.js
+++ b/jac/tests/runtimelib/client/fixtures/cl_npm_mock/mocks/editor.js
@@ -1,0 +1,20 @@
+// Behaving mock for the `fake-editor` npm package.
+//
+// The universal Proxy stub makes imports inert; this returns real values and
+// records what it was called with, which is what a test suite actually needs
+// to assert against.
+
+const priorities = [];
+
+export const editor = {
+  showQuickPick: async (items) => items[items.length - 1],
+
+  createStatusBarItem: (align, priority) => {
+    priorities.push(priority);
+    return { text: "", show() {}, dispose() {} };
+  },
+};
+
+export function recordedPriorities() {
+  return priorities;
+}

--- a/jac/tests/runtimelib/client/fixtures/cl_npm_mock/mocks/telemetry.jac
+++ b/jac/tests/runtimelib/client/fixtures/cl_npm_mock/mocks/telemetry.jac
@@ -1,0 +1,16 @@
+"""Jac-authored mock for the `@fake/telemetry` npm package.
+
+Compiled through the ordinary client pipeline by the cl test runner, so it is
+a normal client module: `:pub` is what makes a name importable from the test.
+"""
+
+glob:pub EVENTS: list = [];
+
+def:pub track(name: str) -> str {
+    EVENTS.append(name);
+    return "tracked:" + name;
+}
+
+def:pub trackedCount -> int {
+    return len(EVENTS);
+}

--- a/jac/tests/runtimelib/client/fixtures/cl_npm_mock/test_mocked.jac
+++ b/jac/tests/runtimelib/client/fixtures/cl_npm_mock/test_mocked.jac
@@ -1,0 +1,32 @@
+"""Client tests whose npm dependencies are replaced by behaving mocks.
+
+`fake-editor` and `@fake/telemetry` are mapped to real modules by this
+project's `[test.npm-stubs]`; `unmapped-pkg` is not, so it keeps the universal
+Proxy stub.  Both paths have to work in the same file.
+"""
+
+import from "fake-editor" { editor, recordedPriorities }
+import from "@fake/telemetry" { track, trackedCount }
+import from "unmapped-pkg" { whatever }
+
+test "a mapped npm module returns real values" {
+    picked = await editor.showQuickPick(["3.11", "3.12"]);
+    assert picked == "3.12";
+}
+
+test "a mapped npm module records what it was called with" {
+    editor.createStatusBarItem("left", 100);
+    assert recordedPriorities()[0] == 100;
+}
+
+test "a jac-authored mock is compiled and staged like any client module" {
+    assert track("boot") == "tracked:boot";
+    assert trackedCount() == 1;
+}
+
+test "an unmapped npm module still falls back to the proxy stub" {
+    # The Proxy swallows everything without throwing; that stays the default.
+    whatever();
+    whatever.deeply.nested.thing();
+    assert 1 + 1 == 2;
+}

--- a/jac/tests/runtimelib/client/test_cl_test_runner_npm.jac
+++ b/jac/tests/runtimelib/client/test_cl_test_runner_npm.jac
@@ -1,0 +1,25 @@
+"""npm import handling in the cl test runner.
+
+Client tests run under bun in a sealed temp dir with no `node_modules`, so
+every non-relative import spec has to be rewritten to something bun can
+resolve.  These cover that rewriting for modules that are not `@jac/runtime`.
+"""
+
+import from pathlib { Path }
+import from jaclang.runtimelib.cl_test_runner { module_is_client, run_cl_test_file }
+
+glob FIXTURES = Path(__file__).parent / "fixtures" / "cl_npm";
+
+test "a client test importing only an npm module runs under bun" {
+    # Regression guard: npm stubbing used to sit inside the `@jac/runtime`
+    # branch of _run_harness, so a client test with no backend import kept its
+    # bare `fake-npm-pkg` spec and bun failed to resolve it.
+    fixture = str(FIXTURES / "test_npm_only.jac");
+    assert module_is_client(fixture) , f"{fixture} is not in the client codespace";
+
+    results = run_cl_test_file(fixture);
+    assert results , "cl test runner discovered no client tests";
+    for res in results {
+        assert res.ok , f"cl test {res.name} failed: {res.error}";
+    }
+}

--- a/jac/tests/runtimelib/client/test_cl_test_runner_npm.jac
+++ b/jac/tests/runtimelib/client/test_cl_test_runner_npm.jac
@@ -2,24 +2,103 @@
 
 Client tests run under bun in a sealed temp dir with no `node_modules`, so
 every non-relative import spec has to be rewritten to something bun can
-resolve.  These cover that rewriting for modules that are not `@jac/runtime`.
+resolve.  These cover that rewriting for modules that are not `@jac/runtime`:
+the universal Proxy fallback, and the per-module mock overrides declared in
+`[test.npm-stubs]` that take precedence over it.
 """
 
+import os;
 import from pathlib { Path }
-import from jaclang.runtimelib.cl_test_runner { module_is_client, run_cl_test_file }
+import from tempfile { TemporaryDirectory }
+import from jaclang.runtimelib.cl_test_runner {
+    module_is_client,
+    run_cl_test_file,
+    _mock_stub_name,
+    _resolve_npm_mocks
+}
 
-glob FIXTURES = Path(__file__).parent / "fixtures" / "cl_npm";
+glob FIXTURES = Path(__file__).parent / "fixtures";
 
 test "a client test importing only an npm module runs under bun" {
     # Regression guard: npm stubbing used to sit inside the `@jac/runtime`
     # branch of _run_harness, so a client test with no backend import kept its
     # bare `fake-npm-pkg` spec and bun failed to resolve it.
-    fixture = str(FIXTURES / "test_npm_only.jac");
+    fixture = str(FIXTURES / "cl_npm" / "test_npm_only.jac");
     assert module_is_client(fixture) , f"{fixture} is not in the client codespace";
 
     results = run_cl_test_file(fixture);
     assert results , "cl test runner discovered no client tests";
     for res in results {
         assert res.ok , f"cl test {res.name} failed: {res.error}";
+    }
+}
+
+test "mapped npm modules behave while unmapped ones keep the proxy" {
+    # The mocks return values, record calls, and are written in both JS and
+    # Jac; `unmapped-pkg` in the same file still falls through to the Proxy.
+    fixture = str(FIXTURES / "cl_npm_mock" / "test_mocked.jac");
+    results = run_cl_test_file(fixture);
+    assert len(results) == 4 , f"expected 4 client tests, got {len(results)}";
+    for res in results {
+        assert res.ok , f"cl test {res.name} failed: {res.error}";
+    }
+}
+
+test "npm stub overrides are read from the nearest jac.toml" {
+    mocks = _resolve_npm_mocks(str(FIXTURES / "cl_npm_mock" / "test_mocked.jac"));
+    assert sorted(mocks.keys()) == ["@fake/telemetry", "fake-editor"];
+    for (spec, path) in mocks.items() {
+        assert os.path.isabs(path) , f"{spec} resolved to a relative path: {path}";
+        assert os.path.isfile(path) , f"{spec} resolved to a missing file: {path}";
+    }
+}
+
+test "a project without npm stub overrides resolves to an empty map" {
+    assert _resolve_npm_mocks(str(FIXTURES / "cl_npm" / "test_npm_only.jac")) == {};
+    assert _resolve_npm_mocks(None) == {};
+}
+
+test "stub filenames are flat, prefixed, and collision-free per spec" {
+    # The work dir is flat, so a spec has to sanitize to a name that cannot
+    # collide with a staged dep or the runtime files written beside it.
+    assert _mock_stub_name("vscode").startswith("__jac_mock_vscode_");
+    assert _mock_stub_name("@scope/pkg").startswith("__jac_mock__scope_pkg_");
+    assert _mock_stub_name("vscode") == _mock_stub_name("vscode");
+
+    # Sanitizing alone would collapse these onto one filename, so the name
+    # carries a digest of the spec it came from.
+    assert _mock_stub_name("a/b/c") != _mock_stub_name("a_b_c");
+
+    seen = set();
+    for spec in ["vscode", "@scope/pkg", "lodash.merge", "a/b/c", "a_b_c"] {
+        name = _mock_stub_name(spec);
+        assert name.startswith("__jac_mock_") , f"{spec} -> {name}";
+        assert name.endswith(".js") , f"{spec} -> {name}";
+        assert name not in ("jac_runtime.js", "client_runtime_core.js");
+        assert name not in seen , f"{spec} collided on {name}";
+        seen.add(name);
+    }
+}
+
+test "a mock path that does not exist fails with a message naming the spec" {
+    with TemporaryDirectory() as td {
+        Path(td, "jac.toml").write_text(
+            '[project]\nname = "x"\n\n[test.npm-stubs]\n'
+            'vscode = "mocks/missing.js"\n',
+            encoding="utf-8"
+        );
+        entry = Path(td, "test_x.jac");
+        entry.write_text('import from "vscode" { window }\n', encoding="utf-8");
+        caught = "";
+        try {
+            _resolve_npm_mocks(str(entry));
+        } except Exception as exc {
+            caught = str(exc);
+        }
+        assert "vscode" in caught , f"error did not name the spec: {caught}";
+        assert "missing.js" in caught , f"error did not name the path: {caught}";
+        # The directory the path was resolved against is the actionable part:
+        # it says *where* the runner looked.
+        assert td in caught , f"error did not name the search dir: {caught}";
     }
 }

--- a/jac/tests/runtimelib/client/test_cl_test_runner_npm.jac
+++ b/jac/tests/runtimelib/client/test_cl_test_runner_npm.jac
@@ -14,7 +14,8 @@ import from jaclang.runtimelib.cl_test_runner {
     module_is_client,
     run_cl_test_file,
     _mock_stub_name,
-    _resolve_npm_mocks
+    _resolve_npm_mocks,
+    _stub_npm_imports
 }
 
 glob FIXTURES = Path(__file__).parent / "fixtures";
@@ -39,6 +40,35 @@ test "mapped npm modules behave while unmapped ones keep the proxy" {
     fixture = str(FIXTURES / "cl_npm_mock" / "test_mocked.jac");
     results = run_cl_test_file(fixture);
     assert len(results) == 4 , f"expected 4 client tests, got {len(results)}";
+    for res in results {
+        assert res.ok , f"cl test {res.name} failed: {res.error}";
+    }
+}
+
+test "every static import form is rewritten, not just `import ... from`" {
+    # A hand-written mock is ordinary JS, so npm specs turn up in forms the
+    # rewriter used to walk straight past, leaving them bare for bun to choke on.
+    src = 'import "pkg-css/theme.css";\n'
+        + 'export { helper } from "pkg-helper";\n'
+        + 'export * from "pkg-all";\n'
+        + 'import { widget } from "pkg-widget";\n'
+        + 'import "./local.js";\n';
+
+    (rewritten, _staged, stub, changed) = _stub_npm_imports(src, {}, {});
+    assert changed;
+    for spec in ["pkg-css/theme.css", "pkg-helper", "pkg-all", "pkg-widget"] {
+        assert f'"{spec}"' not in rewritten , f"{spec} left bare in:\n{rewritten}";
+    }
+    # Relative specs resolve on their own and stay untouched.
+    assert '"./local.js"' in rewritten;
+    # A re-exported name has to exist on the stub or bun cannot bind it.
+    assert "export const helper" in stub;
+}
+
+test "a mapped mock may itself re-export and side-effect import" {
+    fixture = str(FIXTURES / "cl_npm_forms" / "test_forms.jac");
+    results = run_cl_test_file(fixture);
+    assert len(results) == 2 , f"expected 2 client tests, got {len(results)}";
     for res in results {
         assert res.ok , f"cl test {res.name} failed: {res.error}";
     }


### PR DESCRIPTION
Closes #8033.

> **Stacked on #8040.** This branch is based on `fix/cl-test-npm-stub-gate`, so the first of the two commits here is #8040's and appears in this diff. Review #8040 first; once it merges this reduces to the single feature commit. The feature depends on it -- a `vscode`-only test never reached the rewriting stage before that fix.

## Problem

Client tests run under bun in a sealed temp dir with no `node_modules`, so `_stub_npm_imports` rewrites every npm import to one universal Proxy stub:

```js
const __jacNpmStub = new Proxy(function () {}, {
  get: () => __jacNpmStub, apply: () => __jacNpmStub,
});
```

That is the right default -- imports stop crashing. But the Proxy cannot return a value, record a call, or reject a promise, so a test that needs a module to *behave* has nothing to work with:

```jac
picked = await window.showQuickPick(["3.11", "3.12"]);
assert picked == "3.12";   # picked is the Proxy, never "3.12"
```

`_stub_npm_imports` consulted nothing outside its arguments -- no config, no filesystem -- so there was no way to supply an alternative. This is what blocks the VS Code extension's ~500-line EnvManager suite from moving to `jac test` (jaseci-labs/jac-vscode#103), and it is a standing gap for `js-package` authors generally.

## What this adds

A per-module override, resolved before the Proxy fallback:

```toml
[test.npm-stubs]
vscode = "tests/mocks/vscode.js"
"@scope/telemetry" = "tests/mocks/telemetry.jac"
```

Paths resolve against the `jac.toml` that declares them. A mapped spec rewrites to that module; anything unmapped keeps the Proxy, so this is additive and existing suites are untouched. The Proxy file is now written only when something actually falls through to it.

**Mocks can be Jac.** A `.jac` mock is compiled through the ordinary client pipeline and joins the same rewrite pass as any other staged module, so its own `@jac/runtime` and npm imports are handled too -- and if it imports `@jac/runtime`, that alone stages the runtime.

## Design notes

- **Flat work dir.** A spec sanitizes to `__jac_mock_<safe>_<digest>.js`, following the shape `project_db_name` already uses. The digest is what keeps `a/b/c` and `a_b_c` from collapsing onto one filename; the prefix keeps mocks clear of `jac_runtime.js` / `client_runtime_core.js`. Staging refuses a name a dep already claimed.
- **Placement reuse.** Jac mocks are pinned to the client codespace with the existing `[placement.pins]`, not a new mechanism. A mock holding no client-only syntax would otherwise be inferred as server code and compile to no JS -- the runner detects exactly that and says so.
- **Errors name the spec.** Missing file, wrong extension, and empty-client-compile each report which `[test.npm-stubs]` entry caused them and where the runner looked.

## Tests

`jac/tests/runtimelib/client/test_cl_test_runner_npm.jac`, against a fixture project under `fixtures/cl_npm_mock/`:

| Test | Covers |
|---|---|
| mapped modules behave, unmapped keep the proxy | end to end: a JS mock returning a real value, a JS mock recording call arguments, a Jac mock, and an unmapped module on the Proxy -- all in one client test file |
| overrides read from the nearest jac.toml | `[test.npm-stubs]` parsing and path resolution |
| project without overrides | empty map, and a `None` source path |
| stub filenames | prefix, extension, reserved-name avoidance, and the `a/b/c` vs `a_b_c` collision |
| missing mock path | error names the spec, the path, and the directory searched |

The end-to-end test is not vacuous: without the override the mock's return value never arrives and `picked == "3.12"` fails.

## Verification

```
tests/runtimelib/client/test_cl_test_runner_npm.jac    [ 13%]
jaclang/scale/tests/server/test_cl_test_runner.jac     [ 15%]
tests/cli/test_format_cache.jac                        [ 63%]
tests/cli/test_theme.jac                               [100%]
44 passed
```

The scale test is the existing full-stack `@jac/runtime` integration; the two CLI suites exercise `JacConfig` loading, which this PR extends. `jac check` on both touched impls reports the same counts as `main` (`cl_test_runner.impl.jac` 10/29, `config.impl.jac` 31/155) -- no new findings.

## Docs

`[test.npm-stubs]` in the config reference, and a "Mocking npm Modules in Client Tests" section in the testing reference.