### PR TITLE
fix(codegen): isolate emitted future flags (#8308)

### DIFF
--- a/jac/jaclang/compiler/backends/py/codegen_shim.jac
+++ b/jac/jaclang/compiler/backends/py/codegen_shim.jac
@@ -370,7 +370,9 @@ def compile_ir(ir_bytes: bytes) -> CirResult {
     for m in container.modules {
         built_root: ast.Module = transcribe_module(m, classes, keys, container);
         try {
-            code_obj: types.CodeType = compile(built_root, m.mod_path, "exec");
+            code_obj: types.CodeType = compile(
+                built_root, m.mod_path, "exec", flags=0, dont_inherit=True
+            );
         } except (ValueError, SyntaxError, TypeError) as e {
             diags.append(
                 CirDiag(

--- a/jac/tests/compiler/test_codegen_ir.jac
+++ b/jac/tests/compiler/test_codegen_ir.jac
@@ -8,6 +8,7 @@ producer side, which is the seat the sealed native emitter sits in.
 """
 
 import ast as pyast;
+import __future__ as pyfuture;
 import from builtins { exec as pyexec }
 import from jaclang.compiler.backends.py.codegen_ir {
     CIR_FORMAT_VERSION,
@@ -114,6 +115,13 @@ test "codegen ir round trips a real program" {
     assert ns["__doc__"] == "Round trip fixture.";
     assert ns["greet"]("jac") == "hello jac";
     assert ns["greet"].__code__.co_firstlineno == 2;
+}
+
+test "compiled modules do not inherit future flags from the shim" {
+    result = compile_ir(fixture_blob());
+    assert len(result.diags) == 0;
+    assert (result.modules[0].code_obj.co_flags & pyfuture.annotations.compiler_flag)
+        == 0;
 }
 
 test "transcribed tree matches the source ast exactly" {

--- a/release_notes/unreleased/jaclang/8308.bugfix.md
+++ b/release_notes/unreleased/jaclang/8308.bugfix.md
@@ -1,0 +1,1 @@
+- **Generated modules no longer inherit compiler-frame `__future__` flags**: the codegen shim compiles each transcribed module with explicit flags and disables frame inheritance, so a module's `co_flags` reflects its own source rather than the compiler's execution context.

--- a/release_notes/unreleased/jaclang/8308.bugfix.md
+++ b/release_notes/unreleased/jaclang/8308.bugfix.md
@@ -1,1 +1,0 @@
-- **Generated modules no longer inherit compiler-frame `__future__` flags**: the codegen shim compiles each transcribed module with explicit flags and disables frame inheritance, so a module's `co_flags` reflects its own source rather than the compiler's execution context.

--- a/release_notes/unreleased/jaclang/8349.bugfix.md
+++ b/release_notes/unreleased/jaclang/8349.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Generated modules no longer inherit compiler-frame `__future__` flags**: The codegen shim compiles each transcribed module with explicit flags and disables frame inheritance, so a module's `co_flags` reflects its own source rather than the compiler's execution context.


### PR DESCRIPTION
## What changed

The codegen shim calls `compile(...)` with `flags=0` and `dont_inherit=True`, so emitted modules do not inherit the compiler frame's future flags. The regression test checks a module without a future import.

## Validation

Rebased onto `3ad7d91b5`.

- Direct codegen tests: 9 passed.
- JCIR, React state semantics, and Preact backend suites: 43 passed, 1 skipped.
- Formatting and `git diff --check` pass.

The earlier missing LLVM shim error was resolved by supplying the repository's local shim; the final related-suite result above is from that rerun.

Refs #8308.
