### PR TITLE
perf(build): stop redoing unchanged dependency work across binary builds

### DIFF
--- a/.github/actions/setup-jac/action.yml
+++ b/.github/actions/setup-jac/action.yml
@@ -151,6 +151,26 @@ runs:
         restore-keys: |
           jac-precompiled-${{ runner.os }}-${{ runner.arch }}-
 
+    # The payload's compressed deps-layer frame (mkpayload --layer-cache): the
+    # level-19 zstd of the ~600 MB dependency layer, the pack's single most
+    # expensive stage after the JIR precompile. mkpayload content-addresses the
+    # frame and VERIFIES it by decompress + byte-compare before reuse, so like
+    # the precompile tree a stale restore can only miss, never mis-serve --
+    # restore-keys is safe. The key names every pinned input that feeds the
+    # layer (pbs/pip/bun pins and pack code in launcher/**, shim inputs in
+    # native/** + build.zig, the editor closure in editor/** + build.zig.zon,
+    # the wasm_rt floor); unpinned pip releases can still drift the content
+    # mid-key, which just recompresses until the key next rolls.
+    - name: Restore cached payload deps-layer frame
+      id: layers-cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: jac/.payload-layers
+        key: payload-layers-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/launcher/**', 'jac/build.zig', 'jac/build.zig.zon', 'jac/native/**', 'jac/editor/**', 'jac/jaclang/runtimelib/client/bun_installer.jac', 'jac/jaclang/compiler/passes/native/wasm_rt/**') }}
+        restore-keys: |
+          payload-layers-${{ runner.os }}-${{ runner.arch }}-
+
     # The Zig package store (.zig-cache/p): every git/tarball dependency
     # `zig build` fetches -- the pinned neovim fork and, transitively, its PUC
     # Lua source off lua.org's FTP (historically the flakiest fetch in the whole
@@ -332,6 +352,17 @@ runs:
       with:
         path: jac/.precompiled-build
         key: jac-precompiled-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
+
+    # Same prefix-hit re-save logic as the precompile cache above.
+    - name: Save payload deps-layer cache (main only)
+      if: >-
+        github.ref == 'refs/heads/main' &&
+        steps.cache.outputs.cache-hit != 'true' &&
+        steps.layers-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: jac/.payload-layers
+        key: payload-layers-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/launcher/**', 'jac/build.zig', 'jac/build.zig.zon', 'jac/native/**', 'jac/editor/**', 'jac/jaclang/runtimelib/client/bun_installer.jac', 'jac/jaclang/compiler/passes/native/wasm_rt/**') }}
 
     # Seed the Zig package store from main only (see the restore note). Like the
     # precompile cache, a restore-keys prefix hit still leaves cache-hit != true,

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -70,6 +70,15 @@ jobs:
           - os: macos-15-intel
             platform: macos-x86_64
             zig_target: x86_64-macos.12.0
+        # The Intel-Mac leg is release-only: it exists to pin the macOS 12.0
+        # floor for versioned releases, and on the dev channel it was the
+        # critical path (~24 min/merge on the slow Intel runners) for a
+        # rolling prerelease Intel users don't consume. Versioned releases
+        # still ship macos-x86_64. The expression matches nothing ('none')
+        # on the release channel and on release/dispatch events, where
+        # inputs.channel is empty.
+        exclude:
+          - platform: ${{ inputs.channel == 'dev' && 'macos-x86_64' || 'none' }}
     runs-on: ${{ matrix.os }}
     env:
       # -Dtarget flag for zig build: set on release-channel Linux legs, empty
@@ -121,6 +130,75 @@ jobs:
           restore-keys: |
             jac-precompiled-${{ runner.os }}-${{ runner.arch }}-
 
+      # pbs + bun: the two read-mostly runtime trees `zig build` otherwise
+      # re-downloads and re-extracts on every push to main (the ~600 MB
+      # python-build-standalone tree is the slow one; measured at several
+      # minutes per leg). Keys mirror setup-jac verbatim so the Linux-x86_64
+      # leg shares the entry main seeds; the other legs self-seed here (no
+      # other workflow runs on their runners). Dev channel only: the release
+      # channel builds cold on purpose.
+      - name: Restore cached python-build-standalone tree (dev channel)
+        if: inputs.channel == 'dev'
+        uses: actions/cache@v4
+        with:
+          path: jac/.pbs-build
+          key: pbs-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/launcher/payload.zig') }}
+
+      - name: Restore cached bun runtime (dev channel)
+        if: inputs.channel == 'dev'
+        uses: actions/cache@v4
+        with:
+          path: jac/.bun-build
+          key: bun-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/runtimelib/client/bun_installer.jac') }}
+
+      # The payload's compressed deps-layer frame (mkpayload --layer-cache):
+      # content-addressed and verified by decompress + byte-compare before
+      # reuse, so a stale restore can only miss, never mis-serve (same
+      # contract as the JIR tree above). Key mirrors setup-jac verbatim.
+      - name: Restore cached payload deps-layer frame (dev channel)
+        if: inputs.channel == 'dev'
+        uses: actions/cache@v4
+        with:
+          path: jac/.payload-layers
+          key: payload-layers-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/launcher/**', 'jac/build.zig', 'jac/build.zig.zon', 'jac/native/**', 'jac/editor/**', 'jac/jaclang/runtimelib/client/bun_installer.jac', 'jac/jaclang/compiler/passes/native/wasm_rt/**') }}
+          restore-keys: |
+            payload-layers-${{ runner.os }}-${{ runner.arch }}-
+
+      # Release channel: fetch the prebuilt, target-pinned shim that
+      # build-shims.yml publishes on the rolling `deps` prerelease instead of
+      # range-fetching the ~0.5 GB LLVM slice and re-linking the shim cold
+      # (the most expensive step of a release build). The asset name embeds
+      # the hash of the shim's complete input set, so a hit means "built from
+      # exactly these inputs"; the sha256 sidecar guards transport, and the
+      # floor-verification steps below re-check whatever shim gets bundled.
+      # A miss (e.g. right after a shim-input change, before build-shims has
+      # run on a matching tree) falls back to today's cold from-source build,
+      # which then self-seeds the asset.
+      - name: Fetch prebuilt shim from the deps release (release channel)
+        if: inputs.channel != 'dev'
+        id: shim-fetch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHIM_KEY: ${{ hashFiles('jac/native/**', 'jac/build.zig', 'jac/launcher/llvm_release.zig') }}
+        run: |
+          set -euo pipefail
+          EXT=so
+          [ "$RUNNER_OS" = "macOS" ] && EXT=dylib
+          ASSET="libjacllvm-${{ matrix.platform }}-${SHIM_KEY}.${EXT}"
+          mkdir -p .shim-fetch
+          if gh release download deps --repo "$GITHUB_REPOSITORY" \
+               --pattern "$ASSET" --pattern "$ASSET.sha256" \
+               --dir .shim-fetch --clobber 2>/dev/null \
+             && [ -f ".shim-fetch/$ASSET" ] && [ -f ".shim-fetch/$ASSET.sha256" ] \
+             && ( cd .shim-fetch && shasum -a 256 -c "$ASSET.sha256" ); then
+            echo "hit=true" >> "$GITHUB_OUTPUT"
+            echo "file=$GITHUB_WORKSPACE/.shim-fetch/$ASSET" >> "$GITHUB_OUTPUT"
+          else
+            echo "No usable prebuilt shim asset $ASSET; falling back to the cold from-source build."
+            echo "hit=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
+
       # The Zig package store (.zig-cache/p): the neovim fork + its transitive
       # PUC Lua source off lua.org's FTP (the build's flakiest fetch), mini.nvim,
       # tree-sitter-jac, etc. Content-addressed source packages -- immutable, so
@@ -159,12 +237,17 @@ jobs:
         run: echo "version=$(grep -m1 '^version' jac.toml | sed -E 's/.*"([^"]+)".*/\1/')" >> "$GITHUB_OUTPUT"
 
       # The native backend statically links a pinned LLVM; fetch it per target
