### PR TITLE
chore: jac's bundled CPython is the only python this repo has

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -30,7 +30,7 @@ body:
     id: versions
     attributes:
       label: "Versions"
-      placeholder: "Jac 0.11.0 | Python 3.12.2 | jac-scale = 0.1.10 | jac-byllm = 0.5.0"
+      placeholder: "Jac 0.11.0 | Python 3.14.6 | jac-scale = 0.1.10 | jac-byllm = 0.5.0"
 
   - type: textarea
     id: reproduce

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1145,10 +1145,9 @@ jobs:
       with:
         submodules: true
 
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v3
-      with:
-        python-version: 3.12
+    # No setup-python: every step below runs through the jac binary, which
+    # brings its own CPython. The pin existed only because check-guide.sh
+    # piped into a host `python3`; it now pipes into `jac -c`.
 
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/jac/jaclang/cli/docs/reference/config/index.md
+++ b/jac/jaclang/cli/docs/reference/config/index.md
@@ -72,7 +72,7 @@ jac-version = "==0.34.3"   # stamped by `jac create`; widen to `>=`, `<=`, or a 
 # Publishing metadata -- only needed to run `jac build --as wheel`
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 keywords = ["jac", "ai"]
 authors = [{ name = "Your Name", email = "you@example.com" }]
 maintainers = [{ name = "Another Person", email = "them@example.com" }]
