### PR TITLE
fix(compiler): report loop-body captures and make typed loop-body declarations per-iteration

### DIFF
--- a/jac/tests/compiler/passes/ecmascript/fixtures/for_slot_capture.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/for_slot_capture.jac
@@ -1,0 +1,52 @@
+"""Fixture: per-item handlers built inside a `for` slot (#8168).
+
+Three sections build one handler per item, each closing over a local first
+assigned in the body that produces the item:
+
+- `for_slot` assigns bare.  Jac scoping is python-like, so the name binds one
+  function-level symbol and every handler observes the last iteration's value.
+  This section is the footgun the W6009 diagnostic reports; its emitted shape
+  is pinned so the intended scoping stays visible.
+- `annotated` declares the same value with an explicit type.  A typed
+  declaration in a loop body declares a per-iteration local, so each handler
+  keeps its own item.  This is the in-source escape hatch #8083 documented.
+- `map_lambda` is the control: #8130 made lambda bodies variable-owning, so
+  its locals were already per-invocation.
+"""
+
+def:pub Handlers(items: any, sink: any) -> JsxElement {
+    def fire(text: str) {
+        sink(text);
+    }
+
+    return
+        <div>
+            <div id="for_slot">
+                {for s in items {
+                    slotId = str(s.id);
+                    <button onClick={lambda { fire("for_slot:" + slotId); }}>
+                        {slotId}
+                    </button>;
+                }}
+            </div>
+            <div id="map_lambda">
+                {items.map(
+                    lambda (m: any) -> any {
+                        mapId = str(m.id);
+                        return
+                            <button onClick={lambda { fire("map_lambda:" + mapId); }}>
+                                {mapId}
+                            </button>;
+                    }
+                )}
+            </div>
+            <div id="annotated">
+                {for a in items {
+                    annId: str = str(a.id);
+                    <button onClick={lambda { fire("annotated:" + annId); }}>
+                        {annId}
+                    </button>;
+                }}
+            </div>
+        </div>;
+}

--- a/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
@@ -600,6 +600,75 @@ test "lambda assignment to an enclosing local stays a closure rebind" {
     assert_balanced_syntax(js_code, temp_path);
 }
 