-      # before `zig build`. Skipped on a dev-channel shim-cache hit (-Dshim-bin
-      # needs no LLVM at all) or LLVM-cache hit (tree already restored). Both
-      # gates are vacuous on the release channel: the restore steps are
-      # skipped there, so their cache-hit outputs are empty and the fetch runs.
+      # before `zig build`. Skipped when a prebuilt shim is in hand (-Dshim-bin
+      # needs no LLVM at all): the dev-channel shim cache, the release-channel
+      # deps-release fetch, or a dev-channel LLVM-cache hit (tree already
+      # restored). The cross-channel gates are vacuous: each channel's skipped
+      # restore/fetch steps leave their outputs empty, so only its own paths
+      # decide.
       - name: Fetch LLVM for the jacllvm shim
-        if: steps.shim-cache.outputs.cache-hit != 'true' && steps.llvm-cache.outputs.cache-hit != 'true'
+        if: >-
+          steps.shim-cache.outputs.cache-hit != 'true' &&
+          steps.llvm-cache.outputs.cache-hit != 'true' &&
+          steps.shim-fetch.outputs.hit != 'true'
         working-directory: jac
         run: zig build fetch-llvm $DTARGET --summary all
 
@@ -172,13 +255,16 @@ jobs:
         working-directory: jac
         # On a dev-channel shim-cache hit, stage the shim outside its in-tree
         # place path: the build copies -Dshim-bin back there, and a self-copy
-        # would read the file it is truncating. Mirrors setup-jac.
+        # would read the file it is truncating. Mirrors setup-jac. The
+        # release-channel deps-release fetch already lives outside the tree.
         run: |
           SHIM_ARG=()
           if [ "${{ steps.shim-cache.outputs.cache-hit }}" = "true" ]; then
             mkdir -p .shim-build
             cp jaclang/compiler/passes/native/llvm/libjacllvm.* .shim-build/
             SHIM_ARG=(-Dshim-bin=".shim-build/$(ls .shim-build | head -1)")
+          elif [ "${{ steps.shim-fetch.outputs.hit }}" = "true" ]; then
+            SHIM_ARG=(-Dshim-bin="${{ steps.shim-fetch.outputs.file }}")
           fi
           zig build $DTARGET "${SHIM_ARG[@]}" --summary all
 
@@ -296,6 +382,30 @@ jobs:
           if otool -L "$ART" | grep -E "/opt/homebrew|/usr/local"; then
             echo "::error::$ART links Homebrew dylibs."; exit 1
           fi
+
+      # A release-channel cold build just produced (and floor-verified) the
+      # shim the deps release was missing: publish it so the next release with
+      # the same inputs skips the LLVM fetch + link. Best-effort -- shipping
+      # the release binaries must not fail on a seeding hiccup. Runs after the
+      # floor checks on purpose: a floor regression fails the job before
+      # anything is published.
+      - name: Seed the deps release with the built shim (release channel)
+        if: inputs.channel != 'dev' && steps.shim-fetch.outputs.hit != 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ASSET="${{ steps.shim-fetch.outputs.asset }}"
+          mkdir -p dist-shim
+          cp jac/jaclang/compiler/passes/native/llvm/libjacllvm.* "dist-shim/$ASSET"
+          ( cd dist-shim && shasum -a 256 "$ASSET" > "$ASSET.sha256" )
+          gh release create deps --repo "$GITHUB_REPOSITORY" --prerelease \
+            --title "Prebuilt build dependencies (rolling)" \
+            --notes "Content-addressed prebuilt build artifacts (LLVMPY shims). Consumed by build-binaries.yml; not for direct download." \
+            2>/dev/null || true
+          gh release upload deps --repo "$GITHUB_REPOSITORY" \
+            "dist-shim/$ASSET" "dist-shim/$ASSET.sha256" --clobber
 
       - name: Package asset (+ checksum)
         id: pkg