@@ -92,7 +92,7 @@ repository = "https://github.com/user/repo"
 | `jac-version` | string | Jac toolchain version the project targets, as a PEP 440-style specifier. `jac create` stamps `==<current>`; at `jac start --scale` the pod runtime binary, admin console, and base image are all taken from the release that satisfies it, and the deploy aborts if none does. See [jac-version](#jac-version). |
 | `license` | string | SPDX license identifier (e.g. `"MIT"`) |
 | `readme` | string | Path to README file (default: `README.md`) |
-| `requires-python` | string | Minimum Python version (e.g. `">=3.12"`) |
+| `requires-python` | string | Minimum Python version (e.g. `">=3.14"`) -- the wheel carries bytecode precompiled for the CPython the `jac` binary bundles, so a lower floor than that cannot load it |
 | `keywords` | list | Search keywords shown on PyPI |
 | `authors` | list of `{name, email}` | Package authors |
 | `maintainers` | list of `{name, email}` | Package maintainers |

--- a/jac/jaclang/cli/docs/reference/publishing.md
+++ b/jac/jaclang/cli/docs/reference/publishing.md
@@ -25,7 +25,7 @@ version = "1.0.0"
 description = "A handy Jac library"
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 keywords = ["jac", "jaseci", "ai"]
 classifiers = [
   "Programming Language :: Python :: 3",

--- a/jac/tests/compiler/test_placement_facts.jac
+++ b/jac/tests/compiler/test_placement_facts.jac
@@ -1,6 +1,7 @@
 """Tests for the placement facts API, the single placement query surface."""
 
 import os;
+import sys;
 import tempfile;
 import from tests.support { JAC_ROOT }
 import from jaclang.jac0core.program { JacProgram }
@@ -101,7 +102,7 @@ test "sealed images persist placement and expose it without re-derivation" {
     manifest = {
         "format": MANIFEST_FORMAT,
         "package": "app",
-        "python_tag": "cpython-312",
+        "python_tag": f"cpython-{sys.version_info.major}{sys.version_info.minor}",
         "modules": {"svc.jac": {"module": "app.svc", "jir": "svc.jir"}},
         "placement": {"svc.jac": ["server"], "ui/page.jac": ["client"]}
     };

--- a/jac/tests/publish/test_publish.jac
+++ b/jac/tests/publish/test_publish.jac
@@ -16,6 +16,7 @@ import tarfile;
 import tomllib;
 import zipfile;
 import json;
+import sys;
 import tempfile;
 import shutil;
 import from pathlib { Path }
@@ -214,7 +215,12 @@ test "collect_source_files gathers jac files and excludes build artifacts" {
         (pkg / "stale.pyc").write_bytes(bytes([0]));
         pycache = pkg / "__pycache__";
         pycache.mkdir();
-        (pycache / "main.cpython-312.pyc").write_bytes(bytes([0]));
+        (
+            pycache
+            / f"main.cpython-{sys.version_info.major}{sys.version_info.minor}.pyc"
+        ).write_bytes(
+            bytes([0])
+        );
         cfg = pkg_config_with_include(proj, "mypkg");
         files = collect_source_files(cfg, project_root=proj);
         paths = [sf.wheel_path for sf in files];

--- a/jac/tests/runtimelib/client/test_cef_binding.jac
+++ b/jac/tests/runtimelib/client/test_cef_binding.jac
@@ -12,6 +12,7 @@ import os;
 import re;
 import shutil;
 import subprocess;
+import sys;
 import sysconfig;
 import tempfile;
 import from pathlib { Path }
@@ -74,7 +75,8 @@ def _compile_cef_host(host_src: str) -> tuple {
 
 """The embedded-CPython CEF host (cef runtime model) links both libs."""
 test "cef embedded-python host compiles and links libcef_dispatch and libpython" {
-    soname = sysconfig.get_config_var("INSTSONAME") or "libpython3.12.so.1.0";
+    soname = sysconfig.get_config_var("INSTSONAME")
+        or f"libpython{sys.version_info.major}.{sys.version_info.minor}.so.1.0";
     stem = soname.split(".so")[0].encode();
     src = (
         "import sys;\n"

--- a/jac/tests/runtimelib/client/test_desktop_binding.jac
+++ b/jac/tests/runtimelib/client/test_desktop_binding.jac
@@ -9,6 +9,7 @@ drift, wrong/missing externs, wrong soname, and codegen regressions.
 import os;
 import shutil;
 import subprocess;
+import sys;
 import sysconfig;
 import tempfile;
 import from pathlib { Path }
@@ -126,8 +127,9 @@ test "webview binding host compiles and links libwebview.so" {
 
 """The embedded-CPython host (the desktop runtime model) links libpython."""
 test "embedded-python host compiles and links libpython" {
-    soname = sysconfig.get_config_var("INSTSONAME") or "libpython3.12.so.1.0";
-    stem = soname.split(".so")[0].encode();  # e.g. b"libpython3.12"
+    soname = sysconfig.get_config_var("INSTSONAME")
+        or f"libpython{sys.version_info.major}.{sys.version_info.minor}.so.1.0";
+    stem = soname.split(".so")[0].encode();  # e.g. b"libpython3.14"
     src = (
         f'import from "{soname}" {{\n'
         "    def Py_Initialize() -> None;\n"
@@ -176,7 +178,8 @@ between .jac files). The bridge handles GIL management,
 PyObject_CallOneArg, and inttoptr coercion.
 """
 test "plugin bridge host compiles with webview + libpython" {
-    soname = sysconfig.get_config_var("INSTSONAME") or "libpython3.12.so.1.0";
+    soname = sysconfig.get_config_var("INSTSONAME")
+        or f"libpython{sys.version_info.major}.{sys.version_info.minor}.so.1.0";
     # The host inlines the bridge code (same pattern as _generate_host_source)
     src = (
         f'import from "{soname}" {{\n'

--- a/jac/tests/runtimelib/client/test_integration.jac
+++ b/jac/tests/runtimelib/client/test_integration.jac
@@ -16,6 +16,7 @@ import json;
 import os;
 import shutil;
 import subprocess;
+import sys;
 import sysconfig;
 import tempfile;
 import from pathlib { Path }
@@ -1296,7 +1297,8 @@ test "plugin bridge source contains expected elements" {
 
 """plugin_bridge.jac compiles with webview + libpython (link test)."""
 test "plugin bridge links with full native stack" {
-    soname = sysconfig.get_config_var("INSTSONAME") or "libpython3.12.so.1.0";
+    soname = sysconfig.get_config_var("INSTSONAME")
+        or f"libpython{sys.version_info.major}.{sys.version_info.minor}.so.1.0";
     webview_dir = _native_dir() / "webview";
     # The host inlines the bridge code (same pattern as _generate_host_source)
     src = (

--- a/scripts/check-guide.sh
+++ b/scripts/check-guide.sh
@@ -28,7 +28,11 @@ case "$(echo "$BODY" | sed -e 's/^[[:space:]]*//' | head -c 3)" in
 esac
 
 # --- jac guide --json: a parseable guide list ---
-"$JAC" guide --json | python3 -c '
+# `$JAC -c` runs jac's own bundled CPython. A host `python3` would be some
+# other interpreter entirely -- the whole point of the binary is that there
+# is not one -- and depending on it is what forced a `setup-python` step
+# into the smoke job that runs this script.
+"$JAC" guide --json | "$JAC" -c '
 import json, sys
 guides = json.load(sys.stdin)
 assert isinstance(guides, list), "guide --json must emit a list"


### PR DESCRIPTION
`jaclang` ships as one binary with a private CPython **3.14.6** and there is no
pip-installed jaclang -- CONTRIBUTING.md says so outright, and `jac` run from
the checkout already links the dev compiler source. Several places had not
caught up and still assumed a host interpreter, generally 3.12.

None of them announced itself, which is the problem. Each one either pinned a
version nothing runs, or asserted against a soname nothing produces, and a
contributor reading them concludes the floor is 3.12. It is not academic: I hit
this on #8233, ran dev sources through a system `python3`, watched `TypeIs`
resolve to nothing (typeshed guards it at 3.13), concluded a checker test was
"pre-existing broken", and shaped a fixture around a constraint that does not
exist. Under `jac test` the same test passes.

## The one that had teeth

`scripts/check-guide.sh` piped `jac guide --json` into a host `python3`. That
single shellout is the entire reason the `test-jac-pack-smoke` job carried a
`Set up Python 3.12` step -- every other step in that job goes through `jac`.

The pipe now lands in `jac -c`, the same interpreter that produced the JSON,
and the setup step is deleted. Verified: `bash scripts/check-guide.sh jac`
exits 0 with no host python involved.

## The ones that were latent

Four client tests fell back to a literal `libpython3.12.so.1.0` when
`sysconfig.get_config_var("INSTSONAME")` came up empty:

```jac
soname = sysconfig.get_config_var("INSTSONAME") or "libpython3.12.so.1.0";
```

Under jac's runtime that config var answers `libpython3.14.so.1.0`, so the
literal was unreachable -- and wrong if it were ever reached. It is now derived
from `sys.version_info`, which cannot go stale.

Same treatment for two hand-built fixtures that spelled a python tag by hand:
the sealed-manifest `python_tag` in `test_placement_facts.jac` and the
`__pycache__` entry in `test_publish.jac`. `precompile_bytecode.jac` computes
that tag as `f"cpython-{major}{minor}"` off the running interpreter, so the
fixtures now do the same and agree with it by construction rather than by
someone remembering to update them.

## The ones that misinform

`requires-python = ">=3.12"` in the publishing and config references is advice
a reader would follow. A jac wheel carries bytecode precompiled for the bundled
CPython, so a floor below it cannot load the wheel. The examples say `>=3.14`
and the field's table row now explains why. The bug-report template's version
placeholder moves too.

## Deliberately untouched

`python:3.12-slim` stays as the scale pod's fallback base image. Nothing
executes its python: `build_bootstrap_init_container` emits `bash -c` and calls
`jac install`, which uses the runtime jac extracts into the pod. Retagging it
would churn eight test assertions and four doc sites for no behavior change,
and the principled version of that change -- a base image that is not a python
image at all -- needs a real deploy to validate. Flagging it rather than
half-doing it.

## Verification

All on `jac test` (CPython 3.14.6), moderate parallelism:

- `test_publish.jac -t collect_source` -- 6 passed
- `test_placement_facts.jac -t sealed` -- 1 passed
- `test_desktop_binding.jac -t libpython` -- 2 passed
- `test_cef_binding.jac -t libpython` -- 1 passed
- `test_integration.jac -t "full native stack"` -- 1 passed
- `bash scripts/check-guide.sh jac` -- exit 0