### PR TITLE
fix(checker): reject bare archetype fields

### DIFF
--- a/jac/jaclang/compiler/passes/impl/type_checker_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/impl/type_checker_pass.impl.jac
@@ -6,42 +6,16 @@ impl TypeCheckPass.exit_name with Name exit {
     if here.__class__ is not Name {
         return;
     }
+    if self.evaluator._is_non_expression_name(here) {
+        return;
+    }
     is_bare_field = (
         here.sym is not None
         and here.sym.sym_type == SymbolType.HAS_VAR
         and isinstance(here.sym.parent_tab, Archetype)
         and here.expr_ctx == ExprCtx.LOAD
-        and not (
-            isinstance(here.parent, AtomTrailer)
-            and here.parent.is_attr
-            and here.parent.right is here
-        )
     );
     if here.sym is None or is_bare_field {
-        if isinstance(here.parent, AtomTrailer) and here.parent.right is here {
-            return;
-        }
-        if isinstance(here.parent, HasVar)
-            and here.parent.defer
-            and here is not here.parent.name {
-            return;
-        }
-        if isinstance(here.parent, KWPair) and here.parent.key is here {
-            return;
-        }
-        if isinstance(here.parent, SubTag) {
-            return;
-        }
-
-        if isinstance(here.parent, ModulePath) {
-            return;
-        }
-        if isinstance(here.parent, JsxElementName) {
-            return;
-        }
-        if isinstance(here.parent, ModuleCode) and here.parent.name is here {
-            return;
-        }
         self.evaluator.get_type_of_expression(here);
     }
     if here.sym is not None {

--- a/jac/jaclang/compiler/passes/impl/type_checker_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/impl/type_checker_pass.impl.jac
@@ -14,6 +14,7 @@ impl TypeCheckPass.exit_name with Name exit {
         and here.sym.sym_type == SymbolType.HAS_VAR
         and isinstance(here.sym.parent_tab, Archetype)
         and here.expr_ctx == ExprCtx.LOAD
+        and self.evaluator._is_attr_receiver_name(here)
     );
     if here.sym is None or is_bare_field {
         self.evaluator.get_type_of_expression(here);

--- a/jac/jaclang/compiler/passes/impl/type_checker_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/impl/type_checker_pass.impl.jac
@@ -15,6 +15,7 @@ impl TypeCheckPass.exit_name with Name exit {
         and isinstance(here.sym.parent_tab, Archetype)
         and here.expr_ctx == ExprCtx.LOAD
         and self.evaluator._is_attr_receiver_name(here)
+        and not self.evaluator._is_runtime_local_name(here)
     );
     if here.sym is None or is_bare_field {
         self.evaluator.get_type_of_expression(here);

--- a/jac/jaclang/compiler/passes/impl/type_checker_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/impl/type_checker_pass.impl.jac
@@ -6,7 +6,18 @@ impl TypeCheckPass.exit_name with Name exit {
     if here.__class__ is not Name {
         return;
     }
-    if here.sym is None {
+    is_bare_field = (
+        here.sym is not None
+        and here.sym.sym_type == SymbolType.HAS_VAR
+        and isinstance(here.sym.parent_tab, Archetype)
+        and here.expr_ctx == ExprCtx.LOAD
+        and not (
+            isinstance(here.parent, AtomTrailer)
+            and here.parent.is_attr
+            and here.parent.right is here
+        )
+    );
+    if here.sym is None or is_bare_field {
         if isinstance(here.parent, AtomTrailer) and here.parent.right is here {
             return;
         }

--- a/jac/jaclang/compiler/passes/type_checker_pass.jac
+++ b/jac/jaclang/compiler/passes/type_checker_pass.jac
@@ -63,7 +63,7 @@ import from jaclang.compiler.frontend.unitree {
 }
 import from jaclang.compiler.passes.uni_pass { UniPass }
 import from jaclang.compiler.symbol_utils { return_type_is_jsx }
-import from jaclang.compiler.frontend.constant { Tokens as Tok }
+import from jaclang.compiler.frontend.constant { ExprCtx, SymbolType, Tokens as Tok }
 import from jaclang.compiler.frontend.diagnostics { E0033, E0108, E0109 }
 import from jaclang.compiler.types.ct_value { CT_DEFERRED, CtValue }
 import from jaclang.compiler.types.types {

--- a/jac/jaclang/compiler/types/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -1063,6 +1063,32 @@ impl TypeEvaluator._is_attr_receiver_name(expr: Name) -> bool {
     );
 }
 
+impl TypeEvaluator._is_runtime_local_name(expr: Name) -> bool {
+    scope = find_python_scope_node_of(expr);
+    if scope is None {
+        return False;
+    }
+    if expr.value in scope.implicit_rebinds {
+        return True;
+    }
+    for assignment in scope.get_all_sub_nodes(Assignment) {
+        if find_python_scope_node_of(assignment) is not scope {
+            continue;
+        }
+        for target in assignment.target {
+            if isinstance(target, Name) and target.value == expr.value {
+                return True;
+            }
+            for nested in target.get_all_sub_nodes(Name) {
+                if nested.value == expr.value {
+                    return True;
+                }
+            }
+        }
+    }
+    return False;
+}
+
 impl TypeEvaluator._lookup_bare_runtime_name(
     scope: UniScopeNode, name: str
 ) -> Symbol | None {

--- a/jac/jaclang/compiler/types/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -1038,14 +1038,28 @@ impl TypeEvaluator._resolution_scope_for(expr: UniNode) -> UniScopeNode | None {
     return scope;
 }
 
+impl TypeEvaluator._is_non_expression_name(expr: Name) -> bool {
+    return (
+        (isinstance(expr.parent, AtomTrailer) and expr.parent.right is expr)
+        or (
+            isinstance(expr.parent, HasVar)
+            and expr.parent.defer
+            and expr is not expr.parent.name
+        )
+        or (isinstance(expr.parent, KWPair) and expr.parent.key is expr)
+        or isinstance(expr.parent, SubTag)
+        or isinstance(expr.parent, ModulePath)
+        or isinstance(expr.parent, JsxElementName)
+        or (isinstance(expr.parent, ModuleCode) and expr.parent.name is expr)
+        or (isinstance(expr.parent, SemDef) and expr in expr.parent.target)
+    );
+}
+
 impl TypeEvaluator._lookup_bare_runtime_name(
     scope: UniScopeNode, name: str
 ) -> Symbol | None {
     cur: UniScopeNode | None = scope;
     while cur is not None {
-        # Python lexical lookup skips class bodies when resolving names used
-        # inside methods. Archetype fields therefore require an explicit
-        # receiver (`self.field`) and must not mask a module global.
         if not isinstance(cur, Archetype) {
             if isinstance(cur, Module) {
                 return lookup_symtab(cur, name, self.builtins_module);

--- a/jac/jaclang/compiler/types/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -1055,6 +1055,14 @@ impl TypeEvaluator._is_non_expression_name(expr: Name) -> bool {
     );
 }
 
+impl TypeEvaluator._is_attr_receiver_name(expr: Name) -> bool {
+    return (
+        isinstance(expr.parent, AtomTrailer)
+        and expr.parent.target is expr
+        and expr.parent.is_attr
+    );
+}
+
 impl TypeEvaluator._lookup_bare_runtime_name(
     scope: UniScopeNode, name: str
 ) -> Symbol | None {

--- a/jac/jaclang/compiler/types/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -1038,6 +1038,27 @@ impl TypeEvaluator._resolution_scope_for(expr: UniNode) -> UniScopeNode | None {
     return scope;
 }
 
+impl TypeEvaluator._lookup_bare_runtime_name(
+    scope: UniScopeNode, name: str
+) -> Symbol | None {
+    cur: UniScopeNode | None = scope;
+    while cur is not None {
+        # Python lexical lookup skips class bodies when resolving names used
+        # inside methods. Archetype fields therefore require an explicit
+        # receiver (`self.field`) and must not mask a module global.
+        if not isinstance(cur, Archetype) {
+            if isinstance(cur, Module) {
+                return lookup_symtab(cur, name, self.builtins_module);
+            }
+            if found := collect_member_syms(cur, name) {
+                return found[0];
+            }
+        }
+        cur = cur.parent_scope;
+    }
+    return None;
+}
+
 impl TypeEvaluator._is_expr_self(expr: Expr) -> bool {
     if (
         isinstance(expr, Name)

--- a/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
@@ -2053,20 +2053,12 @@ impl TypeEvaluator._get_type_of_expression_core(
 
             if scope := self._resolution_scope_for(expr) {
                 symbol = lookup_symtab(scope, expr.value, self.builtins_module);
-                is_attr_name = (
-                    isinstance(expr.parent, AtomTrailer)
-                    and expr.parent.is_attr
-                    and expr.parent.right is expr
-                );
                 if (
                     symbol is not None
                     and symbol.sym_type == SymbolType.HAS_VAR
                     and isinstance(symbol.parent_tab, Archetype)
-                    and not is_attr_name
+                    and not self._is_non_expression_name(expr)
                 ) {
-                    # A field found through the enclosing archetype is not a
-                    # runtime lexical binding. Retry while skipping archetype
-                    # scopes so a same-named local/global can still win.
                     expr.sym = None;
                     symbol = self._lookup_bare_runtime_name(scope, expr.value);
                 }

--- a/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
@@ -2058,6 +2058,7 @@ impl TypeEvaluator._get_type_of_expression_core(
                     and symbol.sym_type == SymbolType.HAS_VAR
                     and isinstance(symbol.parent_tab, Archetype)
                     and not self._is_non_expression_name(expr)
+                    and self._is_attr_receiver_name(expr)
                 ) {
                     expr.sym = None;
                     symbol = self._lookup_bare_runtime_name(scope, expr.value);

--- a/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
@@ -2059,6 +2059,7 @@ impl TypeEvaluator._get_type_of_expression_core(
                     and isinstance(symbol.parent_tab, Archetype)
                     and not self._is_non_expression_name(expr)
                     and self._is_attr_receiver_name(expr)
+                    and not self._is_runtime_local_name(expr)
                 ) {
                     expr.sym = None;
                     symbol = self._lookup_bare_runtime_name(scope, expr.value);

--- a/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
@@ -2053,6 +2053,23 @@ impl TypeEvaluator._get_type_of_expression_core(
 
             if scope := self._resolution_scope_for(expr) {
                 symbol = lookup_symtab(scope, expr.value, self.builtins_module);
+                is_attr_name = (
+                    isinstance(expr.parent, AtomTrailer)
+                    and expr.parent.is_attr
+                    and expr.parent.right is expr
+                );
+                if (
+                    symbol is not None
+                    and symbol.sym_type == SymbolType.HAS_VAR
+                    and isinstance(symbol.parent_tab, Archetype)
+                    and not is_attr_name
+                ) {
+                    # A field found through the enclosing archetype is not a
+                    # runtime lexical binding. Retry while skipping archetype
+                    # scopes so a same-named local/global can still win.
+                    expr.sym = None;
+                    symbol = self._lookup_bare_runtime_name(scope, expr.value);
+                }
 
                 if (
                     symbol is not None

--- a/jac/jaclang/compiler/types/type_evaluator.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.jac
@@ -112,7 +112,8 @@ import from jaclang.compiler.frontend.unitree {
     UniScopeNode,
     WhileStmt,
     WithStmt,
-    YieldExpr
+    YieldExpr,
+    find_python_scope_node_of
 }
 import from jaclang.compiler.frontend.constant {
     TOKEN_MAP,
@@ -600,6 +601,7 @@ walker TypeEvaluator {
     def _resolution_scope_for(expr: UniNode) -> UniScopeNode | None;
     def _is_non_expression_name(expr: Name) -> bool;
     def _is_attr_receiver_name(expr: Name) -> bool;
+    def _is_runtime_local_name(expr: Name) -> bool;
     def _lookup_bare_runtime_name(scope: UniScopeNode, name: str) -> Symbol | None;
     def _is_expr_self(expr: Expr) -> bool;
     def _is_expr_super(expr: Expr) -> bool;

--- a/jac/jaclang/compiler/types/type_evaluator.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.jac
@@ -75,6 +75,7 @@ import from jaclang.compiler.frontend.unitree {
     MatchStmt,
     MatchWild,
     Module,
+    ModuleCode,
     ModuleItem,
     ModulePath,
     MultiString,
@@ -90,6 +91,7 @@ import from jaclang.compiler.frontend.unitree {
     RaiseStmt,
     ReturnStmt,
     Semi,
+    SemDef,
     SetCompr,
     SetVal,
     Source,
@@ -596,6 +598,7 @@ walker TypeEvaluator {
     def resolve_imported_symbols(sym: Symbol) -> Symbol;
     def _set_symbol_to_expr(expr: NameAtom, sym: Symbol) -> TypeBase;
     def _resolution_scope_for(expr: UniNode) -> UniScopeNode | None;
+    def _is_non_expression_name(expr: Name) -> bool;
     def _lookup_bare_runtime_name(scope: UniScopeNode, name: str) -> Symbol | None;
     def _is_expr_self(expr: Expr) -> bool;
     def _is_expr_super(expr: Expr) -> bool;

--- a/jac/jaclang/compiler/types/type_evaluator.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.jac
@@ -596,6 +596,7 @@ walker TypeEvaluator {
     def resolve_imported_symbols(sym: Symbol) -> Symbol;
     def _set_symbol_to_expr(expr: NameAtom, sym: Symbol) -> TypeBase;
     def _resolution_scope_for(expr: UniNode) -> UniScopeNode | None;
+    def _lookup_bare_runtime_name(scope: UniScopeNode, name: str) -> Symbol | None;
     def _is_expr_self(expr: Expr) -> bool;
     def _is_expr_super(expr: Expr) -> bool;
     def _get_enclosing_function(nd: UniNode) -> Ability | None;

--- a/jac/jaclang/compiler/types/type_evaluator.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.jac
@@ -599,6 +599,7 @@ walker TypeEvaluator {
     def _set_symbol_to_expr(expr: NameAtom, sym: Symbol) -> TypeBase;
     def _resolution_scope_for(expr: UniNode) -> UniScopeNode | None;
     def _is_non_expression_name(expr: Name) -> bool;
+    def _is_attr_receiver_name(expr: Name) -> bool;
     def _lookup_bare_runtime_name(scope: UniScopeNode, name: str) -> Symbol | None;
     def _is_expr_self(expr: Expr) -> bool;
     def _is_expr_super(expr: Expr) -> bool;

--- a/jac/tests/compiler/passes/fixtures/checker/checker_bug_bare_field_name.jac
+++ b/jac/tests/compiler/passes/fixtures/checker/checker_bug_bare_field_name.jac
@@ -28,3 +28,12 @@ obj GlobalControl {
         return global_title.strip();
     }
 }
+
+node NodeWidget {
+    has node_title: str = "field";
+
+    def size -> int {
+        # Graph archetypes follow the same explicit-receiver rule.
+        return len(node_title.strip());
+    }
+}

--- a/jac/tests/compiler/passes/fixtures/checker/checker_bug_bare_field_name.jac
+++ b/jac/tests/compiler/passes/fixtures/checker/checker_bug_bare_field_name.jac
@@ -1,0 +1,30 @@
+glob global_title: str = "module";
+
+obj InlineWidget {
+    has inline_title: str = "field";
+
+    def size -> int {
+        # A field is not an implicit lexical binding inside a method.
+        return len(inline_title.strip());
+    }
+}
+
+obj AnnexWidget {
+    has annex_title: str = "field";
+
+    def size -> int;
+}
+
+impl AnnexWidget.size -> int {
+    # Annex methods must follow the same name-resolution rule.
+    return len(annex_title.strip());
+}
+
+obj GlobalControl {
+    has global_title: str = "field";
+
+    def read_global -> str {
+        # Runtime lexical lookup skips the field and finds the module global.
+        return global_title.strip();
+    }
+}

--- a/jac/tests/compiler/passes/fixtures/checker/checker_bug_bare_field_name.jac
+++ b/jac/tests/compiler/passes/fixtures/checker/checker_bug_bare_field_name.jac
@@ -29,6 +29,16 @@ obj GlobalControl {
     }
 }
 
+obj RebindControl {
+    has rebound_title: str = "field";
+
+    def size -> int {
+        # An assignment records this field as a valid implicit rebind.
+        rebound_title = "local";
+        return len(rebound_title.strip());
+    }
+}
+
 node NodeWidget {
     has node_title: str = "field";
 

--- a/jac/tests/compiler/passes/fixtures/checker/checker_bug_bare_field_name.jac
+++ b/jac/tests/compiler/passes/fixtures/checker/checker_bug_bare_field_name.jac
@@ -39,6 +39,21 @@ obj RebindControl {
     }
 }
 
+obj NestedRebindControl {
+    has nested_title: str = "field";
+
+    def size -> int;
+}
+
+impl NestedRebindControl.size -> int {
+    # A nested assignment still creates a function scope local.
+    if True {
+        nested_title = "local";
+        return len(nested_title.strip());
+    }
+    return 0;
+}
+
 node NodeWidget {
     has node_title: str = "field";
 

--- a/jac/tests/compiler/passes/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/test_checker_bugs.jac
@@ -92,6 +92,9 @@ Bug index:
                 declaration now binds the function local, so its annotation
                 also holds after the block and a sibling block redeclaring
                 the name collides with it (#8060)
+  #BAREFIELD-1 - bare names colliding with archetype fields resolved as if
+                 `self.` were implicit even though runtime lexical scope does
+                 not include archetype members (#8276)
   #TYPEIS-1 - a user-defined predicate returning TypeIs[T] or TypeGuard[T]
               narrowed nothing at its call sites; the checker knew the two
               names but resolved the annotation to nothing, and the CFG's
@@ -2007,5 +2010,27 @@ test "bug_selfovl1_receiver_selects_the_self_typed_overload" {
     );
     assert len(program.errors_had) == 0 , "\n".join(
         e.pretty_print() for e in program.errors_had
+    );
+}
+
+# =========================================================================
+# Bug #BAREFIELD-1 / #8276: archetype fields are members, not lexical names.
+# A bare field collision in an inline or annex method must remain Unknown so
+# the existing attribute-access diagnostic catches code that would otherwise
+# fail with NameError. A module global with the same name as a field remains a
+# valid lexical binding and is the negative control.
+# =========================================================================
+test "bug_barefield1_archetype_fields_require_self" {
+    program = compile_and_check("checker_bug_bare_field_name.jac");
+
+    e1032_lines = [
+        e.loc.first_line
+        for e in program.errors_had
+        if e.code and e.code.code == "E1032" and e.loc
+    ];
+    assert e1032_lines == [8, 20] , (
+        "Bug #BAREFIELD-1: inline and annex bare field reads must be Unknown, "
+        "while a same-named module global must still resolve. "
+        f"Got errors: {[str(e) for e in program.errors_had]}"
     );
 }

--- a/jac/tests/compiler/passes/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/test_checker_bugs.jac
@@ -2023,14 +2023,15 @@ test "bug_selfovl1_receiver_selects_the_self_typed_overload" {
 test "bug_barefield1_archetype_fields_require_self" {
     program = compile_and_check("checker_bug_bare_field_name.jac");
 
-    e1032_lines = [
-        e.loc.first_line
+    e1032_errors = [
+        str(e)
         for e in program.errors_had
-        if e.code and e.code.code == "E1032" and e.loc
+        if e.code and e.code.code == "E1032"
     ];
-    assert e1032_lines == [8, 20] , (
-        "Bug #BAREFIELD-1: inline and annex bare field reads must be Unknown, "
+    assert len(e1032_errors) == 3 , (
+        "Bug #BAREFIELD-1: obj, annex, and node bare field reads must be Unknown, "
         "while a same-named module global must still resolve. "
         f"Got errors: {[str(e) for e in program.errors_had]}"
     );
+    assert all('attribute "strip"' in err for err in e1032_errors);
 }

--- a/jac/tests/compiler/passes/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/test_checker_bugs.jac
@@ -2034,4 +2034,20 @@ test "bug_barefield1_archetype_fields_require_self" {
         f"Got errors: {[str(e) for e in program.errors_had]}"
     );
     assert all('attribute "strip"' in err for err in e1032_errors);
+    with open(
+        os.path.join(CHECKER_FIXTURES, "checker_bug_bare_field_name.jac")
+    ) as source {
+        lines = source.read().splitlines();
+    }
+    rejected_reads = {
+        lines[e.loc.first_line - 1].strip()
+        for e in program.errors_had
+        if e.code and e.code.code == "E1032" and e.loc
+    };
+    assert rejected_reads
+        == {
+            "return len(inline_title.strip());",
+            "return len(annex_title.strip());",
+            "return len(node_title.strip());"
+        } , f"Unexpected bare field diagnostics: {rejected_reads}";
 }

--- a/release_notes/unreleased/jaclang/8276.bugfix.md
+++ b/release_notes/unreleased/jaclang/8276.bugfix.md
@@ -1,0 +1,1 @@
+- Require explicit receivers for archetype field reads so bare field-name collisions are diagnosed instead of failing later with `NameError`.

--- a/release_notes/unreleased/jaclang/8276.bugfix.md
+++ b/release_notes/unreleased/jaclang/8276.bugfix.md
@@ -1,1 +1,0 @@
-- Require explicit receivers for archetype field reads so bare field-name collisions are diagnosed instead of failing later with `NameError`.

--- a/release_notes/unreleased/jaclang/8353.bugfix.md
+++ b/release_notes/unreleased/jaclang/8353.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Require explicit receivers for archetype field reads**: Bare field-name collisions are diagnosed instead of resolving as implicit members and failing later at runtime.


### PR DESCRIPTION
Refs #8276.

## What changed

Unassigned bare archetype fields used as attribute receivers, such as `title.strip()`, no longer resolve as implicit members. Lexical locals, module globals, imports, builtins, assigned fields, and reactive ability-owned state retain their bindings.

The rebase onto `3ad7d91b5` preserves main's walker-based checker hooks and compile-time and type-only use checks.

## Review follow-up

Added the requested `NestedRebindControl`: an annex method with a same-named local assignment inside an `if` block. The diagnostic assertion now identifies the inline, annex, and node field reads separately. Mutation validation proves the control fails when `_is_runtime_local_name` stops protecting assigned locals; normal checker tests pass.

This PR covers attribute receivers only. Standalone field reads, bare ability calls, and bare subscript receivers remain in #8466. That issue still reproduces on current main; its body now includes the subscript case and current validation. GitHub rejected my reopen attempt, so a maintainer needs to reopen it.

## Validation

- Checker regression suite: 80 passed.
- Mutation test with the runtime-local guard disabled: the new nested annex control fails as expected; production code was restored.
- `jac check` on `project/config.jac` and `scale/websocket/websocket.jac`: 2 passed.
- Full compiler-pass suite: 951 passed, 1 failed, 5 skipped.
- Matching main baseline: 950 passed, the same 1 failed, 5 skipped.
- The shared failure is `bug_cycimp1_reentrant_import_guard_returns_stub`, at the settled-module assertion. It passes in isolation on main and fails in the full suite on both revisions.
- Formatting and `git diff --check` pass.

The initial broader run also hit an outdated LLVM shim. Rebuilding the shim from current source removed the executable-link failures; the full-suite results above are from the corrected environment. The shared main failure and repository CI still need maintainer attention before merge.
