### PR TITLE
refactor(native): persist the Archetype/Ability/Enum body union natively and delete its materialize fixup (#8141)

### DIFF
--- a/jac/jaclang/jac0core/jir_registry.jac
+++ b/jac/jaclang/jac0core/jir_registry.jac
@@ -203,7 +203,7 @@ glob NODE_SPECS: tuple = (
              is_scope=False,
              is_cfg=False,
              is_name_atom=False,
-             fields=(FieldDesc(name="body", kind=6), )
+             fields=(FieldDesc(name="body", kind=5), )
          ),
          NodeSpec(
              type_idx=13,

--- a/jac/jaclang/jac0core/parser/materialize.jac
+++ b/jac/jaclang/jac0core/parser/materialize.jac
@@ -8,7 +8,6 @@ import jaclang.jac0core.srcloc as _mat_srcloc;
 import jaclang.jac0core.unitree as uni;
 
 glob MATERIALIZE_FIXUPS: tuple = (
-         ("body-union-reconstruction", 8141),
          ("symbol-stub-replay", 8142),
          ("name-spec-rebinding", 8143),
 
@@ -24,11 +23,6 @@ glob MATERIALIZE_FIXUPS: tuple = (
      };
 
 def materialize_fixups(module: any) {
-    body_elem: dict[str, tuple] = {
-        "Archetype": (uni.ArchBlockStmt, uni.CodeBlockStmt, ),
-        "Ability": (uni.CodeBlockStmt, ),
-        "Enum": (uni.EnumBlockStmt, uni.CtIf, uni.CtFor, )
-    };
     stack: list = [module];
     visited: set = set();
     nodes: list = [];
@@ -46,33 +40,6 @@ def materialize_fixups(module: any) {
         }
     }
     for nd in nodes {
-        elem = body_elem.get(type(nd).__name__);
-        if elem is not None and nd.__dict__.get("body") is None {
-            lb = -1;
-            for (ki, k) in enumerate(nd.kid) {
-                if getattr(k, "name", "") == "LBRACE" {
-                    lb = ki;
-                    break;
-                }
-            }
-            if lb >= 0 {
-                nd.body = [
-                    k
-                    for k in nd.kid[lb + 1:]
-                    if isinstance(k, elem)
-                ];
-            } elif type(nd).__name__ == "Ability" {
-                for k in nd.kid {
-                    if isinstance(k, uni.Expr)
-                        and (k?.kid or [])
-                        and getattr(k.kid[0], "name", "") == "KW_BY" {
-                        nd.body = k;
-                        break;
-                    }
-                }
-            }
-        }
-
         if isinstance(nd, uni.Name) {
             if nd.__dict__.get("name_spec") is not nd {
                 nd.name_spec = nd;

--- a/jac/jaclang/jac0core/unitree.jac
+++ b/jac/jaclang/jac0core/unitree.jac
@@ -294,8 +294,8 @@ obj CodeBlockStmt(UniCFGNode) {
     def postinit -> None;
 }
 
-obj AstImplNeedingNode[T](AstSymbolNode) {
-    has body: (T | None);
+obj AstImplNeedingNode(AstSymbolNode) {
+    has body: (Sequence[UniNode] | UniNode | None);
     has needs_impl: bool { getter; }
 }
 

--- a/jac/jaclang/utils/gen_native_materialize.jac
+++ b/jac/jaclang/utils/gen_native_materialize.jac
@@ -17,8 +17,7 @@ obj MaterializeProfile {
         parse_entry: str,
         parse_entry_module: str,
         diag_class: str,
-        comment_class: str,
-        dead_fields: set;
+        comment_class: str;
 }
 
 glob _UNITREE_MASK_CORPUS_LINES: tuple = (
@@ -80,8 +79,7 @@ def unitree_profile -> MaterializeProfile {
         parse_entry="parse_program",
         parse_entry_module="jaclang.jac0core.parser.parser",
         diag_class="SrcDiag",
-        comment_class="CommentData",
-        dead_fields=set()
+        comment_class="CommentData"
     );
 }
 
@@ -696,9 +694,7 @@ def generate(
             ki = g.kidx(dict_key);
             uid = f"{ci}_{fi}";
             lines.append(f"    # {dict_key}: {ann}");
-            if (sn, lf, ) in prof.dead_fields
-                or (sn not in g.envelope and g.foreign.get((sn, lf, )))
-                or ann is None {
+            if (sn not in g.envelope and g.foreign.get((sn, lf, ))) or ann is None {
                 vname = f"v_{uid}";
                 lines.append(f"    {vname} = _py_none();");
             } elif sn == "SubTag" and lf == "tag" {

--- a/jac/jaclang/utils/gen_native_materialize.jac
+++ b/jac/jaclang/utils/gen_native_materialize.jac
@@ -52,6 +52,12 @@ glob _UNITREE_MASK_CORPUS_LINES: tuple = (
          "    return <div id='a'>{t}</div>;",
          "}",
          "async def later -> None {}",
+         "comptime if 1 > 0 { glob CT_ON: int = 1; }",
+         "enum Tone: int {",
+         "    comptime for N in ('LOW', 'HIGH') {",
+         "        ${ct.name(N)} = ${len(N)},",
+         "    }",
+         "}",
          "test box_holds { assert Box(x=1).m() >= -1; }",
          "with entry { b = Box(x=5); print(f'v={b.m(2)}', {'s': [1, 2.5, True, None]}); }",
 
@@ -75,7 +81,7 @@ def unitree_profile -> MaterializeProfile {
         parse_entry_module="jaclang.jac0core.parser.parser",
         diag_class="SrcDiag",
         comment_class="CommentData",
-        dead_fields={("Archetype", "body", ), ("Ability", "body", ), ("Enum", "body", )}
+        dead_fields=set()
     );
 }
 

--- a/jac/tests/compiler/passes/native/test_sealed_native_parser.jac
+++ b/jac/tests/compiler/passes/native/test_sealed_native_parser.jac
@@ -619,7 +619,7 @@ test "the fixup enumeration is pinned: entries only ever retire" {
     # the native representation erases. Each entry carries its tracking
     # issue; the count NEVER rises -- growing it means teaching the crossing
     # new Python-side knowledge, which is the residue this plan deletes.
-    assert len(MATERIALIZE_FIXUPS) == 3 , (
+    assert len(MATERIALIZE_FIXUPS) == 2 , (
         f"fixup enumeration changed: {MATERIALIZE_FIXUPS}"
     );
     for (fixup_name, issue) in MATERIALIZE_FIXUPS {

--- a/jac/tests/compiler/passes/native/test_sealed_native_parser.jac
+++ b/jac/tests/compiler/passes/native/test_sealed_native_parser.jac
@@ -201,6 +201,124 @@ test "union-erased slots materialize their runtime arm (ImplDef.spec)" {
     assert type(n_impls[0].spec).__name__ == "FuncSignature";
 }
 
+glob _BODY_CARRIERS: tuple = ("Archetype", "Ability", "Enum", ),
+     _BODY_UNION_LINES: tuple = (
+         "obj Box {",
+         "    has x: int = 0;",
+         "    static has count: int = 0;",
+         "    has p: int { getter; }",
+         "    has q: int { getter { return 1; } }",
+         "    def m(p: int) -> int;",
+         "    def n(p: int) -> int { return p + self.x; }",
+         "    obj Inner { has y: int = 1; }",
+         "    comptime if 1 > 0 {",
+         "        has z: int = 2;",
+         "    }",
+         "    comptime for K in ['a'] {",
+         "        def m_${K} -> int { return 3; }",
+         "    }",
+         "    impl m(p: int) -> int { return p; }",
+         "}",
+         "obj Decl;",
+         "def free_fn(a: int) -> int { return a; }",
+         "def by_fn(a: str) -> str by llm();",
+         "def decl_fn(a: int) -> int;",
+         "def abs_fn(a: int) -> int abst;",
+         "node Spot { has label: str = ''; }",
+         "walker Tour {",
+         "    can step with Spot entry;",
+         "    can go with Spot entry { visit [-->]; }",
+         "}",
+         "enum Hue: int {",
+         "    RED = 1,",
+         "    GREEN = 2,",
+         "    comptime for N in ['BLUE'] {",
+         "        ${ct.name(N)} = 3,",
+         "    }",
+         "    comptime if 1 > 0 {",
+         "        VIOLET = 4,",
+         "    }",
+         "    with entry { x = 1; }",
+         "}",
+         "enum Shade;",
+
+     );
+
+def _body_shape(nd: any) -> any {
+    b = nd.__dict__.get("body");
+    if b is None {
+        return None;
+    }
+    if isinstance(b, list) {
+        return [type(i).__name__ for i in b];
+    }
+    return type(b).__name__;
+}
+
+test "the body union of every carrier persists natively (#8141)" {
+    # `Archetype`, `Ability` and `Enum` all carry their body through the
+    # `AstImplNeedingNode` slot, whose arms are a statement list, a `by`
+    # expression, and the bodiless declaration form. The native
+    # representation has to persist the arm it stored: nothing downstream
+    # may reconstruct it by re-reading the kid list, because that
+    # reconstruction duplicates parser body semantics (which member kinds
+    # belong to which carrier's body, which separators do not) and drifts
+    # the moment the grammar moves.
+    nl = chr(10);
+    src = nl.join(list(_BODY_UNION_LINES));
+    path = "__body_union_arms__.jac";
+    (native_mod, native_errs) = _materialize(src, path);
+    (py_mod, py_errs) = _bytecode_parse(src, path);
+    assert native_errs == py_errs == 0 , (
+        f"corpus no longer parses clean: {native_errs}/{py_errs}"
+    );
+    n_carriers = [
+        n
+        for n in native_mod._in_mod_nodes
+        if type(n).__name__ in _BODY_CARRIERS
+    ];
+    p_carriers = [
+        n
+        for n in py_mod._in_mod_nodes
+        if type(n).__name__ in _BODY_CARRIERS
+    ];
+    assert len(n_carriers) == len(p_carriers) , (
+        f"carrier count diverged: {len(n_carriers)} != {len(p_carriers)}"
+    );
+    kinds = {type(n).__name__ for n in p_carriers};
+    assert kinds == set(_BODY_CARRIERS) , f"corpus lost a carrier kind: {kinds}";
+    list_arms = 0;
+    expr_arms = 0;
+    none_arms = 0;
+    for (nn, pn) in zip(n_carriers, p_carriers) {
+        assert type(nn).__name__ == type(pn).__name__;
+        n_shape = _body_shape(nn);
+        p_shape = _body_shape(pn);
+        assert n_shape == p_shape , (
+            f"{type(pn).__name__} body arm diverged: {n_shape} != {p_shape}"
+        );
+        if p_shape is None {
+            none_arms += 1;
+        } elif isinstance(p_shape, list) {
+            list_arms += 1;
+            # Body entries are the tree's own nodes, not copies: passes reach
+            # them through `kid` and through `body` interchangeably.
+            for item in nn.__dict__["body"] {
+                assert `any(k is item for k in nn.kid) , (
+                    f"{type(nn).__name__}.body holds {type(item).__name__} "
+                    "that is not one of its kids"
+                );
+            }
+        } else {
+            expr_arms += 1;
+        }
+    }
+    # Every arm of the union is exercised, not just the braced one.
+    assert list_arms > 0 and none_arms > 0 and expr_arms > 0 , (
+        f"arm coverage: {list_arms} list, {none_arms} none, {expr_arms} expr"
+    );
+}
+
 test "materialized instances carry exactly the bytecode parser's dict keys" {
     # The seal-time field mask exists so passes that probe with hasattr or
     # iterate __dict__ see the same instance shape either way.

--- a/release_notes/unreleased/jaclang/8183.refactor.md
+++ b/release_notes/unreleased/jaclang/8183.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: the native parser persists the Archetype/Ability/Enum body union**: `body` is no longer erased into a slot the native parser never stores, so the materializer emits the arm the parser built and the Python-side body reconstruction that rebuilt it from the kid list is deleted.


### PR DESCRIPTION
Closes #8141.

> **Depends on #8185 and must merge after it.** `build-jac` stays red here until
> #8185 lands: the generated materializer does not compile on today's `main`
> (`error[E1053]` x40 on `UniNode.__sub_node_tab`), so no sealed artifact can be
> built and every seal-gated lane fails for a reason that has nothing to do with
> this change. Verified locally by merging `fix/materializer-nonscalar-dict-key`
> into this branch: 27/27 sealed-parser + generator tests pass on the merged
> tree, plus 33/33 across seal-integrity, unitree census, seam reachability, the
> sealed-native invariant, and demotion.

## The gap

`Archetype`, `Ability` and `Enum` carry their body through one slot inherited
from `AstImplNeedingNode`, declared `has body: (T | None)` on an **unbound**
type parameter. Native sees an optional-of-typevar, classifies the slot
foreign, and the constructor skips it outright, so the arm the parser built
never reaches the struct and the materializer has nothing to read. The
generator listed all three as `dead_fields` (emit `None`), and a Python fixup
then rebuilt `body` by scanning the kid list from the `LBRACE`:

```
"Archetype": (uni.ArchBlockStmt, uni.CodeBlockStmt),
"Ability":   (uni.CodeBlockStmt,),
"Enum":      (uni.EnumBlockStmt, uni.CtIf, uni.CtFor),
```

That filter is a second, widened copy of parser body semantics -- which member
kinds belong to which carrier's body, which separators do not -- plus a
hand-rolled scan for the `by` expression arm. It drifts the moment the grammar
moves.

## The fix

Give the slot the shape it actually holds:

```jac
obj AstImplNeedingNode(AstSymbolNode) {
    has body: (Sequence[UniNode] | UniNode | None);
```

a statement list, a single node (the `by` expression at parse time, the matched
`ImplDef` after decl/impl matching), or nothing. Nothing special-cases the
three class names: the existing native union-slot lowering stores the arm, and
the generated emitter follows the runtime arm through the same `isinstance`
dispatch `ImplDef.body` and `LambdaExpr.body` already use. The generator's
`dead_fields` set is now empty, so it is deleted with the reconstruction --
see the note on that below.

`jir_registry.jac` is regenerated (`jac gen-jir-registry`): the base's field
descriptor moves from `OPT_NODE_REF` to `NODE_LIST`, which is what `Archetype`,
`Ability` and `Enum` already carried.

## Ledger

The `body-union-reconstruction` entry leaves `MATERIALIZE_FIXUPS` and the
pinned count shrinks 3 -> 2, per #8139 Step 2's rule that entries are tracked,
the count pinned, and only ever shrinking. #8142 and #8143 are untouched.

## Why `dead_fields` goes too

It was a hand-curated list that existed for exactly these three slots. The
layout's `foreign` flag is not on its own a sufficient replacement -- #8161
gave `type` a native representation, `UniNode.__sub_node_tab` promptly stopped
being reported foreign, and that is precisely how the seal broke. What makes
the deletion safe is #8185's generation-time decline path: a field whose
annotation has no materializer is erased to `_py_none()` with a warning when
the emitter is generated, derived from the schema instead of curated by hand.
Another reason this PR sequences after #8185.

## Test

`the body union of every carrier persists natively (#8141)` parses a corpus
covering every arm of every carrier -- braced `Archetype` bodies holding
`ArchHas`/`Ability`/nested `Archetype`/`ImplDef`/`CtIf`/`CtFor`, `Ability`
bodies as statement lists, as a `by` expression, and as bare declarations
(including `abst` and accessor forms), `Enum` bodies holding
`Assignment`/`CtFor`/`CtIf`/`ModuleCode`/`PyInlineCode`, and the bodiless
declaration form of all three -- then asserts the materialized arm matches the
bytecode parser's, that all three arm shapes are exercised, and that body
entries are the tree's own kid objects rather than copies.

With the fixup removed and the slot still erased it fails, and so does the
seal's own parity canary: CI run 31812164255 on the intermediate commit reports
`Archetype:Canary|body=none` against the bytecode parser's `body=list:2`.

## One pre-existing break fixed on the way

**The seal-time field mask never saw comptime.** The parity corpus parses
`comptime if` / `comptime for` / `${...}`, but the mask corpus did not, so
`CtIf`, `CtFor` and `CtSplice` were unobserved and fell back to emitting every
layout field, drifting `name_spec` and `semstr` onto instances the bytecode
parser leaves bare. Confirmed pre-existing by running the dict-key parity test
on `upstream/main` with only #8185's fix applied.
