### PR TITLE
test(compiler): a jac.toml placement-pins edit invalidates the module JIR cache (#8073)

### DIFF
--- a/jac/tests/compiler/test_importer.jac
+++ b/jac/tests/compiler/test_importer.jac
@@ -22,6 +22,7 @@ import from jaclang.jac0core.jir {
     get_module_cache_path,
     read_bytecode_only,
     SEC_LLVM_IR,
+    SEC_PLACEMENT,
     SECTIONS_MAGIC,
     HEADER_SIZE,
     read_sections
@@ -532,6 +533,24 @@ test "fresh mtime does not admit a cache written under a different environment" 
     }
 }
 
+def _cached_pins(jir_bytes: bytes) -> dict[str, str] {
+    import from jaclang.jac0core.placement { summary_from_bytes }
+    pos = jir_bytes.find(SECTIONS_MAGIC, HEADER_SIZE);
+    if pos < 0 {
+        return {};
+    }
+    secs = read_sections(jir_bytes, pos + len(SECTIONS_MAGIC));
+    placement = secs.get(SEC_PLACEMENT);
+    if placement is None {
+        return {};
+    }
+    summary = summary_from_bytes(placement);
+    if summary is None {
+        return {};
+    }
+    return {e.name: e.pinned for e in summary.elements};
+}
+
 test "editing placement pins in jac.toml invalidates the module cache" {
     import from jaclang.jac0core.jir { is_module_cache_valid }
     with tempfile.TemporaryDirectory(dir=_test_tmp_dir) as proj {
@@ -559,6 +578,9 @@ test "editing placement pins in jac.toml invalidates the module cache" {
             );
 
             stale = cache_path.read_bytes();
+            assert _cached_pins(stale).get("helper_fn", "") == "" , (
+                "the pre-edit placement summary should carry no pin"
+            );
             with open(toml_path, "a") as f {
                 f.write('\n[placement.pins]\n"m.helper_fn" = "server"\n');
             }
@@ -572,6 +594,9 @@ test "editing placement pins in jac.toml invalidates the module cache" {
             );
             assert is_module_cache_valid(jac_file, cache_path) , (
                 "the rewritten cache must be valid under the new pins"
+            );
+            assert _cached_pins(cache_path.read_bytes()).get("helper_fn") == "server" , (
+                "the recompiled placement summary must honor the new pin"
             );
         } finally {
             if cache_path.exists() {

--- a/jac/tests/compiler/test_importer.jac
+++ b/jac/tests/compiler/test_importer.jac
@@ -532,6 +532,55 @@ test "fresh mtime does not admit a cache written under a different environment" 
     }
 }
 
+test "editing placement pins in jac.toml invalidates the module cache" {
+    import from jaclang.jac0core.jir { is_module_cache_valid }
+    with tempfile.TemporaryDirectory(dir=_test_tmp_dir) as proj {
+        toml_path = os.path.join(proj, "jac.toml");
+        jac_file = os.path.join(proj, "m.jac");
+        with open(toml_path, "w") as f {
+            f.write('[project]\nname = "pins_cache_probe"\n');
+        }
+        with open(jac_file, "w") as f {
+            f.write("def helper_fn() -> int { return 42; }\n");
+        }
+        past = time.time() - 2;
+        os.utime(jac_file, (past, past));
+        os.utime(toml_path, (past, past));
+        compiler = JacCompiler();
+        assert compiler.get_bytecode(jac_file, JacProgram()) is not None;
+        cache_path = get_module_cache_path(jac_file);
+        try {
+            assert cache_path.exists() , "JIR cache was not written";
+            assert os.path.getmtime(cache_path) > os.path.getmtime(jac_file) , (
+                "cache must be newer than source for the mtime fast path to apply"
+            );
+            assert is_module_cache_valid(jac_file, cache_path) , (
+                "fresh cache should be valid"
+            );
+
+            stale = cache_path.read_bytes();
+            with open(toml_path, "a") as f {
+                f.write('\n[placement.pins]\n"m.helper_fn" = "server"\n');
+            }
+            assert not is_module_cache_valid(jac_file, cache_path) , (
+                "a jac.toml pins edit must invalidate the module cache"
+            );
+
+            assert compiler.get_bytecode(jac_file, JacProgram()) is not None;
+            assert cache_path.read_bytes() != stale , (
+                "a recompile must overwrite the stale cache entry"
+            );
+            assert is_module_cache_valid(jac_file, cache_path) , (
+                "the rewritten cache must be valid under the new pins"
+            );
+        } finally {
+            if cache_path.exists() {
+                cache_path.unlink();
+            }
+        }
+    }
+}
+
 test "stub module cache key is source focused" {
     import from jaclang.jac0core.jir {
         compute_module_key,


### PR DESCRIPTION
Closes the coverage gap left by #8073 (root cause fixed in #8197, hardened in #8259).

## Why

#8197 fixed the defect: `is_module_cache_valid` now compares the stored `SEC_ENVKEY` environment fingerprint against live config before the mtime fast path, and a config edit unblocks the cache overwrite so the entry self-heals. But its test perturbs the compiler digest and `JAC_OPT_LEVEL` directly, never the config file.

The pins path depends on two links, and only a test that edits a real jac.toml covers both: `pins_digest` has to be folded into `_project_env_fingerprint`, and the mtime-keyed toml memo in `placement_pins.jac` has to notice the file changed. Either link breaking reproduces #8073, and nothing was red for either. `test_placement_pins.jac` asserts pins serialize into a digest from a toml written once; it never warms a cache and never edits the file.

## What

One test in `tests/compiler/test_importer.jac`, next to the #8197 environment test: warm a module cache in a real project via `get_bytecode`, append a `[placement.pins]` entry to `jac.toml` only (no source file touched, so the mtime fast path still applies, which is asserted), then assert:

1. the cache entry is rejected,
2. a recompile is permitted to overwrite the stale entry,
3. the rewritten entry is valid under the new pins,
4. the rewritten entry's `SEC_PLACEMENT` summary carries `helper_fn` pinned to `server` (the stale one carried no pin).

Assertion 4 ties the test to the reported symptom (wrong emitted placement, not just a stale file) and makes the pin key load-bearing: `pins_digest` hashes the whole table, so without it a pin naming an unrelated element would pass identically.

The `time.time() - 2` backdating is load-bearing twice: it makes the cache newer than the source so the fast path applies, and it guarantees the append moves jac.toml's mtime past the `_load_pins` memo stamp. The `finally` unlink is needed because `get_module_cache_path` can resolve outside the tempdir.

## Verification

- Red under two mutations, at the invalidation assert both times: the pre-#8197 shape (`SEC_ENVKEY` gate disabled), and `pins_digest` dropped from `_project_env_fingerprint`.
- Green on the branch: `jac test tests/compiler/test_importer.jac` passes 24/24; `jac fmt --check` clean.

Test-only change, no release note.
