### PR TITLE
fix(ci): path-gate test-client like every other test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,7 +689,8 @@ jobs:
       run: jac test jac/tests/runtimelib/client/test_desktop_binding.jac
 
   test-client:
-    needs: build-jac
+    needs: [changes, build-jac]
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     # Sealed lane: this suite spawns `jac` subprocesses with isolated env/HOME
     # (serve/client/cli tests). Under the dev lane each such spawn would


### PR DESCRIPTION
## Problem

`test-client` runs on every PR, including docs-only and CI-plumbing changes that cannot affect client behavior (spotted on #8129, where every other test suite correctly skipped but test-client still ran).

It has been the only ungated test job since the workflow consolidation (#7125): that commit gave every sibling suite (`test-compiler`, `test-runtime`, `test-solid-and-desktop`, `test-packages-and-docs`, `test-native-macos`, `test-scale`, `test-pypi-build`) a `changes`-based path filter, but `test-client` shipped with a bare `needs: build-jac` and no `if`, and no later commit revisited it. Cost: several minutes of a blacksmith runner per unrelated PR, for a suite that proves nothing there.

## Fix

Give it the same `core` gate as `test-compiler` / `test-runtime`:

```yaml
test-client:
    needs: [changes, build-jac]
    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
```

`core` is the right filter: the client code lives under `jac/**`, and the filter also covers `ci.yml` itself, so this PR's own run exercises the gate (test-client should RUN here, since ci.yml matches `core`).

`test-client` is not a required branch-protection check (only `jac-check` and `contribution-checks` are; per the build-jac comment, required checks deliberately do not sit behind `needs`), so gating it cannot green-skip branch protection. Push-to-main runs are unaffected: the condition only filters `pull_request` events.