### PR TITLE
ci(release-dev): the rolling dev prerelease rebuilds nightly, not once per merge

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -7,7 +7,7 @@ name: Build jac native binaries
 #     GITHUB_TOKEN-created release emits no release.published event); the
 #     release event is the safety net for releases published by a real user.
 #   - channel=dev: cache-accelerated host-native builds re-published under the
-#     rolling `dev` prerelease. Called by release-dev.yml on pushes to main.
+#     rolling `dev` prerelease. Called by release-dev.yml on its nightly cron.
 
 on:
   workflow_call:

--- a/.github/workflows/macos-seal-probe.yml
+++ b/.github/workflows/macos-seal-probe.yml
@@ -17,7 +17,7 @@ name: macOS seal probe (one leg, no publish)
 #     exists on main.
 #
 # It rides the dev channel on purpose: host-native, cache-accelerated, ~12
-# minutes, and identical to what release-dev.yml runs on every push to main --
+# minutes, and identical to what release-dev.yml runs on its nightly cron --
 # so a green probe here is the same evidence the rolling build produces.
 
 on:

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,28 +1,25 @@
 name: Release jac dev binary (rolling main)
 
-# Rolling "dev" prerelease: pushes to main that touch the binary's inputs
-# rebuild the per-platform binaries and re-publish them under the single
-# force-moved `dev` tag, so .../releases/download/dev/jac-dev-<platform>
-# always maps to the last binary-relevant commit on main. The build itself
-# is build-binaries.yml on the dev channel (cached, host-native).
+# Rolling "dev" prerelease: once a night the tip of main is rebuilt into the
+# per-platform binaries and re-published under the single force-moved `dev`
+# tag, so .../releases/download/dev/jac-dev-<platform> always maps to a recent
+# commit on main. The build itself is build-binaries.yml on the dev channel
+# (cached, host-native).
+#
+# Nightly rather than per-merge: every push to main used to spend three runners
+# on a full rebuild, and nothing downstream needs the dev binary to track main
+# commit-for-commit. Use workflow_dispatch when a specific commit has to reach
+# the dev tag before the next cron.
 
 on:
-  push:
-    branches: [main]
-    # Non-jac pushes (docs, CI plumbing, scripts) cannot change the binary;
-    # skipping them keeps the dev tag pointing at the exact commit the
-    # published binaries were built from -- and stops three full rebuilds
-    # per docs-only merge.
-    paths:
-      - "jac/**"
-      - ".github/workflows/release-dev.yml"
-      - ".github/workflows/build-binaries.yml"
+  schedule:
+    - cron: '30 6 * * *'  # rolling dev binaries from the tip of main
   workflow_dispatch:
 
 permissions:
   contents: write
 
-# A newer push to main supersedes an in-flight dev build.
+# A manual dispatch supersedes an in-flight nightly build.
 concurrency:
   group: release-dev
   cancel-in-progress: true
@@ -44,7 +41,7 @@ jobs:
           set -euxo pipefail
           SHA="${GITHUB_SHA}"
           SHORT="${SHA:0:7}"
-          NOTES="Rolling build of \`main\` @ ${SHORT}. Auto-updated on every push to main; not a stable release."
+          NOTES="Rolling build of \`main\` @ ${SHORT}. Rebuilt nightly from the tip of main; not a stable release."
           git tag -f dev "$SHA"
           git push -f origin refs/tags/dev
           if gh release view dev >/dev/null 2>&1; then

--- a/jac/jaclang/cli/docs/community/codebase-guide.md
+++ b/jac/jaclang/cli/docs/community/codebase-guide.md
@@ -268,7 +268,7 @@ GitHub Actions workflows in `.github/workflows/`:
 | `ci.yml` | All PR/push checks: builds the `jac` binary once, then fans out the full test suite, client/scale jobs, lint + format enforcement, docs validation, contribution checks, and the installer/k8s e2e jobs (path-gated) |
 | `release.yml` | The release lifecycle: version-bump PRs, and on merge the tag + GitHub Release + binary publish (human-approved) |
 | `build-binaries.yml` | Builds the per-platform native `jac` binaries and attaches them to a release |
-| `release-dev.yml` | Rolling `dev` prerelease binaries on every push to main |
+| `release-dev.yml` | Rolling `dev` prerelease binaries, rebuilt nightly from main |
 | `nightly.yml` | Cron canaries: notes-app CEF smoke and the live-release installer check |
 
 Local git hooks come from `jac precommit --install`: a pre-commit hook that formats and lints staged `.jac` files, and a commit-msg hook that blocks AI co-author attribution. Markdown lint and the em-dash ban run on every PR via pre-commit.ci (`.pre-commit-config.yaml`).


### PR DESCRIPTION
## What

`release-dev.yml` fired on every push to `main` touching `jac/**`, so each merged PR force-moved the `dev` tag and spent three runners on a full per-platform rebuild. Nothing downstream needs the dev binary to track `main` commit-for-commit, so the trigger is now a nightly cron:

```yaml
on:
  schedule:
    - cron: '30 6 * * *'
  workflow_dispatch:
```

06:30 UTC is clear of `nightly.yml`'s existing 03:00 and 08:17 legs. Scheduled runs resolve to the default branch, so `GITHUB_SHA` is the tip of `main`. The `paths:` filter goes with the push trigger, and `workflow_dispatch` stays as the escape hatch when a specific commit has to reach the `dev` tag before the next cron.

## Why the build stays unconditional

An obvious refinement is to skip the build when no commits landed since the last run. It is wrong here: `prepare` force-moves the tag *before* `build` runs, so if a night's build failed, the tag would already sit on that commit and a "nothing new" skip would strand `dev` there with no self-heal. One unconditional build per night is cheap next to one per merge, and it always recovers.

## Consequence

`jac/jaclang/scale/injector/binary.jac` downloads `releases/download/dev/jac-dev-<platform>` for dev-channel deploys, so those binaries are now up to ~24h behind `main` instead of tracking the latest binary-relevant merge.

## Also

Three stale cross-references describing the old per-push cadence: `build-binaries.yml`'s channel comment, `macos-seal-probe.yml`'s note on what it mirrors, and the workflow table in `codebase-guide.md`.

PR CI is untouched: `ci.yml`'s `build-jac` still builds a `jac` binary per PR for the test lanes; that one is never published.