### PR TITLE
feat(compiler): GraphSchemaPass -- extract the relational graph schema from archetypes

### DIFF
--- a/jac/jaclang/cli/commands/db.jac
+++ b/jac/jaclang/cli/commands/db.jac
@@ -12,13 +12,16 @@ glob registry = get_registry();
             "action",
             kind=ArgKind.POSITIONAL,
             default="status",
-            help="Action: status, serve, stop, inspect, sql, fetch, list, drop, prune"
+            help="Action: status, serve, stop, inspect, sql, fetch, list, drop, prune, schema"
         ),
         Arg.create(
             "query",
             kind=ArgKind.POSITIONAL,
             default="",
-            help="SQL text (for `jac db sql`) or database name (for `jac db drop`)"
+            help=(
+                "SQL text (for `jac db sql`), database name (for `jac db drop`), "
+                "or .jac file (for `jac db schema`)"
+            )
         ),
         Arg.create(
             "data_dir",
@@ -55,6 +58,10 @@ glob registry = get_registry();
     examples=[
         ("jac db status", "Show the project store's server state and row counts"),
         ("jac db inspect", "Summarize anchors by kind and archetype"),
+        (
+            "jac db schema app.jac",
+            "Show the relational schema derived from the program's archetypes"
+        ),
         ("jac db sql \"SELECT count(*) FROM anchors\"", "Run one SQL statement"),
         ("jac db list", "List every jac database in the shared cluster"),
         ("jac db prune", "Report databases whose project is gone (drops nothing)"),

--- a/jac/jaclang/cli/commands/impl/db.impl.jac
+++ b/jac/jaclang/cli/commands/impl/db.impl.jac
@@ -15,7 +15,8 @@ enum DbAction(StrEnum) {
     FETCH = 'fetch',
     LIST = 'list',
     DROP = 'drop',
-    PRUNE = 'prune'
+    PRUNE = 'prune',
+    SCHEMA = 'schema'
 }
 
 
@@ -383,6 +384,136 @@ def _db_drop(data_dir: str, database: str, yes: bool) -> int {
 }
 
 
+def _schema_col(f: dict) -> str {
+    import from jaclang.jac0core.passes.graph_schema_pass { SCALAR_SQL }
+    tier = f.get('tier', 'json');
+    opt = '' if f.get('optional') else ' NOT NULL';
+    if tier == 'scalar' {
+        return f"{SCALAR_SQL.get(f.get('type'), 'text')}{opt}";
+    }
+    if tier == 'enum' {
+        return f"text{opt}  -- enum {f.get('target')}";
+    }
+    if tier == 'node_ref' {
+        return f"uuid{opt} REFERENCES nodes(id)  -- {f.get('target')}";
+    }
+    if tier == 'node_ref_list' {
+        return f"uuid[]{opt}  -- ordered {f.get('target')} refs";
+    }
+    if tier == 'scalar_list' {
+        return f"jsonb{opt}  -- {f.get('type')}";
+    }
+    if tier in ['obj', 'obj_list'] {
+        return f"jsonb{opt}  -- {f.get('target')} (side-table candidate)";
+    }
+    return f"jsonb{opt}";
+}
+
+
+def _render_edge_line(name: str, spec: dict) -> str {
+    declared = spec.get('declared');
+    observed = spec.get('observed') or [];
+    parts: list[str] = [];
+    if declared {
+        parts.append(
+            f"declared {declared.get('src') or '?'} -> {declared.get('dst') or '?'}"
+        );
+    }
+    if observed {
+        obs = ", ".join(f"{s or '?'} -> {d or '?'}" for (s, d) in observed);
+        parts.append(f"observed {obs}");
+    }
+    if not parts {
+        parts.append("no endpoints known");
+    }
+    open_mark = '';
+    if any((s is None or d is None) for (s, d) in observed) {
+        open_mark = '  [open]';
+    }
+    und = '  [undirected seen]' if spec.get('undirected_seen') else '';
+    return f"  {name}: {'; '.join(parts)}{open_mark}{und}";
+}
+
+
+def _db_schema(target: str) -> int {
+    import json;
+    if not target {
+        console.error("usage: jac db schema <file.jac>");
+        return 1;
+    }
+    path = str(Path(target).expanduser().resolve());
+    if not Path(path).is_file() {
+        console.error(f"no such file: {target}");
+        return 1;
+    }
+    import from jaclang.jac0core.program { JacProgram }
+    import from jaclang.jac0core.compiler { get_boundary_analysis_sched }
+    prog = JacProgram();
+    prev_errors = len(prog.errors_had);
+    try {
+        prog.compile(path);
+    } except Exception as e {
+        console.error(f"compile failed: {e}");
+        return 1;
+    }
+    if len(prog.errors_had) > prev_errors {
+        for e in prog.errors_had[prev_errors:] {
+            console.error(str(e));
+        }
+        return 1;
+    }
+    mod = prog.find_module(path);
+    if mod is None {
+        console.error(f"module not found after compile: {path}");
+        return 1;
+    }
+    man = mod.gen.interop_manifest;
+    if man and not man.graph_schema {
+        try {
+            prog.run_schedule(mod, get_boundary_analysis_sched());
+        } except Exception {
+            ;
+        }
+    }
+    gs = man.graph_schema if man else {};
+    if not gs {
+        console.print("no graph schema (module declares no archetypes)");
+        return 0;
+    }
+    nodes = gs.get('nodes', {});
+    edges = gs.get('edges', {});
+    objs = gs.get('objs', {});
+    console.print(f"Graph schema for {target} (module {gs.get('module')})");
+    console.print(f"\nNode tables ({len(nodes)}):");
+    for (name, spec) in nodes.items() {
+        bases = spec.get('bases') or [];
+        suffix = f"  -- extends {', '.join(bases)}" if bases else '';
+        console.print(f"  n_{name.lower()} (id uuid PK -> nodes(id)){suffix}");
+        for f in spec.get('fields', []) {
+            console.print(f"    {f.get('name'):<20} {_schema_col(f)}");
+        }
+    }
+    console.print(f"\nEdge relations ({len(edges)}) -> one edges table:");
+    for (name, spec) in edges.items() {
+        console.print(_render_edge_line(name, spec));
+        for f in spec.get('fields', []) {
+            console.print(f"    {f.get('name'):<20} {_schema_col(f)} (props)");
+        }
+    }
+    if objs {
+        console.print(f"\nEmbedded objects ({len(objs)}):");
+        for (name, spec) in objs.items() {
+            kind = 'flat scalar -> side table' if spec.get('flat_scalar') else 'jsonb';
+            console.print(f"  {name} ({kind})");
+            for f in spec.get('fields', []) {
+                console.print(f"    {f.get('name'):<20} {_schema_col(f)}");
+            }
+        }
+    }
+    return 0;
+}
+
+
 impl db(
     action: str = "status",
     query: str = "",
@@ -395,6 +526,9 @@ impl db(
     if verb is None {
         console.error(f"unknown action: {action}");
         return 1;
+    }
+    if verb == DbAction.SCHEMA {
+        return _db_schema(query);
     }
     if verb == DbAction.SERVE {
         return _db_serve(data_dir, port);

--- a/jac/jaclang/cli/impl/manifest.impl.jac
+++ b/jac/jaclang/cli/impl/manifest.impl.jac
@@ -652,6 +652,10 @@ def _command_routes -> list[CommandMeta] {
                     "Show the project store's server state and row counts"
                 ),
                 ('jac db inspect', 'Summarize anchors by kind and archetype'),
+                (
+                    'jac db schema app.jac',
+                    "Show the relational schema derived from the program's archetypes"
+                ),
                 ('jac db sql "SELECT count(*) FROM anchors"', 'Run one SQL statement'),
                 ('jac db list', 'List every jac database in the shared cluster'),
                 (
@@ -675,13 +679,13 @@ def _command_routes -> list[CommandMeta] {
                     name='action',
                     kind=ArgKind.POSITIONAL,
                     default='status',
-                    help='Action: status, serve, stop, inspect, sql, fetch, list, drop, prune'
+                    help='Action: status, serve, stop, inspect, sql, fetch, list, drop, prune, schema'
                 ),
                 ArgMeta(
                     name='query',
                     kind=ArgKind.POSITIONAL,
                     default='',
-                    help='SQL text (for `jac db sql`) or database name (for `jac db drop`)'
+                    help='SQL text (for `jac db sql`), database name (for `jac db drop`), or .jac file (for `jac db schema`)'
                 ),
                 ArgMeta(
                     name='data_dir',

--- a/jac/jaclang/jac0core/codeinfo.jac
+++ b/jac/jaclang/jac0core/codeinfo.jac
@@ -552,6 +552,7 @@ obj InteropManifest {
     has bindings: dict[(str, InteropBinding)] = field(default_factory=`dict),
         boundary_types: dict[(str, BoundaryTypeInfo)] = field(default_factory=`dict),
         endpoint_effects: dict[(str, dict)] = field(default_factory=`dict),
+        graph_schema: dict = field(default_factory=`dict),
         func_access: dict[(str, bool)] = field(default_factory=`dict),
         walker_access: dict[(str, bool)] = field(default_factory=`dict),
         native_module_imports: dict[(str, NativeModuleInfo)] = field(

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -33,6 +33,7 @@ import from jaclang.jac0core.passes {
     BoundaryAnalysisPass,
     DeclImplMatchPass,
     EndpointEffectPass,
+    GraphSchemaPass,
     JacAnnexPass,
     JcirBytecodeGenPass,
     JcirGenPass,
@@ -419,7 +420,8 @@ def import_error_re_enters(err: BaseException, file_path: str) -> (str | None) {
 
 def get_boundary_analysis_sched -> list[type[Transform]] {
     return validate_schedule(
-        [BoundaryAnalysisPass, EndpointEffectPass], origin='boundary-analysis schedule'
+        [BoundaryAnalysisPass, EndpointEffectPass, GraphSchemaPass],
+        origin='boundary-analysis schedule'
     );
 }
 

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -644,6 +644,7 @@ impl JacCompiler._build_interop_dict(result: uni.Module) -> dict {
     interop_data['func_access'] = dict(manifest.func_access);
     interop_data['walker_access'] = dict(manifest.walker_access);
     interop_data['endpoint_effects'] = dict(manifest.endpoint_effects);
+    interop_data['graph_schema'] = dict(manifest.graph_schema);
     return interop_data;
 }
 
@@ -672,6 +673,7 @@ impl JacCompiler._deserialize_interop_table(
     manifest.func_access.update(cached_interop.get('func_access', {}));
     manifest.walker_access.update(cached_interop.get('walker_access', {}));
     manifest.endpoint_effects.update(cached_interop.get('endpoint_effects', {}));
+    manifest.graph_schema.update(cached_interop.get('graph_schema', {}));
     return manifest;
 }
 

--- a/jac/jaclang/jac0core/passes/__init__.py
+++ b/jac/jaclang/jac0core/passes/__init__.py
@@ -17,6 +17,7 @@ from jaclang.jac0core.passes.ast_validation_pass import ASTValidationPass
 from jaclang.jac0core.passes.boundary_analysis_pass import BoundaryAnalysisPass
 from jaclang.jac0core.passes.decl_impl_match_pass import DeclImplMatchPass
 from jaclang.jac0core.passes.endpoint_effect_pass import EndpointEffectPass
+from jaclang.jac0core.passes.graph_schema_pass import GraphSchemaPass
 from jaclang.jac0core.passes.jcir_bc_gen_pass import JcirBytecodeGenPass
 from jaclang.jac0core.passes.jcir_gen_pass import JcirGenPass
 from jaclang.jac0core.passes.module_codegen_pass import ModuleCodegenPass
@@ -47,5 +48,6 @@ __all__ = [
     "BoundaryAnalysisPass",
     "PlacementApplyPass",
     "EndpointEffectPass",
+    "GraphSchemaPass",
     "ModuleCodegenPass",
 ]

--- a/jac/jaclang/jac0core/passes/graph_schema_pass.jac
+++ b/jac/jaclang/jac0core/passes/graph_schema_pass.jac
@@ -1,0 +1,404 @@
+"""Graph schema extraction.
+
+Derives the relational shape of a module's graph from what the program
+already declares: node/edge/obj archetypes with typed `has` fields, declared
+edge endpoints (`edge E: Src -> Tgt`), and — for edges declared without
+endpoints — the endpoint types observed at every connect site (`ConnectOp`).
+
+The result is written to `ir_in.gen.interop_manifest.graph_schema` as a
+plain JSON-serializable dict so it travels with the compiled module and the
+.jir cache, and can be consumed by the store (DDL derivation) and the query
+planner (join maps, untyped-hop pruning).
+
+Endpoint inference is best-effort by design: an operand whose static type
+cannot be resolved records `None` (an open endpoint). Consumers must treat
+an edge with any open observation as connecting unknown node types — this
+degrades planning, never correctness.
+"""
+
+import from jaclang.jac0core.unitree {
+    Ability,
+    Archetype,
+    AstSymbolNode,
+    AtomTrailer,
+    AtomUnit,
+    BinaryExpr,
+    ConnectOp,
+    EventSignature,
+    Expr,
+    FuncCall,
+    HasVar,
+    IndexSlice,
+    Name,
+    Null,
+    SpecialVarRef,
+    Token,
+    UniNode
+}
+import from jaclang.jac0core.constant { EdgeDir, SymbolType, Tokens as Tok }
+import from jaclang.jac0core.passes.uni_pass { UniPass }
+
+glob SCALAR_SQL: dict[str, str] = {
+         'str': 'text',
+         'int': 'bigint',
+         'float': 'double precision',
+         'bool': 'boolean',
+         'bytes': 'bytea',
+         'UUID': 'uuid',
+         'datetime': 'timestamptz',
+         'date': 'date',
+         'time': 'time',
+         'timedelta': 'interval',
+         'Decimal': 'numeric'
+     },
+     GENERIC_EDGE = 'GenericEdge',
+     ROOT_NODE = 'Root';
+
+
+class GraphSchemaPass(UniPass) {
+    def before_pass(self: GraphSchemaPass) {
+        self._nodes: dict[str, dict] = {};
+        self._edges: dict[str, dict] = {};
+        self._objs: dict[str, dict] = {};
+    }
+
+    def enter_archetype(self: GraphSchemaPass, nd: Archetype) -> None {
+        # arch_kind is None for obj/class archetypes, so key off the token
+        kind = nd.arch_type.name;
+        if kind not in [Tok.KW_NODE, Tok.KW_EDGE, Tok.KW_OBJECT, Tok.KW_CLASS] {
+            return;
+        }
+        if not isinstance(nd.name, Name) {
+            return;
+        }
+        spec = {
+            'module': self.ir_in.name,
+            'bases': self._base_names(nd),
+            'fields': [self._field_spec(hv) for hv in nd.get_has_vars()]
+        };
+        if kind == Tok.KW_NODE {
+            self._nodes[nd.name.sym_name] = spec;
+        } elif kind == Tok.KW_EDGE {
+            spec['declared'] = self._declared_endpoints(nd);
+            spec['observed'] = [];
+            spec['undirected_seen'] = False;
+            self._edges[nd.name.sym_name] = spec;
+        } else {
+            fields = spec['fields'];
+            spec['flat_scalar'] = bool(fields)
+                and all(f['tier'] in ['scalar', 'enum'] for f in fields);
+            self._objs[nd.name.sym_name] = spec;
+        }
+    }
+
+    def enter_binary_expr(self: GraphSchemaPass, nd: BinaryExpr) -> None {
+        if not isinstance(nd.op, ConnectOp) {
+            return;
+        }
+        edge_name = GENERIC_EDGE;
+        conn = nd.op.conn_type;
+        if conn is not None {
+            named = self._expr_type_name(conn);
+            if named {
+                edge_name = named;
+            }
+        }
+        entry = self._edges.get(edge_name);
+        if entry is None {
+            entry = {
+                'module': self.ir_in.name,
+                'bases': [],
+                'fields': [],
+                'declared': None,
+                'observed': [],
+                'undirected_seen': False
+            };
+            self._edges[edge_name] = entry;
+        }
+        left = self._node_type_of(nd.left);
+        right = self._node_type_of(nd.right);
+        if nd.op.edge_dir == EdgeDir.IN {
+            (src, dst) = (right, left);
+        } else {
+            (src, dst) = (left, right);
+        }
+        if nd.op.edge_dir == EdgeDir.ANY {
+            entry['undirected_seen'] = True;
+        }
+        pair = [src, dst];
+        if pair not in entry['observed'] {
+            entry['observed'].append(pair);
+        }
+    }
+
+    def after_pass(self: GraphSchemaPass) {
+        if not (self._nodes or self._edges or self._objs) {
+            return;
+        }
+        self.ir_in.gen.interop_manifest.graph_schema = {
+            'version': 1,
+            'module': self.ir_in.name,
+            'nodes': self._nodes,
+            'edges': self._edges,
+            'objs': self._objs
+        };
+    }
+
+    # ------------------------------------------------------------------
+    # declaration side
+
+    def _base_names(self: GraphSchemaPass, nd: Archetype) -> list[str] {
+        out: list[str] = [];
+        for b in (nd.base_classes or []) {
+            named = self._expr_type_name(b);
+            if named {
+                out.append(named);
+            }
+        }
+        return out;
+    }
+
+    def _declared_endpoints(self: GraphSchemaPass, nd: Archetype) -> (dict | None) {
+        if nd.src_endpoint is None and nd.tgt_endpoint is None {
+            return None;
+        }
+        return {
+            'src': self._expr_type_name(nd.src_endpoint),
+            'dst': self._expr_type_name(nd.tgt_endpoint)
+        };
+    }
+
+    def _field_spec(self: GraphSchemaPass, hv: HasVar) -> dict {
+        ann = hv.type_tag.tag if hv.type_tag else None;
+        info = self._classify_type(ann);
+        info['name'] = hv.name.sym_name;
+        info['has_default'] = hv.value is not None or hv.defer;
+        return info;
+    }
+
+    # Classify a type annotation into a storage tier:
+    #   scalar        -> typed column (SCALAR_SQL)
+    #   enum          -> text column
+    #   node_ref      -> uuid FK column into the node directory
+    #   node_ref_list -> uuid[] column
+    #   obj           -> flattenable side-table candidate (jsonb otherwise)
+    #   json          -> jsonb column (dicts, unions, unresolved, `any`)
+    def _classify_type(self: GraphSchemaPass, ann: (Expr | None)) -> dict {
+        out = {'tier': 'json', 'type': 'any', 'target': None, 'optional': False};
+        while isinstance(ann, AtomUnit) {
+            ann = ann.value;
+        }
+        if ann is None or not isinstance(ann, Expr) {
+            return out;
+        }
+        # unwrap (X | None) into optional X; wider unions stay json
+        if isinstance(ann, BinaryExpr)
+            and isinstance(ann.op, Token)
+            and ann.op.name == Tok.BW_OR {
+            parts = self._union_parts(ann);
+            non_null = [
+                p
+                for p in parts
+                if not self._is_null_expr(p)
+            ];
+            if len(non_null) == 1 and len(parts) > len(non_null) {
+                inner = self._classify_type(non_null[0]);
+                inner['optional'] = True;
+                return inner;
+            }
+            out['type'] = 'union';
+            return out;
+        }
+        if isinstance(ann, AtomTrailer) {
+            return self._classify_subscript(ann, out);
+        }
+        named = self._expr_type_name(ann);
+        if not named {
+            return out;
+        }
+        out['type'] = named;
+        if named in SCALAR_SQL {
+            out['tier'] = 'scalar';
+            return out;
+        }
+        if named == 'None' {
+            out['optional'] = True;
+            return out;
+        }
+        sym = self._resolve_symbol(ann);
+        if sym is None {
+            return out;
+        }
+        if sym.sym_type == SymbolType.NODE_ARCH {
+            out['tier'] = 'node_ref';
+            out['target'] = named;
+        } elif sym.sym_type == SymbolType.EDGE_ARCH {
+            out['tier'] = 'edge_ref';
+            out['target'] = named;
+        } elif sym.sym_type == SymbolType.ENUM_ARCH {
+            out['tier'] = 'enum';
+            out['target'] = named;
+        } elif sym.sym_type == SymbolType.OBJECT_ARCH {
+            out['tier'] = 'obj';
+            out['target'] = named;
+        }
+        return out;
+    }
+
+    def _classify_subscript(
+        self: GraphSchemaPass, ann: AtomTrailer, out: dict
+    ) -> dict {
+        base = self._expr_type_name(ann.target);
+        if not base or not isinstance(ann.right, IndexSlice) {
+            return out;
+        }
+        out['type'] = base;
+        if base not in ['list', 'set'] {
+            return out;
+        }
+        slices = ann.right.slices;
+        if len(slices) != 1 or slices[0].start is None {
+            return out;
+        }
+        elem = self._classify_type(slices[0].start);
+        if elem['tier'] == 'node_ref' {
+            out['tier'] = 'node_ref_list';
+            out['target'] = elem['target'];
+        } elif elem['tier'] == 'scalar' {
+            out['tier'] = 'scalar_list';
+            out['type'] = f"{base}[{elem['type']}]";
+        } elif elem['tier'] == 'obj' {
+            out['tier'] = 'obj_list';
+            out['target'] = elem['target'];
+        }
+        return out;
+    }
+
+    def _is_null_expr(self: GraphSchemaPass, nd: Expr) -> bool {
+        if isinstance(nd, Null) {
+            return True;
+        }
+        return isinstance(nd, Name) and nd.sym_name == 'None';
+    }
+
+    def _union_parts(self: GraphSchemaPass, nd: Expr) -> list[Expr] {
+        if isinstance(nd, BinaryExpr)
+            and isinstance(nd.op, Token)
+            and nd.op.name == Tok.BW_OR {
+            return self._union_parts(nd.left) + self._union_parts(nd.right);
+        }
+        return [nd];
+    }
+
+    # ------------------------------------------------------------------
+    # connect-site side
+
+    def _node_type_of(self: GraphSchemaPass, operand: (Expr | None)) -> (str | None) {
+        if operand is None {
+            return None;
+        }
+        # chained connect: the value of `a ++> b` is its target side
+        if isinstance(operand, BinaryExpr) and isinstance(operand.op, ConnectOp) {
+            return self._node_type_of(operand.right);
+        }
+        if isinstance(operand, FuncCall) {
+            sym = self._resolve_symbol(operand.target);
+            if sym and sym.sym_type == SymbolType.NODE_ARCH {
+                return sym.sym_name;
+            }
+            return None;
+        }
+        if isinstance(operand, SpecialVarRef) {
+            if operand.sym_name == 'root' {
+                return ROOT_NODE;
+            }
+            if operand.sym_name == 'self' {
+                arch = self._enclosing_archetype(operand);
+                if arch and arch.arch_kind == 'node' and isinstance(arch.name, Name) {
+                    return arch.name.sym_name;
+                }
+                return None;
+            }
+            if operand.sym_name == 'here' {
+                return self._here_type(operand);
+            }
+            return None;
+        }
+        if isinstance(operand, Name) {
+            sym = self._resolve_symbol(operand);
+            if sym and sym.sym_type == SymbolType.NODE_ARCH {
+                return sym.sym_name;
+            }
+        }
+        return None;
+    }
+
+    def _here_type(self: GraphSchemaPass, nd: UniNode) -> (str | None) {
+        cursor = nd.parent;
+        while cursor is not None and not isinstance(cursor, Ability) {
+            cursor = cursor.parent;
+        }
+        if cursor is None {
+            return None;
+        }
+        sig = cursor.signature;
+        if isinstance(sig, EventSignature) and isinstance(sig.arch_tag_info, Name) {
+            named = sig.arch_tag_info.sym_name;
+            return ROOT_NODE if named == 'root' else named;
+        }
+        return None;
+    }
+
+    def _enclosing_archetype(self: GraphSchemaPass, nd: UniNode) -> (Archetype | None) {
+        cursor = nd.parent;
+        while cursor is not None and not isinstance(cursor, Archetype) {
+            cursor = cursor.parent;
+        }
+        return cursor;
+    }
+
+    # ------------------------------------------------------------------
+    # shared helpers
+
+    def _expr_type_name(self: GraphSchemaPass, e: (Expr | None)) -> (str | None) {
+        if e is None {
+            return None;
+        }
+        if isinstance(e, Name) {
+            return e.sym_name;
+        }
+        if isinstance(e, FuncCall) {
+            return self._expr_type_name(e.target);
+        }
+        if isinstance(e, AtomTrailer) {
+            attrs = e.as_attr_list;
+            if attrs {
+                last = attrs[-1];
+                if isinstance(last, AstSymbolNode) {
+                    return last.sym_name;
+                }
+            }
+        }
+        return None;
+    }
+
+    def _resolve_symbol(self: GraphSchemaPass, e: (Expr | None)) -> (object | None) {
+        if isinstance(e, Name) {
+            sym = e.sym;
+            if not sym and e.sym_tab {
+                sym = e.sym_tab.lookup(e.sym_name, deep=True);
+            }
+            return sym;
+        }
+        if isinstance(e, AtomTrailer) {
+            attrs = e.as_attr_list;
+            if attrs {
+                last = attrs[-1];
+                if isinstance(last, AstSymbolNode) and last.sym {
+                    return last.sym;
+                }
+            }
+        }
+        return None;
+    }
+}

--- a/jac/tests/compiler/test_graph_schema_pass.jac
+++ b/jac/tests/compiler/test_graph_schema_pass.jac
@@ -1,0 +1,133 @@
+"""Graph schema extraction (GraphSchemaPass).
+
+The relational shape of a module's graph is derived from what the program
+already declares: node/edge/obj archetypes with typed `has` fields, declared
+edge endpoints (`edge E: Src --> Tgt`), and connect sites for edges declared
+without endpoints. The result lands in interop_manifest.graph_schema and is
+JSON-serializable so it can travel with the .jir cache.
+"""
+
+import json;
+import os;
+import tempfile;
+import from jaclang.jac0core.program { JacProgram }
+
+glob FIXTURE = (
+         "obj Settings {\n"
+         "    has theme: str = \"light\",\n"
+         "        lang: str = \"en\";\n"
+         "}\n"
+         "obj Payload {\n"
+         "    has data: dict = {},\n"
+         "        note: str = \"\";\n"
+         "}\n"
+         "node Profile {\n"
+         "    has username: str = \"\",\n"
+         "        followers: int = 0,\n"
+         "        settings: (Settings | None) = None,\n"
+         "        payload: Payload = Payload(),\n"
+         "        best_friend: (Tweet | None) = None;\n"
+         "}\n"
+         "node Tweet {\n"
+         "    has content: str = \"\",\n"
+         "        embedding: list[float] = [];\n"
+         "}\n"
+         "node Comment {\n"
+         "    has content: str = \"\";\n"
+         "}\n"
+         "edge Follow {}\n"
+         "edge Post: Profile --> Tweet {}\n"
+         "edge Like {\n"
+         "    has weight: float = 1.0;\n"
+         "}\n"
+         "walker add_profile {\n"
+         "    can build with `root entry {\n"
+         "        p = here ++> Profile(username=\"a\");\n"
+         "    }\n"
+         "}\n"
+         "walker interact {\n"
+         "    can act with Profile entry {\n"
+         "        t = Profile(username=\"b\") +>:Post():+> Tweet(content=\"hi\");\n"
+         "        here +>:Follow():+> Profile(username=\"c\");\n"
+         "        here +>:Like(weight=2.0):+> t[0];\n"
+         "        c = Comment(content=\"x\");\n"
+         "        here ++> c;\n"
+         "    }\n"
+         "}\n"
+     );
+
+
+def compile_fixture -> dict {
+    tmp = tempfile.mkdtemp(prefix="jac_graph_schema_");
+    path = os.path.join(tmp, "gsfix.jac");
+    with open(path, "w") as f {
+        f.write(FIXTURE);
+    }
+    prog = JacProgram();
+    mod = prog.compile(path);
+    assert not prog.errors_had , (
+        f"fixture must compile clean: {[str(e) for e in prog.errors_had]}"
+    );
+    return mod.gen.interop_manifest.graph_schema;
+}
+
+
+def field_map(spec: dict) -> dict {
+    return {f['name']: f for f in spec['fields']};
+}
+
+
+test "node has-fields classify into storage tiers" {
+    gs = compile_fixture();
+    assert set(gs['nodes'].keys()) == {'Profile', 'Tweet', 'Comment'};
+    prof = field_map(gs['nodes']['Profile']);
+    assert prof['username']['tier'] == 'scalar' and prof['username']['type'] == 'str';
+    assert prof['followers']['tier'] == 'scalar';
+    assert prof['settings']['tier'] == 'obj' and prof['settings']['optional'];
+    assert prof['settings']['target'] == 'Settings';
+    assert prof['payload']['tier'] == 'obj' and not prof['payload']['optional'];
+    assert prof['best_friend']['tier'] == 'node_ref';
+    assert prof['best_friend']['target'] == 'Tweet';
+    assert prof['best_friend']['optional'];
+    tweet = field_map(gs['nodes']['Tweet']);
+    assert tweet['embedding']['tier'] == 'scalar_list';
+}
+
+test "declared edge endpoints are authoritative and observations corroborate" {
+    gs = compile_fixture();
+    post = gs['edges']['Post'];
+    assert post['declared'] == {'src': 'Profile', 'dst': 'Tweet'};
+    assert ['Profile', 'Tweet'] in post['observed'];
+}
+
+test "undeclared edges get endpoints observed at connect sites" {
+    gs = compile_fixture();
+    follow = gs['edges']['Follow'];
+    assert follow['declared'] is None;
+    assert ['Profile', 'Profile'] in follow['observed'];
+
+    # `t[0]` is not statically resolvable: the destination must stay open,
+    # never guessed.
+    like = gs['edges']['Like'];
+    assert ['Profile', None] in like['observed'];
+    lf = field_map(like);
+    assert lf['weight']['tier'] == 'scalar';
+}
+
+test "bare ++> records against GenericEdge including root sources" {
+    gs = compile_fixture();
+    gen = gs['edges']['GenericEdge'];
+    assert ['Root', 'Profile'] in gen['observed'];
+    assert ['Profile', None] in gen['observed'];
+}
+
+test "objs report flat_scalar for side-table eligibility" {
+    gs = compile_fixture();
+    assert gs['objs']['Settings']['flat_scalar'];
+    assert not gs['objs']['Payload']['flat_scalar'];
+}
+
+test "graph schema is json-serializable for the jir cache" {
+    gs = compile_fixture();
+    assert json.loads(json.dumps(gs)) == gs;
+}


### PR DESCRIPTION
Part of the relational-schema program (RFC: jaseci-labs/jac#8357). This is the first of four PRs; they are **not GitHub-stacked** — each targets `main` and is meant to merge **in order** (this one, then relational-shadow-store, relational-read-path, relational-read-fusion). Until the earlier ones merge, a later PR's diff shows the cumulative history.

## What

New compiler pass `GraphSchemaPass` (jac0core, boundary-analysis schedule after `EndpointEffectPass`) that derives the **relational schema of a program's graph** from what it already declares, plus a `jac db schema <file.jac>` command to inspect it.

## Why

Persistence today is one monolithic `anchors` table: every node/edge of every type is one row, archetype fields live in a `props` jsonb blob, and relationality is two self-referencing uuid columns. The type system's knowledge that `Follow` connects `Profile -> Profile` exists nowhere in the schema. This pass extracts exactly that so later stages can store into real per-type tables. Full design and rationale: #8357.

## What it derives

- **Per-archetype table specs** from `has` declarations, one storage tier per field: scalar column, `uuid` FK for node/edge references, side-table candidate for flat-scalar objs, jsonb for dynamic/union/`any`.
- **Edge endpoint relations**: declared endpoints (`edge Post: Profile --> Tweet`) are authoritative; undeclared edges accumulate observed `(src, dst)` pairs from every `ConnectOp` site. Unresolvable operands record an **open** endpoint, never a guess. Bare `++>` records against `GenericEdge`.

Output lands in `interop_manifest.graph_schema` (plain JSON) and is persisted through the `.jir` interop dict on build and restore.

## Safety

**Inert until consumed** — nothing reads `graph_schema` in this PR, so no runtime behavior changes.

## Testing

6 tests in `jac/tests/compiler/test_graph_schema_pass.jac`. Note: the CLI route manifest was hand-synced for the `db schema` metadata (`gen-cli-manifest` needs the native LLVM shim); re-run it where the toolchain exists if parity flags it.