--- a/.github/workflows/build-shims.yml
+++ b/.github/workflows/build-shims.yml
@@ -1,0 +1,178 @@
+name: Build LLVMPY shim assets
+
+# Prebuilds the target-pinned LLVMPY_* shim (jac/native statically linked
+# against the pinned LLVM slice) for every release platform and attaches it to
+# the rolling `deps` prerelease, named by the hash of its complete input set:
+#
+#   libjacllvm-<platform>-<hashFiles(jac/native/**, jac/build.zig,
+#                                    jac/launcher/llvm_release.zig)>.<so|dylib>
+#
+# build-binaries.yml's release channel fetches the matching asset instead of
+# range-fetching the ~0.5 GB LLVM slice and re-linking the shim cold on every
+# release (the single most expensive step of a release build). Content
+# addressing keeps the trust story intact: a key hit means "built from exactly
+# these inputs", assets are only ever written by main-push runs of this
+# workflow (or a release build self-seeding after its own cold build), each
+# asset ships a sha256 sidecar for transport integrity, and the release build
+# still floor-verifies whatever shim it ends up bundling.
+#
+# The dev channel is untouched: it builds host-native shims and reuses the
+# native-ABI Actions cache (`jac-shim-*`), which the release channel cannot
+# share because these assets are cross-targeted at the glibc 2.17 / macOS 12.0
+# floors.
+
+on:
+  push:
+    branches: [main]
+    # The shim's complete input set: a push touching none of these cannot
+    # change the asset key, so skip the run entirely.
+    paths:
+      - jac/native/**
+      - jac/build.zig
+      - jac/launcher/llvm_release.zig
+      - .github/workflows/build-shims.yml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirrors build-binaries.yml's release-channel matrix: same runners,
+        # same zig_target floors (macOS-ARM is host-native there too).
+        include:
+          - os: ubuntu-latest
+            platform: linux-x86_64
+            zig_target: x86_64-linux-gnu.2.17
+          - os: ubuntu-24.04-arm
+            platform: linux-aarch64
+            zig_target: aarch64-linux-gnu.2.17
+          - os: macos-14
+            platform: macos-aarch64
+          - os: macos-15-intel
+            platform: macos-x86_64
+            zig_target: x86_64-macos.12.0
+    runs-on: ${{ matrix.os }}
+    env:
+      DTARGET: ${{ matrix.zig_target && format('-Dtarget={0}', matrix.zig_target) || '' }}
+    steps:
+      # SHA-pinned: this job holds contents:write and publishes artifacts that
+      # release builds bundle into user-downloaded binaries.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # The asset key is the shim input hash; a re-run (or a dispatch on an
+      # unchanged tree) whose asset already exists has nothing to do.
+      - name: Compute asset name; skip if already published
+        id: asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHIM_KEY: ${{ hashFiles('jac/native/**', 'jac/build.zig', 'jac/launcher/llvm_release.zig') }}
+        run: |
+          set -euo pipefail
+          EXT=so
+          [ "$RUNNER_OS" = "macOS" ] && EXT=dylib
+          ASSET="libjacllvm-${{ matrix.platform }}-${SHIM_KEY}.${EXT}"
+          echo "name=$ASSET" >> "$GITHUB_OUTPUT"
+          if gh release view deps --repo "$GITHUB_REPOSITORY" --json assets \
+               --jq '.assets[].name' 2>/dev/null | grep -qx "$ASSET"; then
+            echo "Asset $ASSET already published; nothing to do."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Same key as setup-jac / build-binaries so all workflows share one LLVM
+      # tree per os/arch (the pinned slice is target-derived from (os, arch),
+      # so the host-keyed entry serves the cross-floor build too).
+      - name: Restore cached LLVM
+        if: steps.asset.outputs.exists != 'true'
+        id: llvm-cache
+        uses: actions/cache@v4
+        with:
+          path: jac/.llvm-build
+          key: llvm-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/launcher/llvm_release.zig') }}
+
+      # Same key as setup-jac / build-binaries: one shared entry per os/arch.
+      - name: Cache the Zig package store
+        if: steps.asset.outputs.exists != 'true'
+        uses: actions/cache@v4
+        with:
+          path: .zig-cache/p
+          key: zig-pkgs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/build.zig.zon') }}
+          restore-keys: |
+            zig-pkgs-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Set up Zig 0.16.0
+        if: steps.asset.outputs.exists != 'true'
+        # SHA-pinned: same shipping-artifacts rationale as the checkout.
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Fetch LLVM
+        if: steps.asset.outputs.exists != 'true' && steps.llvm-cache.outputs.cache-hit != 'true'
+        working-directory: jac
+        run: zig build -Dno-ninja fetch-llvm $DTARGET --summary all
+
+      - name: Build the shim
+        if: steps.asset.outputs.exists != 'true'
+        working-directory: jac
+        run: zig build -Dno-ninja jacllvm $DTARGET --summary all
+
+      # Hold the artifact to the same floors build-binaries enforces on release
+      # binaries, BEFORE it is published -- a floor regression must fail here,
+      # not at the next release. macOS-ARM is host-native (no pinned floor).
+      - name: Verify glibc floor
+        if: steps.asset.outputs.exists != 'true' && runner.os == 'Linux'
+        working-directory: jac
+        env:
+          ZIG_TARGET: ${{ matrix.zig_target }}
+        run: |
+          set -euxo pipefail
+          FLOOR="${ZIG_TARGET##*gnu.}"
+          SHIM="jaclang/compiler/passes/native/llvm/libjacllvm.so"
+          hi="$(objdump -T "$SHIM" 2>/dev/null | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/GLIBC_//' | sort -V | tail -1 || true)"
+          : "${hi:=0}"
+          echo "$SHIM -> max GLIBC_$hi (floor $FLOOR)"
+          if [ "$(printf '%s\n%s\n' "$FLOOR" "$hi" | sort -V | tail -1)" != "$FLOOR" ]; then
+            echo "::error::$SHIM requires GLIBC_$hi (> $FLOOR)"; exit 1
+          fi
+
+      - name: Verify macOS floor
+        if: steps.asset.outputs.exists != 'true' && runner.os == 'macOS' && matrix.zig_target
+        working-directory: jac
+        env:
+          ZIG_TARGET: ${{ matrix.zig_target }}
+        run: |
+          set -euxo pipefail
+          FLOOR="${ZIG_TARGET##*macos.}"
+          SHIM="jaclang/compiler/passes/native/llvm/libjacllvm.dylib"
+          minos="$(otool -l "$SHIM" | awk '/minos/ {print $2; exit}')"
+          echo "$SHIM -> minos $minos (floor $FLOOR)"
+          if [ "$(printf '%s\n%s\n' "$FLOOR" "$minos" | sort -V | tail -1)" != "$FLOOR" ]; then
+            echo "::error::$SHIM requires macOS $minos (> $FLOOR)"; exit 1
+          fi
+          if otool -L "$SHIM" | grep -E "/opt/homebrew|/usr/local"; then
+            echo "::error::$SHIM links Homebrew dylibs; the from-source slice must not."; exit 1
+          fi
+
+      - name: Publish to the deps prerelease
+        if: steps.asset.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ASSET="${{ steps.asset.outputs.name }}"
+          mkdir -p dist
+          cp jac/jaclang/compiler/passes/native/llvm/libjacllvm.* "dist/$ASSET"
+          ( cd dist && shasum -a 256 "$ASSET" > "$ASSET.sha256" )
+          gh release create deps --repo "$GITHUB_REPOSITORY" --prerelease \
+            --title "Prebuilt build dependencies (rolling)" \
+            --notes "Content-addressed prebuilt build artifacts (LLVMPY shims). Consumed by build-binaries.yml; not for direct download." \
+            2>/dev/null || true
+          gh release upload deps --repo "$GITHUB_REPOSITORY" \
+            "dist/$ASSET" "dist/$ASSET.sha256" --clobber

--- a/jac/.gitignore
+++ b/jac/.gitignore
@@ -88,6 +88,9 @@ jaclang/vendor/typeshed/stdlib
 # Persistent JIR precompile cache: mkpayload seeds site/_precompiled from it
 # and writes the refreshed tree back (see build.zig --precompiled-cache).
 .precompiled-build/
+# Persistent deps-layer frame cache: mkpayload reuses the payload's compressed
+# dependency layer across builds (see build.zig --layer-cache).
+.payload-layers/
 # Zig-built LLVMPY_* shim, placed in-tree per host platform (see build.zig).
 libjacllvm.so
 libjacllvm.dylib

--- a/jac/build.zig
+++ b/jac/build.zig
@@ -184,19 +184,21 @@ pub fn build(b: *std.Build) void {
     addTests(b, target, optimize);
 
     // The one Zig build tool (launcher/payload.zig) that replaces the old
-    // bash scripts; it uses std for http/tar/crypto and all DEcompression, plus
-    // vendored libzstd (below) for the one thing std cannot do: ENcode the zstd
-    // runtime payload. It shells out only to the fetched pbs python (pip + JIR
-    // precompile). Built for the host since it runs at build time. Created here
-    // (not inside the payload block) so the arch-independent `fetch-typeshed`
-    // step can reuse it.
+    // bash scripts; it uses std for http/tar/crypto and network DEcompression,
+    // plus vendored libzstd (below) for the one thing std cannot do: ENcode
+    // the zstd runtime payload -- and for the fast decode that verifies cached
+    // deps-layer frames on reuse (payload.zig frameDecodesTo), hence `.both`.
+    // It shells out only to the fetched pbs python (pip + JIR precompile).
+    // Built for the host since it runs at build time. Created here (not inside
+    // the payload block) so the arch-independent `fetch-typeshed` step can
+    // reuse it.
     const tool_mod = b.createModule(.{
         .root_source_file = b.path("launcher/payload.zig"),
         .target = b.graph.host,
         .optimize = .ReleaseSafe,
         .link_libc = true,
     });
-    linkLibzstd(b, tool_mod, .compress);
+    linkLibzstd(b, tool_mod, .both);
     const tool = b.addExecutable(.{ .name = "payload", .root_module = tool_mod });
     const root = b.pathFromRoot(".");
 
@@ -387,6 +389,18 @@ pub fn build(b: *std.Build) void {
         if (link_dir == null) {
             mk.addArg(b.fmt("--precompiled-cache={s}", .{b.pathFromRoot(".precompiled-build")}));
         }
+
+        // Persistent deps-layer frame cache (mirrors .precompiled-build): the
+        // payload's dependency layer (CPython tree, pip helpers, editor
+        // closure, native shims) is tarred deterministically, keyed on its
+        // exact bytes, and its level-19 zstd frame -- the pack's dominant cost
+        // -- is reused from this dir when the content is unchanged. Like the
+        // precompile cache it is deliberately NOT a tracked input: a cached
+        // frame is decompressed and byte-compared before reuse, so the dir can
+        // never change the payload -- only how fast it packs. Passed in every
+        // mode (dev/linked-source packs benefit the most: their payload is
+        // almost entirely deps layer).
+        mk.addArg(b.fmt("--layer-cache={s}", .{b.pathFromRoot(".payload-layers")}));
 
         // Fused ninja editor: stage the assembled nvim tree (runtime + config)
         // into the payload. A directory arg normally defeats caching (the path

--- a/jac/launcher/payload.zig
+++ b/jac/launcher/payload.zig
@@ -29,7 +29,10 @@
 //!
 //!   payload mkpayload <pbs-python-dir> <repo-root> <out.tar.zst>
 //!       Assemble the runtime payload: jaclang site + private CPython, tarred
-//!       and zstd-compressed (the format runtime.zig decompresses).
+//!       and zstd-compressed (the format runtime.zig decompresses) as two
+//!       concatenated frames -- a content-addressed deps frame reusable
+//!       across builds via --layer-cache, and a small per-commit jac frame
+//!       (see tarZstDir).
 //!
 //!   payload typeshed-sha <commit>
 //!       Print the decompressed-tar sha256 for a typeshed commit -- the value to
@@ -99,7 +102,7 @@ pub fn main(init: std.process.Init) !void {
     const io = init.io;
     const gpa = init.gpa;
 
-    var argv: [16][]const u8 = undefined;
+    var argv: [20][]const u8 = undefined;
     var n: usize = 0;
     var it = init.minimal.args.iterate();
     // Cap at argv.len: every subcommand here takes a fixed, small set of args, so
@@ -145,7 +148,7 @@ pub fn main(init: std.process.Init) !void {
             try fetchTypeshed(io, gpa, a, argv[2]);
         },
         .mkpayload => {
-            if (n < 5) die("usage: payload mkpayload <pbs-python-dir> <repo-root> <out.tar.zst> [--shim=PATH] [--skip-precompile] [--link-source=PATH] [--precompiled-cache=DIR] [--nvim=DIR] [--seal] [--debug-src]\n(--seal: freeze bootstrap + emit MANIFEST.json; the payload boots from JIR, sources ship for tracebacks)", .{});
+            if (n < 5) die("usage: payload mkpayload <pbs-python-dir> <repo-root> <out.tar.zst> [--shim=PATH] [--skip-precompile] [--link-source=PATH] [--precompiled-cache=DIR] [--layer-cache=DIR] [--nvim=DIR] [--seal] [--debug-src]\n(--seal: freeze bootstrap + emit MANIFEST.json; the payload boots from JIR, sources ship for tracebacks)", .{});
             // Trailing flags (after the positional pbs/root/out, see build.zig):
             var shim_so: ?[]const u8 = null;
             var pyembed_so: ?[]const u8 = null;
@@ -155,6 +158,7 @@ pub fn main(init: std.process.Init) !void {
             var musl_dir: ?[]const u8 = null;
             var wasm_libc_dir: ?[]const u8 = null;
             var precompiled_cache: ?[]const u8 = null;
+            var layer_cache: ?[]const u8 = null;
             var nvim_dir: ?[]const u8 = null;
             var ninja_link: ?[]const u8 = null;
             var seal = false;
@@ -178,6 +182,8 @@ pub fn main(init: std.process.Init) !void {
                     wasm_libc_dir = arg["--wasm-libc=".len..];
                 } else if (std.mem.startsWith(u8, arg, "--precompiled-cache=")) {
                     precompiled_cache = arg["--precompiled-cache=".len..];
+                } else if (std.mem.startsWith(u8, arg, "--layer-cache=")) {
+                    layer_cache = arg["--layer-cache=".len..];
                 } else if (std.mem.startsWith(u8, arg, "--nvim=")) {
                     nvim_dir = arg["--nvim=".len..];
                 } else if (std.mem.startsWith(u8, arg, "--ninja-link=")) {
@@ -188,7 +194,7 @@ pub fn main(init: std.process.Init) !void {
                     debug_src = true;
                 }
             }
-            try mkPayload(io, gpa, a, init.environ_map, argv[2], argv[3], argv[4], shim_so, pyembed_so, bun_bin, skip_precompile, link_source, musl_dir, wasm_libc_dir, precompiled_cache, nvim_dir, ninja_link, seal, debug_src);
+            try mkPayload(io, gpa, a, init.environ_map, argv[2], argv[3], argv[4], shim_so, pyembed_so, bun_bin, skip_precompile, link_source, musl_dir, wasm_libc_dir, precompiled_cache, layer_cache, nvim_dir, ninja_link, seal, debug_src);
         },
         .@"typeshed-sha" => {
             if (n < 3) die("usage: payload typeshed-sha <commit>", .{});
@@ -1064,6 +1070,14 @@ fn mkPayload(
     // stale or partial dir is harmless (it only misses reuse), which is why
     // CI can restore it with prefix-fallback keys unlike the binary cache.
     precompiled_cache: ?[]const u8,
+    // Persistent compressed-frame cache for the payload's deps layer (the
+    // CPython tree, pip helpers, editor closure, native shims -- everything
+    // except the jaclang tree). Level-19 zstd over ~600 MB is the pack's
+    // dominant cost and its input rarely changes; entries are content-
+    // addressed by the sha256 of the exact tar bytes and re-verified by
+    // decompress + compare on reuse, so like the precompile cache a stale or
+    // corrupt dir can never change the payload -- only how fast it packs.
+    layer_cache: ?[]const u8,
     // The assembled ninja editor tree (jac/build.zig composes it from the
     // neovim dependency's exported runtime + the jac/editor/ninja config
     // layer). Staged verbatim under stage/nvim/ -- the launcher's `jac ninja`
@@ -1264,8 +1278,7 @@ fn mkPayload(
         }
     }
 
-    log("==> packing tar | zstd -{d}", .{PAYLOAD_ZSTD_LEVEL});
-    try tarZstDir(io, gpa, a, stage, out);
+    try tarZstDir(io, gpa, a, stage, out, layer_cache);
     log("==> payload: {s}", .{out});
 }
 
@@ -1333,7 +1346,18 @@ fn precompile(io: Io, gpa: Allocator, a: Allocator, parent_env: *std.process.Env
     try env.put("PYTHONPATH", site);
     try env.put("PYTHONUTF8", "1");
     try env.put("PYTHONDONTWRITEBYTECODE", "1");
-    try env.put("HOME", site);
+    // Hermetic $HOME for the precompiler -- but NOT the site dir itself. The
+    // precompiler boots the full runtime, which drops per-run state under `~`
+    // (the embedded-postgres data dir with its WAL/postmaster.pid/server.log,
+    // the JIR bootstrap jbc cache); with HOME=site those droppings were staged
+    // into every shipped payload as dead weight, made the payload
+    // build-nondeterministic (defeating the deps-layer frame cache), and left
+    // a live postmaster writing under site/ while stageTree copied it. The
+    // precompiler's actual product lands in site/jaclang/_precompiled via
+    // explicit paths and does not depend on HOME.
+    const scratch_home = try std.fmt.allocPrint(a, "{s}.home", .{site});
+    try Dir.cwd().createDirPath(io, scratch_home);
+    try env.put("HOME", scratch_home);
     try env.put("PATH", "/usr/bin:/bin");
     // Pin the precompiler to the bundled (staged-site) jaclang, NOT a dev-source
     // tree. The build runs inside the repo whose jac.toml carries
@@ -1390,7 +1414,6 @@ fn precompile(io: Io, gpa: Allocator, a: Allocator, parent_env: *std.process.Env
         log("   sealed: MANIFEST.json present; payload boots from JIR (sources ship for tracebacks, never compiled).", .{});
     }
 }
-
 
 /// Stage the relocatable pbs `python3.x` launcher under `python/bin/`. Project
 /// venvs created by the fused `jac` binary use this as their base interpreter.
@@ -1505,11 +1528,19 @@ fn precompilePyc(io: Io, a: Allocator, py: []const u8, stage: []const u8) void {
     log("==> precompiling stdlib + site -> hash-based .pyc (survives materialize)", .{});
     const stdlib = std.fmt.allocPrint(a, "{s}/python/lib/python{s}", .{ stage, py_ver }) catch return;
     const site_dir = std.fmt.allocPrint(a, "{s}/site", .{stage}) catch return;
+    // -s/-p rewrite each code object's co_filename from the absolute staging
+    // dir (a per-build zig-cache path) to a stable /jac-rt/... form. The
+    // staging path never exists at runtime anyway (the payload extracts under
+    // <cache>/jac/rt), so this only trades one dead path in tracebacks for a
+    // stable, readable one -- and it is what makes the deps layer's bytes
+    // build-independent, i.e. what lets tarZstDir's content-addressed frame
+    // cache ever hit.
     _ = runChild(io, &.{
-        py,       "-m",              "compileall",
-        "--invalidation-mode", "unchecked-hash",
-        "-q",     "-f",              "-j",
-        "0",      stdlib,            site_dir,
+        py,                    "-m",             "compileall",
+        "--invalidation-mode", "unchecked-hash", "-q",
+        "-f",                  "-j",             "0",
+        "-s",                  stage,            "-p",
+        "/jac-rt",             stdlib,           site_dir,
     }, null, true);
 }
 
@@ -1831,9 +1862,18 @@ fn skipJaclang(p: []const u8) bool {
 }
 
 /// macOS hygiene: AppleDouble (._*) sidecars break jaclang's .impl scanner.
+/// Also drop top-level home-dir droppings (`.cache/`, `Library/`, `.local/`):
+/// nothing at runtime reads them from the payload, so anything a build step
+/// writes there (see precompile's scratch_home note) is dead weight that would
+/// also make the payload nondeterministic.
 fn skipStageSite(p: []const u8) bool {
     const base = std.fs.path.basename(p);
-    return std.mem.startsWith(u8, base, "._") or std.mem.eql(u8, base, ".DS_Store");
+    if (std.mem.startsWith(u8, base, "._") or std.mem.eql(u8, base, ".DS_Store")) return true;
+    for ([_][]const u8{ ".cache", "Library", ".local" }) |top| {
+        if (std.mem.eql(u8, p, top)) return true;
+        if (std.mem.startsWith(u8, p, top) and p.len > top.len and p[top.len] == '/') return true;
+    }
+    return false;
 }
 
 /// jac.toml `key = "value"` -> value (first match; good enough for the flat
@@ -1882,12 +1922,14 @@ fn runChild(io: Io, argv: []const []const u8, env: ?*const std.process.Environ.M
     return ok;
 }
 
-// ----------------------------------------------------- libzstd (encode only)
+// ---------------------------------------------------------------- libzstd
 // Upstream libzstd, pinned in build.zig.zon and compiled into this build-time
-// tool by build.zig's linkLibzstdCompress. ONLY the encoder is bound here:
-// everything this tool DECODES (pbs, typeshed, zips) stays std, and the
-// shipped launcher decodes the payload with pure `std.compress.zstd`. Zig std
-// has no zstd encoder -- that gap is this dependency's entire reason to exist.
+// tool by build.zig's linkLibzstd (`.both`). The encoder is the dependency's
+// reason to exist (Zig std has no zstd encoder); everything this tool DECODES
+// from the network (pbs, typeshed, zips) stays std. The one libzstd decode
+// here is frameDecodesTo's verification of cached deps-layer frames, where
+// std's pure-Zig decoder would burn seconds per pack on a ~600 MB tar.
+extern fn ZSTD_decompress(dst: [*]u8, dst_cap: usize, src: [*]const u8, src_len: usize) usize;
 extern fn ZSTD_createCCtx() ?*anyopaque;
 extern fn ZSTD_freeCCtx(cctx: ?*anyopaque) usize;
 extern fn ZSTD_CCtx_setParameter(cctx: ?*anyopaque, param: c_int, value: c_int) usize;
@@ -1947,37 +1989,172 @@ fn sourceFileMode(io: Io, dir: Dir, sub_path: []const u8) u32 {
     return 0;
 }
 
-/// tar `stage` (its top-level `python` + `site`) and zstd it to `out`. The
-/// runtime side (runtime.zig extractPayload) decompresses this exact format
-/// with pure std. The full tar is built in memory (~430 MB plus the compress
-/// bound) -- a build-machine-only cost that buys one-shot multithreaded
-/// ZSTD_compress2 instead of a hand-rolled streaming Io.Writer adapter.
-fn tarZstDir(io: Io, gpa: Allocator, a: Allocator, stage: []const u8, out: []const u8) !void {
-    var aw: Io.Writer.Allocating = .init(gpa);
-    defer aw.deinit();
-    var tw: std.tar.Writer = .{ .underlying_writer = &aw.writer };
+/// The payload's VOLATILE layer: the jaclang compiler/runtime tree and its
+/// site shims, which change on nearly every commit. Everything else is the
+/// DEPS layer: the CPython tree, pip helpers, the ninja editor closure, the C
+/// floors -- and the LLVMPY shim + contained bun, which live under jaclang/'s
+/// path but are dependency-pinned artifacts. Routing is a performance choice,
+/// not a correctness one: the deps frame is content-addressed by the sha256
+/// of its exact tar bytes and verified on reuse (see depsFrameCached), so a
+/// wrong-side entry costs compression time or cache hits, never payload
+/// correctness.
+fn isVolatilePath(p: []const u8) bool {
+    if (std.mem.startsWith(u8, p, "site/jaclang")) {
+        if (std.mem.indexOf(u8, p, "compiler/passes/native/llvm") != null) return false;
+        if (std.mem.indexOf(u8, p, "runtimelib/client/_bun") != null) return false;
+        return true;
+    }
+    return std.mem.startsWith(u8, p, "site/_jac_finder.py") or
+        std.mem.startsWith(u8, p, "site/sitecustomize.py") or
+        std.mem.startsWith(u8, p, "site/jac_linked_source") or
+        std.mem.startsWith(u8, p, "site/__pycache__");
+}
 
+/// tar `stage` (its top-level `python` + `site`) and zstd it to `out`, as TWO
+/// concatenated zstd frames: a big, rarely-changing deps frame and a small
+/// per-commit jac frame. The runtime side needs no format change: its
+/// PayloadDecoder already resets between frames (`frame_done`), std.tar reads
+/// the decoded stream as one continuous archive (std.tar.Writer emits no
+/// end-of-archive blocks, so frame boundaries are invisible to it), and the
+/// trailer sha256 still covers the whole concatenation. Splitting exists so
+/// the deps frame -- level-19 zstd over ~600 MB, the pack's dominant cost --
+/// can be reused from `layer_cache` when its content is unchanged, which is
+/// every build that doesn't bump a dependency pin.
+///
+/// Entries are SORTED before writing: the deps frame is keyed on its exact
+/// tar bytes, so fs-dependent walk order must not leak into the key. Each
+/// tar is built in memory (a build-machine-only cost that buys one-shot
+/// multithreaded ZSTD_compress2 instead of a hand-rolled streaming adapter);
+/// extraction is order-independent (std.tar.extract creates parent dirs for
+/// file entries).
+fn tarZstDir(io: Io, gpa: Allocator, a: Allocator, stage: []const u8, out: []const u8, layer_cache: ?[]const u8) !void {
     var stage_dir = try Dir.cwd().openDir(io, stage, .{ .iterate = true });
     defer stage_dir.close(io);
-    var walker = try stage_dir.walk(gpa);
-    defer walker.deinit();
-    while (try walker.next(io)) |entry| {
-        switch (entry.kind) {
-            .directory => try tw.writeDir(entry.path, .{}),
-            else => {
-                const bytes = try stage_dir.readFileAlloc(io, entry.path, a, .unlimited);
-                defer a.free(bytes);
-                // Carry the real on-disk mode so executable scripts keep their
-                // exec bit; `mode = 0` would strip IXUSR (see runtime.zig
-                // extractPayload's matching .executable_bit_only).
-                try tw.writeFileBytes(entry.path, bytes, .{ .mode = sourceFileMode(io, stage_dir, entry.path) });
-            },
+
+    const Entry = struct { path: []const u8, dir: bool };
+    var entries = std.array_list.Managed(Entry).init(gpa);
+    defer {
+        for (entries.items) |e| gpa.free(e.path);
+        entries.deinit();
+    }
+    {
+        var walker = try stage_dir.walk(gpa);
+        defer walker.deinit();
+        while (try walker.next(io)) |entry| {
+            const path = try gpa.dupe(u8, entry.path);
+            errdefer gpa.free(path);
+            try entries.append(.{ .path = path, .dir = entry.kind == .directory });
+        }
+    }
+    std.mem.sort(Entry, entries.items, {}, struct {
+        fn lt(_: void, x: Entry, y: Entry) bool {
+            return std.mem.lessThan(u8, x.path, y.path);
+        }
+    }.lt);
+
+    var deps_aw: Io.Writer.Allocating = .init(gpa);
+    defer deps_aw.deinit();
+    var jac_aw: Io.Writer.Allocating = .init(gpa);
+    defer jac_aw.deinit();
+    var deps_tw: std.tar.Writer = .{ .underlying_writer = &deps_aw.writer };
+    var jac_tw: std.tar.Writer = .{ .underlying_writer = &jac_aw.writer };
+
+    for (entries.items) |e| {
+        const tw = if (isVolatilePath(e.path)) &jac_tw else &deps_tw;
+        if (e.dir) {
+            try tw.writeDir(e.path, .{});
+        } else {
+            const bytes = try stage_dir.readFileAlloc(io, e.path, a, .unlimited);
+            defer a.free(bytes);
+            // Carry the real on-disk mode so executable scripts keep their
+            // exec bit; `mode = 0` would strip IXUSR (see runtime.zig
+            // extractPayload's matching .executable_bit_only).
+            try tw.writeFileBytes(e.path, bytes, .{ .mode = sourceFileMode(io, stage_dir, e.path) });
         }
     }
 
-    const frame = try zstdCompressAlloc(gpa, aw.written());
-    defer gpa.free(frame);
-    try Dir.cwd().writeFile(io, .{ .sub_path = out, .data = frame });
+    const deps_frame = try depsFrameCached(io, gpa, a, layer_cache, deps_aw.written());
+    defer gpa.free(deps_frame);
+
+    log("==> packing jac layer | zstd -{d}", .{PAYLOAD_ZSTD_LEVEL});
+    const jac_frame = try zstdCompressAlloc(gpa, jac_aw.written());
+    defer gpa.free(jac_frame);
+
+    var f = try Dir.cwd().createFile(io, out, .{ .truncate = true });
+    defer f.close(io);
+    try f.writeStreamingAll(io, deps_frame);
+    try f.writeStreamingAll(io, jac_frame);
+}
+
+/// The compressed deps frame for `tar_bytes`, reusing a verified cache entry
+/// when one exists. Entries are content-addressed
+/// (`deps-<sha256 of the tar bytes>.tar.zst`) and re-verified by decompress +
+/// byte-compare on EVERY reuse, so a truncated, stale, or tampered cache file
+/// can never reach a shipped payload -- it just falls back to a fresh
+/// compress (which also rewrites the entry). No cache dir = always compress;
+/// that is the release channel's cold-by-policy path on fresh runners.
+fn depsFrameCached(io: Io, gpa: Allocator, a: Allocator, layer_cache: ?[]const u8, tar_bytes: []const u8) ![]u8 {
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(tar_bytes, &digest, .{});
+    const key_buf = runtime.hexDigest(&digest);
+    const key: []const u8 = &key_buf;
+
+    const cache_path: ?[]const u8 = if (layer_cache) |lc|
+        try std.fmt.allocPrint(a, "{s}/deps-{s}.tar.zst", .{ lc, key })
+    else
+        null;
+
+    if (cache_path) |cp| {
+        if (Dir.cwd().readFileAlloc(io, cp, gpa, .unlimited)) |frame| {
+            if (frameDecodesTo(gpa, frame, tar_bytes)) {
+                log("==> deps layer: reusing cached frame (key {s})", .{key[0..16]});
+                return frame;
+            }
+            gpa.free(frame);
+            log("==> deps layer: cached frame failed verification; recompressing", .{});
+        } else |_| {
+            log("==> deps layer: no cached frame (key {s}); compressing", .{key[0..16]});
+        }
+    }
+
+    log("==> packing deps layer | zstd -{d}", .{PAYLOAD_ZSTD_LEVEL});
+    const frame = try zstdCompressAlloc(gpa, tar_bytes);
+    if (cache_path) |cp| {
+        // Single-entry cache, like .precompiled-build: drop other keys before
+        // writing so the dir never accumulates ~150 MB frames from old pins.
+        // Best-effort throughout -- a cache write failure only costs speed.
+        pruneLayerCache(io, a, layer_cache.?, std.fs.path.basename(cp));
+        Dir.cwd().createDirPath(io, layer_cache.?) catch {};
+        Dir.cwd().writeFile(io, .{ .sub_path = cp, .data = frame }) catch |err|
+            log("==> deps layer: cache write failed ({s}); continuing", .{@errorName(err)});
+    }
+    return frame;
+}
+
+/// True when `frame` zstd-decompresses to exactly `expect`. Decode-side
+/// libzstd is linked into this tool for this one check (build.zig linkLibzstd
+/// `.both`): it is what makes deps-frame cache reuse as trustworthy as a
+/// fresh compress.
+fn frameDecodesTo(gpa: Allocator, frame: []const u8, expect: []const u8) bool {
+    const dst = gpa.alloc(u8, expect.len) catch return false;
+    defer gpa.free(dst);
+    const n = ZSTD_decompress(dst.ptr, dst.len, frame.ptr, frame.len);
+    if (ZSTD_isError(n) != 0) return false;
+    return n == expect.len and std.mem.eql(u8, dst[0..n], expect);
+}
+
+/// Delete every `deps-*.tar.zst` in `dir_path` except `keep`. Best-effort.
+fn pruneLayerCache(io: Io, a: Allocator, dir_path: []const u8, keep: []const u8) void {
+    var dir = Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
+    var it = dir.iterate();
+    while (it.next(io) catch null) |e| {
+        if (e.kind != .file) continue;
+        if (!std.mem.startsWith(u8, e.name, "deps-") or !std.mem.endsWith(u8, e.name, ".tar.zst")) continue;
+        if (std.mem.eql(u8, e.name, keep)) continue;
+        const stale = std.fmt.allocPrint(a, "{s}/{s}", .{ dir_path, e.name }) catch continue;
+        Dir.cwd().deleteFile(io, stale) catch {};
+    }
 }
 
 // ----------------------------------------------------------------- tests
@@ -2075,7 +2252,7 @@ test "tarZstDir round-trips through the launcher's payload decoder" {
     });
 
     const out = try std.fmt.allocPrint(a, "{s}/payload.tar.zst", .{base});
-    try tarZstDir(io, gpa, a, stage, out);
+    try tarZstDir(io, gpa, a, stage, out, null);
 
     const frame = try Dir.cwd().readFileAlloc(io, out, gpa, .unlimited);
     defer gpa.free(frame);
@@ -2112,5 +2289,156 @@ test "tarZstDir round-trips through the launcher's payload decoder" {
         defer pf.close(io);
         const pst = try pf.stat(io);
         try testing.expect(pst.permissions.toMode() & 0o100 == 0);
+    }
+}
+
+/// Test helper: extract a packed (multi-frame) payload file through the
+/// launcher's real decode path and return the opened dest dir.
+fn extractForTest(io: Io, gpa: Allocator, packed_path: []const u8, dest: []const u8) !Dir {
+    const frame = try Dir.cwd().readFileAlloc(io, packed_path, gpa, .unlimited);
+    defer gpa.free(frame);
+    const dctx = runtime.ZSTD_createDCtx() orelse return error.OutOfMemory;
+    defer _ = runtime.ZSTD_freeDCtx(dctx);
+    const dbuf = try gpa.alloc(u8, 1 << 20);
+    defer gpa.free(dbuf);
+    var dec = runtime.PayloadDecoder.init(dctx, frame, dbuf);
+    try Dir.cwd().createDirPath(io, dest);
+    var dest_dir = try Dir.cwd().openDir(io, dest, .{});
+    errdefer dest_dir.close(io);
+    try std.tar.extract(io, dest_dir, &dec.reader, .{ .mode_mode = runtime.payload_extract_mode_mode, .strip_components = 0 });
+    return dest_dir;
+}
+
+/// Test helper: the single `deps-*.tar.zst` in the layer cache dir (fails the
+/// test if there is not exactly one -- pruning must keep the cache single-entry).
+fn soleCacheEntry(io: Io, a: Allocator, cache: []const u8) ![]const u8 {
+    var dir = try Dir.cwd().openDir(io, cache, .{ .iterate = true });
+    defer dir.close(io);
+    var found: ?[]const u8 = null;
+    var it = dir.iterate();
+    while (try it.next(io)) |e| {
+        if (e.kind != .file) continue;
+        try testing.expect(found == null);
+        found = try std.fmt.allocPrint(a, "{s}/{s}", .{ cache, e.name });
+    }
+    return found orelse error.TestUnexpectedResult;
+}
+
+// The layered-pack contract, end to end through the launcher's real decoder:
+//  1. the deps frame is the output's byte prefix and survives a jaclang-only
+//     edit unchanged (the steady-state reuse this exists for);
+//  2. a VALID cached frame is reused verbatim (proved with an alternative
+//     frame -- different bytes, same decoded tar -- planted in the cache);
+//  3. a CORRUPT cached frame is rejected and recompressed (a poisoned cache
+//     can never reach a payload);
+//  4. a deps-side edit rolls the key and prunes the old entry.
+test "layered payload: frame reuse is verified, corruption falls back" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [MAX_PATH]u8 = undefined;
+    const base = base_buf[0..try tmp.dir.realPath(io, &base_buf)];
+
+    const stage = try std.fmt.allocPrint(a, "{s}/stage", .{base});
+    const cache = try std.fmt.allocPrint(a, "{s}/layers", .{base});
+    const wf = struct {
+        fn wf(io_: Io, a_: Allocator, stage_: []const u8, rel: []const u8, data: []const u8) !void {
+            const p = try std.fmt.allocPrint(a_, "{s}/{s}", .{ stage_, rel });
+            try Dir.cwd().createDirPath(io_, std.fs.path.dirname(p).?);
+            try Dir.cwd().writeFile(io_, .{ .sub_path = p, .data = data });
+        }
+    }.wf;
+    // Deps side: python tree, a pip helper, and the two dependency-pinned
+    // artifacts that live under jaclang/'s path on purpose.
+    try wf(io, a, stage, "python/lib/marker.txt", "pybytecode-marker\n");
+    try wf(io, a, stage, "site/pytest/helper.py", "helper = 1\n");
+    try wf(io, a, stage, "site/jaclang/compiler/passes/native/llvm/libjacllvm.so", "fake-shim-bytes");
+    try wf(io, a, stage, "site/jaclang/runtimelib/client/_bun/bun", "fake-bun-bytes");
+    // Volatile side: the compiler tree + site shims.
+    try wf(io, a, stage, "site/jaclang/mod.py", "version = 1\n");
+    try wf(io, a, stage, "site/_jac_finder.py", "finder\n");
+
+    const out1 = try std.fmt.allocPrint(a, "{s}/p1.tar.zst", .{base});
+    try tarZstDir(io, gpa, a, stage, out1, cache);
+    const entry1 = try soleCacheEntry(io, a, cache);
+    const frame1 = try Dir.cwd().readFileAlloc(io, entry1, a, .unlimited);
+    const p1 = try Dir.cwd().readFileAlloc(io, out1, a, .unlimited);
+    // The cached deps frame is the packed payload's byte prefix.
+    try testing.expect(p1.len > frame1.len);
+    try testing.expectEqualSlices(u8, frame1, p1[0..frame1.len]);
+    {
+        var d1 = try extractForTest(io, gpa, out1, try std.fmt.allocPrint(a, "{s}/x1", .{base}));
+        defer d1.close(io);
+        try testing.expectEqualStrings("pybytecode-marker\n", try d1.readFileAlloc(io, "python/lib/marker.txt", a, .unlimited));
+        try testing.expectEqualStrings("fake-shim-bytes", try d1.readFileAlloc(io, "site/jaclang/compiler/passes/native/llvm/libjacllvm.so", a, .unlimited));
+        try testing.expectEqualStrings("version = 1\n", try d1.readFileAlloc(io, "site/jaclang/mod.py", a, .unlimited));
+        try testing.expectEqualStrings("finder\n", try d1.readFileAlloc(io, "site/_jac_finder.py", a, .unlimited));
+    }
+
+    // (1) jaclang-only edit: deps frame identical, jac layer picks up the change.
+    try wf(io, a, stage, "site/jaclang/mod.py", "version = 2\n");
+    const out2 = try std.fmt.allocPrint(a, "{s}/p2.tar.zst", .{base});
+    try tarZstDir(io, gpa, a, stage, out2, cache);
+    const p2 = try Dir.cwd().readFileAlloc(io, out2, a, .unlimited);
+    try testing.expectEqualSlices(u8, frame1, p2[0..frame1.len]);
+    {
+        var d2 = try extractForTest(io, gpa, out2, try std.fmt.allocPrint(a, "{s}/x2", .{base}));
+        defer d2.close(io);
+        try testing.expectEqualStrings("version = 2\n", try d2.readFileAlloc(io, "site/jaclang/mod.py", a, .unlimited));
+    }
+
+    // (2) Reuse is verbatim, not a deterministic recompress: plant an
+    // alternative frame (level-1: different bytes, same decoded tar) and
+    // expect it embedded as-is.
+    const deps_tar = try a.alloc(u8, 1 << 20);
+    const deps_tar_len = ZSTD_decompress(deps_tar.ptr, deps_tar.len, frame1.ptr, frame1.len);
+    try testing.expect(ZSTD_isError(deps_tar_len) == 0);
+    const alt = alt: {
+        const cctx = ZSTD_createCCtx() orelse return error.OutOfMemory;
+        defer _ = ZSTD_freeCCtx(cctx);
+        setCParam(cctx, ZSTD_c_compressionLevel, 1);
+        setCParam(cctx, ZSTD_c_windowLog, runtime.PAYLOAD_WINDOW_LOG);
+        const dst = try a.alloc(u8, ZSTD_compressBound(deps_tar_len));
+        const m = ZSTD_compress2(cctx, dst.ptr, dst.len, deps_tar.ptr, deps_tar_len);
+        try testing.expect(ZSTD_isError(m) == 0);
+        break :alt dst[0..m];
+    };
+    try testing.expect(!std.mem.eql(u8, alt, frame1));
+    try Dir.cwd().writeFile(io, .{ .sub_path = entry1, .data = alt });
+    const out3 = try std.fmt.allocPrint(a, "{s}/p3.tar.zst", .{base});
+    try tarZstDir(io, gpa, a, stage, out3, cache);
+    const p3 = try Dir.cwd().readFileAlloc(io, out3, a, .unlimited);
+    try testing.expectEqualSlices(u8, alt, p3[0..alt.len]);
+    {
+        var d3 = try extractForTest(io, gpa, out3, try std.fmt.allocPrint(a, "{s}/x3", .{base}));
+        defer d3.close(io);
+        try testing.expectEqualStrings("pybytecode-marker\n", try d3.readFileAlloc(io, "python/lib/marker.txt", a, .unlimited));
+    }
+
+    // (3) Corrupt cache entry: verification must reject it and recompress to
+    // a correct payload (byte-identical to the honest level-19 pack).
+    const bad = try a.dupe(u8, alt);
+    bad[bad.len / 2] ^= 0xff;
+    try Dir.cwd().writeFile(io, .{ .sub_path = entry1, .data = bad });
+    const out4 = try std.fmt.allocPrint(a, "{s}/p4.tar.zst", .{base});
+    try tarZstDir(io, gpa, a, stage, out4, cache);
+    const p4 = try Dir.cwd().readFileAlloc(io, out4, a, .unlimited);
+    try testing.expectEqualSlices(u8, p2, p4);
+
+    // (4) Deps-side edit: new key, and the old entry is pruned away.
+    try wf(io, a, stage, "site/pytest/helper.py", "helper = 2\n");
+    const out5 = try std.fmt.allocPrint(a, "{s}/p5.tar.zst", .{base});
+    try tarZstDir(io, gpa, a, stage, out5, cache);
+    const entry2 = try soleCacheEntry(io, a, cache);
+    try testing.expect(!std.mem.eql(u8, entry1, entry2));
+    {
+        var d5 = try extractForTest(io, gpa, out5, try std.fmt.allocPrint(a, "{s}/x5", .{base}));
+        defer d5.close(io);
+        try testing.expectEqualStrings("helper = 2\n", try d5.readFileAlloc(io, "site/pytest/helper.py", a, .unlimited));
     }
 }


### PR DESCRIPTION
## Problem

Steady-state CI spends most of its binary-build minutes redoing work whose inputs did not change. Measured on recent runs:

- Every merge to main rebuilds the dev-channel binaries on 4 runners (~58 runner-min/merge). The build steps run 8.4-13.4 min per leg while a fully warm PR `build-jac` proves ~3 min is achievable: the dev channel restores the shim/JIR/zig-pkg caches but re-downloads and re-extracts the ~600 MB python-build-standalone tree and bun on every leg, every merge.
- The macos-x86_64 (Intel) dev leg is the critical path (~24 min/merge on the slow Intel runners) for a rolling prerelease Intel users do not consume.
- Every release build cold-fetches the ~0.5 GB LLVM slice and re-links the LLVMPY shim per target (the single most expensive build step) even when `native/**`, `build.zig`, and the LLVM pin are unchanged since the last release.
- Every build (PR, dev, release) re-compresses the entire ~600 MB payload at zstd level 19, even though the dependency layer inside it (CPython tree, pip helpers, editor closure, native shims) changes only on pin bumps.

At ~82 merges/week this is roughly 60-90 runner-hours/week, most of it latency on the paths contributors and dev-binary users actually wait on.

## Changes

**1. Dev channel: restore the pbs + bun caches** (`build-binaries.yml`)

Two `actions/cache` steps with keys identical to `setup-jac`, so the Linux-x86_64 leg reuses the entries main already seeds and the other legs self-seed. Dev channel only; the release channel stays cold on purpose.

**2. Dev channel: drop the Intel-Mac leg** (`build-binaries.yml`)

The leg exists to pin the macOS 12.0 floor, which is a release-channel concern; versioned releases still ship `macos-x86_64`. Implemented as a matrix `exclude` derived from `inputs.channel`, so `release:` events and dispatch runs (empty channel) keep all four legs.

**3. Release channel: prebuilt, content-addressed shims** (`build-shims.yml`, `build-binaries.yml`)

A new workflow builds the target-pinned (glibc 2.17 / macOS 12.0 floor) LLVMPY shims whenever their input set changes (`jac/native/**`, `jac/build.zig`, `jac/launcher/llvm_release.zig`), floor-verifies them, and attaches them to a rolling `deps` prerelease named `libjacllvm-<platform>-<hashFiles(inputs)>.<so|dylib>` with a sha256 sidecar.

The release channel fetches the matching asset instead of cold-fetching LLVM and re-linking; a miss falls back to today's cold build and then self-seeds the asset (after the existing floor-verification steps, so a floor regression can never publish). Trust model: a key hit means "built from exactly these inputs", assets are only written by main-push or release runs holding `contents: write`, and the release build still floor-verifies whatever shim it bundles. The dev channel is untouched (its host-native shim cache cannot serve the cross-targeted release build anyway).

**4. Layered payload: stop recompressing the dependency layer** (`payload.zig`, `build.zig`, `setup-jac`, `build-binaries.yml`)

`mkpayload` now writes the payload as two concatenated zstd frames: a deps frame (CPython tree, pip helpers, ninja editor closure, C floors, and the LLVMPY shim + contained bun, which live under `jaclang/`'s path but are dependency-pinned) and a small per-commit jac frame (the jaclang tree + site shims).

The runtime needs no change: `PayloadDecoder` already resets between frames, `std.tar` reads the decoded stream as one continuous archive (`std.tar.Writer` emits no end-of-archive blocks, so frame boundaries are invisible), and the trailer sha256 still covers the whole concatenation. Binary format, extraction, and the `-Dpayload` override are unchanged.

The deps frame is content-addressed: entries are tar'd in sorted order (walk order cannot leak into the key), the frame is keyed on the sha256 of its exact tar bytes and cached in `.payload-layers/` (`--layer-cache`, mirroring `--precompiled-cache`).

Making the layer byte-stable surfaced two latent payload bugs, both fixed here:

- `compileall` baked the absolute staging dir (a per-build zig-cache path) into every stdlib/site `.pyc` as `co_filename`. That path never exists at runtime, so the precompile now normalizes it to a stable `/jac-rt/...` prefix (`compileall -s/-p`), which is also more readable in tracebacks.
- The precompiler ran with `HOME` set to the site dir itself, so everything its runtime boot wrote under `~` was staged into every shipped payload: an embedded-postgres data directory (WAL, `postmaster.pid`, `server.log`) and the JIR bootstrap jbc cache, all dead weight nothing reads at runtime, different on every build, and, with a postmaster still live under `site/` while `stageTree` copied it, a source of intermittent build failures. The precompiler now gets a scratch `HOME` outside the site tree, and `stageTree` additionally refuses top-level `.cache/`, `Library/`, and `.local/` droppings so a future regression cannot silently ship them again. On reuse the cached frame is decompressed and byte-compared against the freshly built tar, so a stale, truncated, or tampered cache entry can never reach a shipped payload; it just falls back to a fresh compress. The payload tool links libzstd's decode side (`linkLibzstd .both`) for that check.

CI caches `.payload-layers` in `setup-jac` (main-gated save, like the other read-mostly caches) and in the dev channel. Release builds run on fresh runners with no cache dir, so they stay cold by construction.

Since level-19 zstd over the ~600 MB deps layer is the pack's dominant cost after the JIR precompile, every warm build (PR `build-jac`, all dev legs, local `zig build`) now compresses only the small jac layer.

## Tests and local validation

- `zig build test`: 26/26 pass, including a new end-to-end test through the launcher's real decoder covering: the deps frame is the output's byte prefix and survives a jaclang-only edit unchanged; a valid cached frame is reused verbatim (proved by planting an alternative frame that decodes identically); a corrupt cached frame is rejected and recompressed to a byte-identical payload; a deps-side edit rolls the key and prunes the old entry.
- Full local build + smoke test of the resulting binary with a clean env (`--version`, `jac run` prints `ok`), exercising the two-frame payload through the real extract path.
- Back-to-back full builds with a jaclang edit in between: the second build completed in 112 s and reused the cached deps frame untouched (its mtime predates the rebuilt binary; a miss would have rewritten it).
- Measured on macos-aarch64: the shipped binary dropped from 206 MB to 96 MB once the postgres/jbc droppings stopped shipping, and the payload's deps frame is 71 MB of the total.

## Expected impact

- Dev-channel legs: build steps drop from 8.4-13.4 min toward the ~3 min warm baseline, minus the payload compression as well; the Intel leg (~24 min critical path) disappears from the per-merge path.
- PR `build-jac`: ~3 min toward ~1.5-2 min (JIR precompile + staging remain).
- Releases: skip the ~0.5 GB LLVM fetch + shim link per leg when shim inputs are unchanged since the last release.
- Local `zig build` after the first: payload pack cost drops to the jac layer only.
- Shipped binaries get smaller: the postgres data dir + jbc cache dead weight no longer rides in every payload.
