### PR TITLE
fix(client): restore state setter bindings (#8224)

### DIFF
--- a/jac/jaclang/compiler/passes/ecmascript/backends/impl/react.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/backends/impl/react.impl.jac
@@ -138,7 +138,13 @@ impl ReactBackend.lower_state_field(s: StateField) -> list[es.Statement] {
     declarator = es.VariableDeclarator(
         id=es.Identifier(name=self._state_cell_name(s.name)), init=hook_call
     );
-    decl_stmt = es.VariableDeclaration(declarations=[declarator], kind='const');
+    setter_declarator = es.VariableDeclarator(
+        id=es.Identifier(name=self._get_setter_name(s.name)),
+        init=self._state_cell_member(s.name, 'set')
+    );
+    decl_stmt = es.VariableDeclaration(
+        declarations=[declarator, setter_declarator], kind='const'
+    );
     return [decl_stmt];
 }
 

--- a/jac/tests/compiler/passes/ecmascript/fixtures/state_setter_binding.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/state_setter_binding.jac
@@ -1,0 +1,15 @@
+"""A client state setter remains a first-class binding."""
+
+obj:pub Box {
+    has theme: str = "",
+        setTheme: any = None;
+}
+
+def:pub use_thing -> Box {
+    has theme: str = "dark";
+    return Box(theme=theme, setTheme=setTheme);
+}
+
+def:pub app -> JsxElement {
+    return <div>{use_thing().theme}</div>;
+}

--- a/jac/tests/compiler/passes/ecmascript/test_state_store_lowering.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_state_store_lowering.jac
@@ -89,3 +89,18 @@ test "preact backend inherits the store cell lowering" {
     js = compile_with_backend("state_semantics_component.jac", PreactBackend());
     assert_store_contract(js, "preact");
 }
+
+test "react-family state keeps the public setter binding" {
+    for (backend_name, backend) in [
+        ("react", ReactBackend()),
+        ("preact", PreactBackend())
+    ] {
+        js = compile_with_backend("state_setter_binding.jac", backend);
+        assert re.search(r"setTheme\s*=\s*__jacS_theme\.set", js) , (
+            f"[{backend_name}] has theme must bind setTheme to its store setter:\n{js}"
+        );
+        assert "setTheme: setTheme" in js , (
+            f"[{backend_name}] consumers must receive the bound setter:\n{js}"
+        );
+    }
+}

--- a/release_notes/unreleased/jaclang/8224.bugfix.md
+++ b/release_notes/unreleased/jaclang/8224.bugfix.md
@@ -1,0 +1,1 @@
+- **Client `has` state keeps its setter binding on React and Preact**: `has theme` now emits `setTheme` as a reference to the state cell's setter, so code can pass the setter to another object or function without shipping an undefined JavaScript identifier.


### PR DESCRIPTION
## What changed

React-family state lowering now emits two bindings for each client `has` field:

```js
const __jacS_theme = useJacState("dark"), setTheme = __jacS_theme.set;
```

The state cell continues to provide synchronous reads and writes. The public `setTheme` name once again exists as a first-class function that user code can pass to another object or function. Preact inherits the same lowering.

## Why

The read-your-writes migration replaced `const [theme, setTheme] = useState(...)` with a `useJacState` cell but emitted only the cell. References to `setTheme` remained bare identifiers, so `jac check` and the client build passed while the module failed with `ReferenceError` at runtime.

## Impact

Code that returns or passes a `setX` binding from a client function no longer ships an unbound identifier.

## Validation

- `jac test jac/tests/compiler/passes/ecmascript/test_state_store_lowering.jac jac/tests/compiler/passes/ecmascript/test_preact_backend.jac` — 19 passed
- `jac fmt --check` on the changed Jac files
- `git diff --check`