### PR TITLE
fix(client): restore the comma dropped when #8208 and #8211 merged

### DIFF
--- a/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
@@ -34,7 +34,7 @@ import from jaclang.jac0core.diagnostics {
     E5080,
     E5081,
     E5085,
-    E5086
+    E5086,
     E5099
 }
 


### PR DESCRIPTION
Main is red at 506edce83. `jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac` cannot parse, so sealing reports it has no JIR and `jac-check` fails its full-tree sweep.

## Cause

Two PRs added an entry to the same diagnostics import list:

- #8208 added `E5099` after `E5085,`
- #8211 added `E5086` after `E5085,`, as the last item, so with no trailing comma

Each was valid against its own base and each was green. The two additions landed on adjacent lines, so git merged them with no conflict and produced:

```
    E5085,
    E5086
    E5099
}
```

The missing separator is a syntax error. Nothing caught it before merge because the broken state exists only in the merge result, not in either branch.

## Fix

Add the comma.

## Verification

- `jac fmt --check --lintfix` passes on the file (formatting requires a successful parse, which is the failure the seal reports).
- Green main `0a0b28106` (the #8208 merge) and red main `506edce83` (the #8211 merge) differ in this file only by the `E5086` line.

## Blast radius

This unblocks #8209 and #8210, which are both inheriting `build-jac` and `test-cef-build` failures from this base through their merge refs.