### PR TITLE
ci: the swap-headroom fallback fails loud instead of guaranteeing a dead leg

### DIFF
--- a/.github/actions/setup-jac/action.yml
+++ b/.github/actions/setup-jac/action.yml
@@ -313,9 +313,9 @@ runs:
           SIZE_GB=24
         fi
         if [ "$SIZE_GB" -lt 4 ]; then
-          echo "::warning::$SWAP_DIR has ${AVAIL_GB}G free, too little to spare;" \
-               "the seal runs on the stock swap and may exhaust the runner"
-          exit 0
+          echo "::error::$SWAP_DIR has ${AVAIL_GB}G free, too little to spare;" \
+               "the seal needs swap headroom at this root count and would exhaust the runner"
+          exit 1
         fi
         SWAP_FILE="$SWAP_DIR/jac-seal-swap"
         sudo fallocate -l "${SIZE_GB}G" "$SWAP_FILE" \

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -338,9 +338,9 @@ jobs:
             SIZE_GB=24
           fi
           if [ "$SIZE_GB" -lt 4 ]; then
-            echo "::warning::$SWAP_DIR has ${AVAIL_GB}G free, too little to spare;" \
-                 "the seal runs on the stock swap and may exhaust the runner"
-            exit 0
+            echo "::error::$SWAP_DIR has ${AVAIL_GB}G free, too little to spare;" \
+                 "the seal needs swap headroom at this root count and would exhaust the runner"
+            exit 1
           fi
           SWAP_FILE="$SWAP_DIR/jac-seal-swap"
           sudo fallocate -l "${SIZE_GB}G" "$SWAP_FILE" \


### PR DESCRIPTION
At thirteen sealed roots the seal's peak RSS (~1.6 GiB per root, measured in #8281) exceeds the hosted runners' stock swap, so a Linux leg that cannot add the headroom no longer runs slow -- it dies mid-build with no diagnostic ("runner lost communication"). The SIZE_GB < 4 fallback in both copies of the headroom step (build-binaries.yml and the shared setup-jac action) previously warned and continued into that guaranteed death; it now refuses at setup, naming the disk-space cause while it is still attributable.

Flagged by sealing wave 5's capacity analysis (#8281) as the standing risk for every wave from here on. Workflow-only change; the real long-term fix remains the materializer crossing's tree reclaim.

Part of #8201.