+test "annotated loop-body local declares per-iteration inside the loop" {
+    fixture_file_path = os.path.join(FIXTURES, "for_slot_capture.jac");
+    js_code = compile_fixture_to_js(fixture_file_path);
+
+    assert "annId = String(a.id);" in js_code;
+    assert "let annId;" not in js_code , (
+        "a typed declaration in a loop body declares a per-iteration local, so "
+        "no empty hoisted declaration of it may exist at component scope; "
+        "hoisting makes every handler built in the loop share one binding "
+        "and observe the last item (#8168)"
+    );
+    assert "let annId = String(a.id);" in js_code , (
+        "the typed declaration must carry its `let` at the assignment site "
+        "inside the loop body"
+    );
+    assert_balanced_syntax(js_code, fixture_file_path);
+}
+
+test "bare loop-body local keeps its single function-level binding" {
+    fixture_file_path = os.path.join(FIXTURES, "for_slot_capture.jac");
+    js_code = compile_fixture_to_js(fixture_file_path);
+
+    assert "let slotId;" in js_code , (
+        "Jac scoping is python-like: a bare assignment anywhere in a function "
+        "binds one function-level symbol, so the loop-body local must keep "
+        "hoisting. The footgun this creates for escaping closures is reported "
+        "by W6009, not fixed by changing the scoping (#8168)"
+    );
+    assert "let slotId = " not in js_code;
+}
+
+test "for-slot handlers act on the item their own iteration built" {
+    import shutil;
+    if not shutil.which("node") {
+        import pytest;
+        pytest.skip("node not on PATH");
+    }
+    fixture_file_path = os.path.join(FIXTURES, "for_slot_capture.jac");
+    js_code = compile_fixture_to_js(fixture_file_path);
+
+    harness = "\nconst __out = [];\nconst __tree = Handlers({items: [{id: \"first\"}, {id: \"second\"}, {id: \"last\"}], sink: (t) => __out.push(t)});\nconst __found = [];\n(function walk(n, section) {\n  if (n == null || typeof n !== \"object\") return;\n  if (Array.isArray(n)) { for (const c of n) walk(c, section); return; }\n  const id = n.props && n.props.id;\n  if (id) section = id;\n  if (n.props && typeof n.props.onClick === \"function\") __found.push([section, n.props.onClick]);\n  walk(n.kids, section);\n})(__tree, \"?\");\nconst __by = {};\nfor (const [s, fn] of __found) {\n  __out.length = 0;\n  fn();\n  (__by[s] = __by[s] || []).push(String(__out[0]).split(\":\")[1]);\n}\nconsole.log(JSON.stringify(__by));\n";
+    wrapper = "function __jacJsx(tag, props, kids) { return {tag, props, kids: kids === undefined ? [] : kids}; }\n"
+        + js_code
+        + harness;
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", wrapper],
+        capture_output=True,
+        text=True,
+        timeout=30
+    );
+    assert result.returncode == 0 , (
+        f"for-slot fixture crashed in Node:\nstderr={result.stderr!r}"
+    );
+    got = json.loads(result.stdout.strip());
+
+    assert got["annotated"] == ["first", "second", "last"] , (
+        "each handler built from a typed loop-body local must fire with its "
+        f"own item; got {got['annotated']}"
+    );
+    assert got["map_lambda"] == ["first", "second", "last"] , (
+        f"the #8130 lambda control must stay per-invocation; got {got['map_lambda']}"
+    );
+    assert got["for_slot"] == ["last", "last", "last"] , (
+        "the bare form shares one function-level binding by design (python-like "
+        "scoping), so every handler observes the last iteration; W6009 reports "
+        f"it rather than the scoping changing under the author. Got {got['for_slot']}"
+    );
+}
+
 test "lambda returning dict literal parenthesises the arrow body" {
     jac_code = "def:pub app -> str {\n    style_of = lambda (kind: str) { {\"color\": \"red\" if kind == \"warn\" else \"blue\"}; };\n    return style_of(\"warn\")[\"color\"];\n}\n";
     temp_path = write_temp_jac(jac_code);

--- a/jac/tests/compiler/passes/main/fixtures/loop_capture/loop_capture_client.jac
+++ b/jac/tests/compiler/passes/main/fixtures/loop_capture/loop_capture_client.jac
@@ -1,0 +1,64 @@
+"""Fixture: closures built inside a loop body over a loop-body local (#8168).
+
+Jac scoping is python-like, so a bare assignment in a loop body binds one
+symbol in the enclosing function: every closure built in that body reads
+whatever the final iteration wrote, silently. Only the `bare` sections have
+that shape; every other section already has a per-iteration binding and must
+stay silent, or the diagnostic would fire on the fixes it recommends.
+"""
+
+def:pub Handlers(items: any, sink: any) -> JsxElement {
+    def fire(text: str) {
+        sink(text);
+    }
+
+    def handler_for(item_id: str) -> any {
+        return lambda { fire(item_id); };
+    }
+
+    can with entry {
+        ticks: any = [];
+
+        # Reported: the `for`-to counter is hoisted out of the loop head, so
+        # every closure appended here reads the counter's final value.
+        for i = 0 while i < 3 with i += 1 {
+            ticks.append(lambda { fire(str(i)); });
+        }
+    }
+
+    return
+        <div>
+            <div id="bare">
+                {for s in items {
+                    bareId = str(s.id);
+                    <button onClick={lambda { fire(bareId); }}>{bareId}</button>;
+                }}
+            </div>
+            <div id="annotated">
+                {for a in items {
+                    annId: str = str(a.id);
+                    <button onClick={lambda { fire(annId); }}>{annId}</button>;
+                }}
+            </div>
+            <div id="target">
+                {for t in items {
+                    <button onClick={lambda { fire(str(t.id)); }}>{str(t.id)}</button>;
+                }}
+            </div>
+            <div id="factory">
+                {for f in items {
+                    facId = str(f.id);
+                    <button onClick={handler_for(facId)}>{facId}</button>;
+                }}
+            </div>
+            <div id="mapped">
+                {items.map(
+                    lambda (m: any) -> any {
+                        mapId = str(m.id);
+                        return
+                            <button onClick={lambda { fire(mapId); }}>{mapId}</button>;
+                    }
+                )}
+            </div>
+        </div>;
+}

--- a/jac/tests/compiler/passes/main/fixtures/loop_capture/loop_capture_server.jac
+++ b/jac/tests/compiler/passes/main/fixtures/loop_capture/loop_capture_server.jac
@@ -1,0 +1,19 @@
+"""Fixture: the same capture shape in server code (#8168).
+
+Python's late-binding closure is documented behaviour there and the emitted
+code matches it, so W6009 -- a client-codespace diagnostic about a divergence
+the author cannot see -- must not fire on this module.
+"""
+
+def collect(items: list[str]) -> list {
+    out: list = [];
+    for s in items {
+        label = s.upper();
+        out.append(lambda { print(label); });
+    }
+    return out;
+}
+
+with entry {
+    print(len(collect(["a", "b"])));
+}

--- a/jac/tests/compiler/passes/main/test_loop_capture_check.jac
+++ b/jac/tests/compiler/passes/main/test_loop_capture_check.jac
@@ -1,0 +1,99 @@
+"""W6009: closures built in a loop body over a loop-body local (#8168).
+
+A per-item handler created inside a `for` slot closes over a local first
+assigned in the loop body. Jac scoping is python-like, so that local binds one
+symbol in the enclosing component and every handler observes the last
+iteration's value -- silently, since labels and other eagerly read positions
+are evaluated during the loop and stay correct.
+
+The scoping is intended, so the fix is a diagnostic. These tests pin that it
+fires exactly on the shapes that share a binding, stays silent on every shape
+that already has a per-iteration one (including the annotation the help text
+recommends), and reaches `jac check`, which compiles with codegen disabled.
+"""
+
+import os;
+import from tests.support { JAC_ROOT }
+import jaclang;
+import from jaclang.jac0core.compile_options { CompileOptions }
+import from jaclang.jac0core.program { JacProgram }
+
+glob FIXTURES = os.path.join(
+         JAC_ROOT, "tests", "compiler", "passes", "main", "fixtures", "loop_capture"
+     );
+
+"""Compile a fixture the way `jac check` does: type check, no codegen."""
+def check_fixture(name: str) -> JacProgram {
+    prog = JacProgram();
+    prog.compile(
+        os.path.join(FIXTURES, name),
+        options=CompileOptions(no_cgen=True, type_check=True)
+    );
+    return prog;
+}
+
+def warnings_with_code(prog: JacProgram, code: str) -> list {
+    return [
+        w
+        for w in prog.warnings_had
+        if w.code is not None and w.code.code == code
+    ];
+}
+
+test "loop-body local captured by an escaping closure warns W6009" {
+    prog = check_fixture("loop_capture_client.jac");
+    msgs = [str(w) for w in warnings_with_code(prog, "W6009")];
+
+    assert any("bareId" in m for m in msgs) , (
+        "a handler built in a `for` slot over a bare loop-body local shares "
+        f"one component binding and must be reported; got: {msgs}"
+    );
+}
+
+test "hoisted for-to counter captured in the loop body warns W6009" {
+    prog = check_fixture("loop_capture_client.jac");
+    msgs = [str(w) for w in warnings_with_code(prog, "W6009")];
+
+    assert any("'i'" in m for m in msgs) , (
+        "the `for x = a to ... by ...` counter is declared once outside the "
+        f"loop, so closures built in the body all read its last value; got: {msgs}"
+    );
+}
+
+test "W6009 stays silent on every per-iteration binding" {
+    prog = check_fixture("loop_capture_client.jac");
+    msgs = [str(w) for w in warnings_with_code(prog, "W6009")];
+
+    for (name, why) in [
+        ("annId", "a typed declaration in a loop body is a per-iteration local"),
+        ("t", "an `in`-loop target binds fresh on every iteration"),
+        ("facId", "a value bound through a function parameter is per call"),
+        ("mapId", "a lambda-body local is per-invocation since #8130"),
+
+    ] {
+        assert not any((("'" + name + "'") in m) for m in msgs) , (
+            f"W6009 must not fire on '{name}': {why}. Got: {msgs}"
+        );
+    }
+}
+
+test "W6009 reports each shared binding once" {
+    prog = check_fixture("loop_capture_client.jac");
+    warns = warnings_with_code(prog, "W6009");
+
+    assert len(warns) == 2 , (
+        "one report per name that shares a binding, not one per capturing "
+        f"closure or per reference; got: {[str(w) for w in warns]}"
+    );
+}
+
+test "W6009 does not fire on server code" {
+    prog = check_fixture("loop_capture_server.jac");
+    warns = warnings_with_code(prog, "W6009");
+
+    assert warns == [] , (
+        "Python's late-binding closure is documented behaviour and the "
+        "emitted code matches it, so server code must stay silent; got: "
+        f"{[str(w) for w in warns]}"
+    );
+}


### PR DESCRIPTION
Fixes #8168.

**Work in progress** — failing tests are in; the fix follows.

A per-item handler created inside a `for` slot closes over a local first
assigned in the loop body. Since #7925 that local is declared once in the
enclosing component and the loop body only assigns to it, so every handler
shares one binding and reads whatever the final iteration wrote. Nothing is
reported at build time or by `jac check`.

Two halves, per the issue:

1. **Diagnostic (`W6009`).** Function-level ownership of a bare loop-body
   local is the documented intent, so the fix is a report, not a semantics
   change. It fires from the type-check schedule, so `jac check` shows it —
   the ES pass, where the hoist is known, does not run under `check`
   (`no_cgen=True`), which is why that channel has always been silent.

2. **Typed declarations in a loop body are per-iteration again.** #8052 moved
   every block-level typed declaration to the enclosing function so a
   reassignment is checked against the declared annotation (#BLOCKANN-1),
   which took the `for`-slot escape hatch #8083 documented with it. The
   restore is scoped to loop bodies, where a declaration is entered once per
   iteration; `if`/`try` blocks keep #8052's semantics.