### PR TITLE
test(native): pin the any-container narrow flavors the #8052 rework settled

### DIFF
--- a/jac/tests/compiler/passes/native/fixtures/container_any_narrow.jac
+++ b/jac/tests/compiler/passes/native/fixtures/container_any_narrow.jac
@@ -1,0 +1,74 @@
+"""Consume-side isinstance narrowing of an `any` container (jac#8052).
+
+A container that crossed the boxing boundary is canonically heterogeneous:
+an any-held list stores tagged jacval slots and an any-held dict stores
+string keys with jacval values, which is the layout any-subscript and
+any-iteration already assume. `isinstance(x, list)` narrows the checker
+type to the BARE `list`, and the bare container's default native lowering
+is the unboxed i64 flavor -- so the narrowed unbox used to produce a
+`List.i64`-typed pointer that then met a `list[any]` destination and died
+on the cross-flavor guard (E5092, or a mismatching-types store). The
+minimal shape is `peek` below: it crashes the emitter even when no caller
+ever passes a list. The rest value-checks the narrowed consume against
+the sv/bytecode run of this same fixture.
+"""
+
+def peek(val: any) -> int {
+    if isinstance(val, list) {
+        lst: list[any] = val;
+        return len(lst);
+    }
+    return -1;
+}
+
+def narrowed_list_miss -> int {
+    return peek(5);
+}
+
+def list_probe(val: any) -> int {
+    if isinstance(val, list) {
+        lst: list[any] = val;
+        n: int = len(lst);
+        first: int = lst[0];
+        total: int = 0;
+        for e in lst {
+            if isinstance(e, int) {
+                iv: int = e;
+                total += iv;
+            }
+        }
+        return n * 1000 + first * 10 + total;
+    }
+    return -1;
+}
+
+def narrowed_list_consume -> int {
+    arr: list[any] = [];
+    arr.append(7);
+    arr.append("two");
+    arr.append(4);
+    return list_probe(arr);
+}
+
+def dict_probe(val: any) -> int {
+    if isinstance(val, dict) {
+        d: dict[str, any] = val;
+        klen: int = 0;
+        for k in d {
+            klen += len(k);
+        }
+        return klen * 10 + len(d);
+    }
+    return -1;
+}
+
+def narrowed_dict_consume -> int {
+    m: dict[str, any] = {};
+    m["ab"] = 1;
+    m["c"] = "x";
+    return dict_probe(m);
+}
+
+def narrowed_dict_miss -> int {
+    return dict_probe("s");
+}

--- a/jac/tests/compiler/passes/native/test_native_container_elem_infer.jac
+++ b/jac/tests/compiler/passes/native/test_native_container_elem_infer.jac
@@ -240,3 +240,33 @@ test "un-inferable elem type: an unorderable mixed comparison is refused, not gu
         + f"a str, got {[str(e) for e in prog.errors_had]}"
     );
 }
+
+test "isinstance-narrowed any container unboxes at the boxed-boundary flavor" {
+    # jac#8052: `isinstance(x, list)` on an `any` narrows to the BARE `list`,
+    # whose default lowering is the unboxed i64 flavor; the narrowed unbox
+    # must instead take the canonical heterogeneous layout every any-consume
+    # site assumes, or the value dies at its `list[any]` destination.
+    eng = native_engine("container_any_narrow.jac");
+    sv = sv_funcs("container_any_narrow.jac");
+    for fn in [
+        "narrowed_list_miss",
+        "narrowed_list_consume",
+        "narrowed_dict_consume",
+        "narrowed_dict_miss"
+    ] {
+        na_v = native_call(eng, fn);
+        sv_v = int(sv[fn]());
+        assert na_v == sv_v , f"native {fn}() == {na_v} but sv gives {sv_v}";
+    }
+    # Pin the values too, so the two pathways cannot agree on a shared wrong
+    # answer: 3 elements, first == 7, int elements sum to 11; keys "ab"/"c"
+    # total 3 chars across 2 entries.
+    assert native_call(eng, "narrowed_list_consume") == 3081 , (
+        "narrowed list consume must read len, index, and elements congruently"
+    );
+    assert native_call(eng, "narrowed_dict_consume") == 32 , (
+        "narrowed dict consume must iterate keys and read len congruently"
+    );
+    assert native_call(eng, "narrowed_list_miss") == -1 , "non-list any misses";
+    assert native_call(eng, "narrowed_dict_miss") == -1 , "non-dict any misses";
+}


### PR DESCRIPTION
Post-merge residue of #8052's final CI green-up, rebased onto main as tests only.

## What happened

#8052's last regression (`TypeError: cannot store %"List.i64"* to %"List.jacval"**` at `builder.jac:540`, which produced the "No native engine produced" equivalence failures) was fixed twice in parallel: once on the branch head that merged (`e58d573eee`, the bare-list/Sequence flow-narrow unboxing at the boxed-element flavor) and once independently with a slightly wider surface (bare `dict` handling plus value-checked regression tests). The list fixes are duplicates and the merged one stands. The dict compiler hunk was **dropped after verification**: with it reverted on current main, every test here passes, so bare-dict narrows resolve correctly through their own consume path today and a speculative branch does not land.

What survives is the coverage, which main does not have:

- **The minimal emitter-crash reduction**, value-checked: `isinstance(val, list)` on an `any`, assigned to a `list[any]` local -- no list need ever be passed. Before `e58d573eee` this crashed codegen outright; nothing on main pins it.
- **The same narrowed-consume shapes for `dict`**, so the path that makes them work today cannot silently regress into the same failure signature.

## Verification

- Both tests pass on current main (`ae48aff660`).
- The list reduction reproduces the exact #8052-era crash when run against the pre-fix branch head (`bdec19b0b4`).
- `jac test jac/tests/compiler/passes/native/test_native_container_elem_infer.jac`: 8 passed.

Tests only; no compiler changes, no release fragment (the check maps fragments to `jac/jaclang/` changes).