### PR TITLE
ci: give the release build's Linux legs swap headroom so the eleven-root seal cannot kill the runner

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -299,6 +299,59 @@ jobs:
         working-directory: jac
         run: zig build fetch-llvm $DTARGET --summary all
 
+      # The seal that closes `zig build` compiles every NATIVE_SEAL_ROOTS entry
+      # in ONE process, and each materializer crossing it makes strands that
+      # crossing's native tree: the unitree parent/kid cycles defeat plain RC
+      # and the artifact collector is not yet multi-module-safe to arm (#8139;
+      # ci.yml chunks test-compiler against the same accumulation). Wave 4 took
+      # the seal from nine roots to eleven and the accumulation now outgrows a
+      # hosted Linux runner. On cd049457a both Linux legs died mid-seal with
+      # "the runner has received a shutdown signal" and exit 143 -- no zig
+      # diagnostic, no failed command, the signature of a runner whose memory
+      # is gone -- while the macOS leg, whose swap grows on demand, finished
+      # the same commit in 45m against a ~30m baseline. The stranded pages are
+      # cold (written once, never read again), so swap holds them for the price
+      # of the paging: give the Linux legs the headroom macOS takes for
+      # granted. Retire this step when the crossing reclaims its tree.
+      - name: Swap headroom for the sealed precompile (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          echo "--- before"
+          free -h
+          swapon --show || true
+          df -h
+          # Prefer the runner's scratch volume: the build stages the payload on
+          # the workspace volume, so a swapfile there competes with it.
+          WORK_DEV="$(df -P "$RUNNER_TEMP" | awk 'NR==2 {print $1}')"
+          MNT_DEV="$(df -P /mnt 2>/dev/null | awk 'NR==2 {print $1}' || true)"
+          if [ -n "$MNT_DEV" ] && [ "$MNT_DEV" != "$WORK_DEV" ]; then
+            SWAP_DIR=/mnt
+            RESERVE_GB=2
+          else
+            SWAP_DIR="$RUNNER_TEMP"
+            RESERVE_GB=25
+          fi
+          AVAIL_GB=$(( $(df -Pk "$SWAP_DIR" | awk 'NR==2 {print $4}') / 1048576 ))
+          SIZE_GB=$(( AVAIL_GB - RESERVE_GB ))
+          if [ "$SIZE_GB" -gt 24 ]; then
+            SIZE_GB=24
+          fi
+          if [ "$SIZE_GB" -lt 4 ]; then
+            echo "::warning::$SWAP_DIR has ${AVAIL_GB}G free, too little to spare;" \
+                 "the seal runs on the stock swap and may exhaust the runner"
+            exit 0
+          fi
+          SWAP_FILE="$SWAP_DIR/jac-seal-swap"
+          sudo fallocate -l "${SIZE_GB}G" "$SWAP_FILE" \
+            || sudo dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$(( SIZE_GB * 1024 ))
+          sudo chmod 600 "$SWAP_FILE"
+          sudo mkswap "$SWAP_FILE"
+          sudo swapon "$SWAP_FILE"
+          echo "--- after"
+          free -h
+          swapon --show
+
       - name: Build the jac binary (one command)
         working-directory: jac
         # On a dev-channel shim-cache hit, stage the shim outside its in-tree


### PR DESCRIPTION
The rolling dev release has been red since sealing wave 4 (#8277). Both
Linux legs of run 31948606351 died inside `zig build` with "the runner has
received a shutdown signal" and exit code 143: no zig diagnostic, no failed
command, no output at all after `fetch-typeshed: ready`. That is a runner
whose memory is gone, not a build error, and it is the same death
a0c3985e3 chased out of test-compiler. Re-running that commit reproduced it
on both legs within a minute of the same mark, so it is deterministic
rather than a runner blip.

The seal that closes the build compiles every NATIVE_SEAL_ROOTS entry in
ONE process, and each materializer crossing strands that crossing's native
tree: the unitree parent/kid cycles defeat plain RC and the artifact
collector is not yet multi-module-safe to arm (the reclaim tracks with
#8139). Wave 4 took the seal from nine roots to eleven, and the
accumulation now outgrows a hosted Linux runner.

| leg | attempt 1 | attempt 2 | green baseline |
|---|---|---|---|
| linux-aarch64 | died 20m37s in | died 20m01s in | 27m37s |
| linux-x86_64 | died 30m10s in | died 30m54s in | 25m01s |
| macos-14 | 45m03s, green | n/a | 27m10s / 30m10s / 30m30s |

Replaying that same `zig build` locally on cd049457a finishes: eleven
artifacts, every canary green, exit 0, peak 19.3 GiB resident
(`/usr/bin/time -v` ru_maxrss 20,207,580 KB). Both hosted Linux images
report 15 GiB of RAM behind a 3 GiB stock swapfile. Eighteen gibibytes is
the whole budget, the seal wants 19.3, and that is the entire failure.
macOS survives the same peak because its swap grows on demand, which is
also why it slowed to 45m.

So the seal is not broken; the runner is out of room. The stranded pages
are cold, written once and never read again, so swap holds them for the
price of the paging. This step adds 24 GiB of it, prints free/df/swapon
before and after so the next capacity question is answered from the log
rather than guessed, and warns instead of failing if some future image
cannot spare the space. It is a capacity floor, not a fix: retire it when
the crossing reclaims its tree.

Validated on the real runner images before merge: the same commit plus this
step, dispatched through the same release-dev workflow, built all three
legs green (linux-aarch64 47m07s, linux-x86_64 45m36s, macos-14 41m55s).
The paging costs the Linux legs roughly 15 minutes each, which is the price
of a dev binary that exists.

While here, the compiler-fingerprint tripwire in this file was checked and
is not drifted: the workflow's `git ls-tree` rule and
`jaclang.jac0core.jir.compiler_source_files` enumerate the same 291 files
on this tree, diffed empty in both directions.
