### PR TITLE
feat(store): relational shadow store -- dual-write typed tables in the anchors txn

### DIFF
--- a/jac/jaclang/cli/commands/db.jac
+++ b/jac/jaclang/cli/commands/db.jac
@@ -12,13 +12,16 @@ glob registry = get_registry();
             "action",
             kind=ArgKind.POSITIONAL,
             default="status",
-            help="Action: status, serve, stop, inspect, sql, fetch, list, drop, prune"
+            help="Action: status, serve, stop, inspect, sql, fetch, list, drop, prune, schema"
         ),
         Arg.create(
             "query",
             kind=ArgKind.POSITIONAL,
             default="",
-            help="SQL text (for `jac db sql`) or database name (for `jac db drop`)"
+            help=(
+                "SQL text (for `jac db sql`), database name (for `jac db drop`), "
+                "or .jac file (for `jac db schema`)"
+            )
         ),
         Arg.create(
             "data_dir",
@@ -55,6 +58,10 @@ glob registry = get_registry();
     examples=[
         ("jac db status", "Show the project store's server state and row counts"),
         ("jac db inspect", "Summarize anchors by kind and archetype"),
+        (
+            "jac db schema app.jac",
+            "Show the relational schema derived from the program's archetypes"
+        ),
         ("jac db sql \"SELECT count(*) FROM anchors\"", "Run one SQL statement"),
         ("jac db list", "List every jac database in the shared cluster"),
         ("jac db prune", "Report databases whose project is gone (drops nothing)"),

--- a/jac/jaclang/cli/commands/db.jac
+++ b/jac/jaclang/cli/commands/db.jac
@@ -12,7 +12,7 @@ glob registry = get_registry();
             "action",
             kind=ArgKind.POSITIONAL,
             default="status",
-            help="Action: status, serve, stop, inspect, sql, fetch, list, drop, prune, schema"
+            help="Action: status, serve, stop, inspect, sql, fetch, list, drop, prune, schema, parity"
         ),
         Arg.create(
             "query",
@@ -61,6 +61,10 @@ glob registry = get_registry();
         (
             "jac db schema app.jac",
             "Show the relational schema derived from the program's archetypes"
+        ),
+        (
+            "jac db parity",
+            "Check the relational shadow tables against the anchors table"
         ),
         ("jac db sql \"SELECT count(*) FROM anchors\"", "Run one SQL statement"),
         ("jac db list", "List every jac database in the shared cluster"),

--- a/jac/jaclang/cli/commands/impl/db.impl.jac
+++ b/jac/jaclang/cli/commands/impl/db.impl.jac
@@ -15,7 +15,8 @@ enum DbAction(StrEnum) {
     FETCH = 'fetch',
     LIST = 'list',
     DROP = 'drop',
-    PRUNE = 'prune'
+    PRUNE = 'prune',
+    SCHEMA = 'schema'
 }
 
 
@@ -383,6 +384,136 @@ def _db_drop(data_dir: str, database: str, yes: bool) -> int {
 }
 
 
+def _schema_col(f: dict) -> str {
+    import from jaclang.jac0core.passes.graph_schema_pass { SCALAR_SQL }
+    tier = f.get('tier', 'json');
+    opt = '' if f.get('optional') else ' NOT NULL';
+    if tier == 'scalar' {
+        return f"{SCALAR_SQL.get(f.get('type'), 'text')}{opt}";
+    }
+    if tier == 'enum' {
+        return f"text{opt}  -- enum {f.get('target')}";
+    }
+    if tier == 'node_ref' {
+        return f"uuid{opt} REFERENCES nodes(id)  -- {f.get('target')}";
+    }
+    if tier == 'node_ref_list' {
+        return f"uuid[]{opt}  -- ordered {f.get('target')} refs";
+    }
+    if tier == 'scalar_list' {
+        return f"jsonb{opt}  -- {f.get('type')}";
+    }
+    if tier in ['obj', 'obj_list'] {
+        return f"jsonb{opt}  -- {f.get('target')} (side-table candidate)";
+    }
+    return f"jsonb{opt}";
+}
+
+
+def _render_edge_line(name: str, spec: dict) -> str {
+    declared = spec.get('declared');
+    observed = spec.get('observed') or [];
+    parts: list[str] = [];
+    if declared {
+        parts.append(
+            f"declared {declared.get('src') or '?'} -> {declared.get('dst') or '?'}"
+        );
+    }
+    if observed {
+        obs = ", ".join(f"{s or '?'} -> {d or '?'}" for (s, d) in observed);
+        parts.append(f"observed {obs}");
+    }
+    if not parts {
+        parts.append("no endpoints known");
+    }
+    open_mark = '';
+    if any((s is None or d is None) for (s, d) in observed) {
+        open_mark = '  [open]';
+    }
+    und = '  [undirected seen]' if spec.get('undirected_seen') else '';
+    return f"  {name}: {'; '.join(parts)}{open_mark}{und}";
+}
+
+
+def _db_schema(target: str) -> int {
+    import json;
+    if not target {
+        console.error("usage: jac db schema <file.jac>");
+        return 1;
+    }
+    path = str(Path(target).expanduser().resolve());
+    if not Path(path).is_file() {
+        console.error(f"no such file: {target}");
+        return 1;
+    }
+    import from jaclang.jac0core.program { JacProgram }
+    import from jaclang.jac0core.compiler { get_boundary_analysis_sched }
+    prog = JacProgram();
+    prev_errors = len(prog.errors_had);
+    try {
+        prog.compile(path);
+    } except Exception as e {
+        console.error(f"compile failed: {e}");
+        return 1;
+    }
+    if len(prog.errors_had) > prev_errors {
+        for e in prog.errors_had[prev_errors:] {
+            console.error(str(e));
+        }
+        return 1;
+    }
+    mod = prog.find_module(path);
+    if mod is None {
+        console.error(f"module not found after compile: {path}");
+        return 1;
+    }
+    man = mod.gen.interop_manifest;
+    if man and not man.graph_schema {
+        try {
+            prog.run_schedule(mod, get_boundary_analysis_sched());
+        } except Exception {
+            ;
+        }
+    }
+    gs = man.graph_schema if man else {};
+    if not gs {
+        console.print("no graph schema (module declares no archetypes)");
+        return 0;
+    }
+    nodes = gs.get('nodes', {});
+    edges = gs.get('edges', {});
+    objs = gs.get('objs', {});
+    console.print(f"Graph schema for {target} (module {gs.get('module')})");
+    console.print(f"\nNode tables ({len(nodes)}):");
+    for (name, spec) in nodes.items() {
+        bases = spec.get('bases') or [];
+        suffix = f"  -- extends {', '.join(bases)}" if bases else '';
+        console.print(f"  n_{name.lower()} (id uuid PK -> nodes(id)){suffix}");
+        for f in spec.get('fields', []) {
+            console.print(f"    {f.get('name'):<20} {_schema_col(f)}");
+        }
+    }
+    console.print(f"\nEdge relations ({len(edges)}) -> one edges table:");
+    for (name, spec) in edges.items() {
+        console.print(_render_edge_line(name, spec));
+        for f in spec.get('fields', []) {
+            console.print(f"    {f.get('name'):<20} {_schema_col(f)} (props)");
+        }
+    }
+    if objs {
+        console.print(f"\nEmbedded objects ({len(objs)}):");
+        for (name, spec) in objs.items() {
+            kind = 'flat scalar -> side table' if spec.get('flat_scalar') else 'jsonb';
+            console.print(f"  {name} ({kind})");
+            for f in spec.get('fields', []) {
+                console.print(f"    {f.get('name'):<20} {_schema_col(f)}");
+            }
+        }
+    }
+    return 0;
+}
+
+
 impl db(
     action: str = "status",
     query: str = "",
@@ -395,6 +526,9 @@ impl db(
     if verb is None {
         console.error(f"unknown action: {action}");
         return 1;
+    }
+    if verb == DbAction.SCHEMA {
+        return _db_schema(query);
     }
     if verb == DbAction.SERVE {
         return _db_serve(data_dir, port);

--- a/jac/jaclang/cli/commands/impl/db.impl.jac
+++ b/jac/jaclang/cli/commands/impl/db.impl.jac
@@ -16,7 +16,8 @@ enum DbAction(StrEnum) {
     LIST = 'list',
     DROP = 'drop',
     PRUNE = 'prune',
-    SCHEMA = 'schema'
+    SCHEMA = 'schema',
+    PARITY = 'parity'
 }
 
 
@@ -176,6 +177,32 @@ def _db_sql(data_dir: str, query: str) -> int {
         store.close();
     }
     return 0;
+}
+
+
+def _db_parity(data_dir: str) -> int {
+    rt = _runtime_for(data_dir);
+    store = _open_store(rt);
+    try {
+        import from jaclang.runtimelib.relational { relational_parity }
+        store.begin(TxnIsolation.READ_COMMITTED);
+        probs = relational_parity(store, limit=100000);
+        store.commit();
+        if not probs {
+            console.success('relational parity clean');
+            return 0;
+        }
+        for p in probs[:50] {
+            console.error(p);
+        }
+        if len(probs) > 50 {
+            console.error(f"... and {len(probs) - 50} more");
+        }
+        console.error(f"{len(probs)} parity problem(s)");
+        return 1;
+    } finally {
+        store.close();
+    }
 }
 
 
@@ -545,6 +572,9 @@ impl db(
     }
     if verb == DbAction.SQL {
         return _db_sql(dd, query);
+    }
+    if verb == DbAction.PARITY {
+        return _db_parity(dd);
     }
     if verb == DbAction.LIST {
         return _db_list(dd);

--- a/jac/jaclang/cli/impl/manifest.impl.jac
+++ b/jac/jaclang/cli/impl/manifest.impl.jac
@@ -652,6 +652,10 @@ def _command_routes -> list[CommandMeta] {
                     "Show the project store's server state and row counts"
                 ),
                 ('jac db inspect', 'Summarize anchors by kind and archetype'),
+                (
+                    'jac db schema app.jac',
+                    "Show the relational schema derived from the program's archetypes"
+                ),
                 ('jac db sql "SELECT count(*) FROM anchors"', 'Run one SQL statement'),
                 ('jac db list', 'List every jac database in the shared cluster'),
                 (
@@ -675,13 +679,13 @@ def _command_routes -> list[CommandMeta] {
                     name='action',
                     kind=ArgKind.POSITIONAL,
                     default='status',
-                    help='Action: status, serve, stop, inspect, sql, fetch, list, drop, prune'
+                    help='Action: status, serve, stop, inspect, sql, fetch, list, drop, prune, schema'
                 ),
                 ArgMeta(
                     name='query',
                     kind=ArgKind.POSITIONAL,
                     default='',
-                    help='SQL text (for `jac db sql`) or database name (for `jac db drop`)'
+                    help='SQL text (for `jac db sql`), database name (for `jac db drop`), or .jac file (for `jac db schema`)'
                 ),
                 ArgMeta(
                     name='data_dir',

--- a/jac/jaclang/cli/impl/manifest.impl.jac
+++ b/jac/jaclang/cli/impl/manifest.impl.jac
@@ -656,6 +656,10 @@ def _command_routes -> list[CommandMeta] {
                     'jac db schema app.jac',
                     "Show the relational schema derived from the program's archetypes"
                 ),
+                (
+                    'jac db parity',
+                    'Check the relational shadow tables against the anchors table'
+                ),
                 ('jac db sql "SELECT count(*) FROM anchors"', 'Run one SQL statement'),
                 ('jac db list', 'List every jac database in the shared cluster'),
                 (
@@ -679,7 +683,7 @@ def _command_routes -> list[CommandMeta] {
                     name='action',
                     kind=ArgKind.POSITIONAL,
                     default='status',
-                    help='Action: status, serve, stop, inspect, sql, fetch, list, drop, prune, schema'
+                    help='Action: status, serve, stop, inspect, sql, fetch, list, drop, prune, schema, parity'
                 ),
                 ArgMeta(
                     name='query',

--- a/jac/jaclang/jac0core/codeinfo.jac
+++ b/jac/jaclang/jac0core/codeinfo.jac
@@ -552,6 +552,7 @@ obj InteropManifest {
     has bindings: dict[(str, InteropBinding)] = field(default_factory=`dict),
         boundary_types: dict[(str, BoundaryTypeInfo)] = field(default_factory=`dict),
         endpoint_effects: dict[(str, dict)] = field(default_factory=`dict),
+        graph_schema: dict = field(default_factory=`dict),
         func_access: dict[(str, bool)] = field(default_factory=`dict),
         walker_access: dict[(str, bool)] = field(default_factory=`dict),
         native_module_imports: dict[(str, NativeModuleInfo)] = field(

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -33,6 +33,7 @@ import from jaclang.jac0core.passes {
     BoundaryAnalysisPass,
     DeclImplMatchPass,
     EndpointEffectPass,
+    GraphSchemaPass,
     JacAnnexPass,
     JcirBytecodeGenPass,
     JcirGenPass,
@@ -419,7 +420,8 @@ def import_error_re_enters(err: BaseException, file_path: str) -> (str | None) {
 
 def get_boundary_analysis_sched -> list[type[Transform]] {
     return validate_schedule(
-        [BoundaryAnalysisPass, EndpointEffectPass], origin='boundary-analysis schedule'
+        [BoundaryAnalysisPass, EndpointEffectPass, GraphSchemaPass],
+        origin='boundary-analysis schedule'
     );
 }
 

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -644,6 +644,7 @@ impl JacCompiler._build_interop_dict(result: uni.Module) -> dict {
     interop_data['func_access'] = dict(manifest.func_access);
     interop_data['walker_access'] = dict(manifest.walker_access);
     interop_data['endpoint_effects'] = dict(manifest.endpoint_effects);
+    interop_data['graph_schema'] = dict(manifest.graph_schema);
     return interop_data;
 }
 
@@ -672,6 +673,7 @@ impl JacCompiler._deserialize_interop_table(
     manifest.func_access.update(cached_interop.get('func_access', {}));
     manifest.walker_access.update(cached_interop.get('walker_access', {}));
     manifest.endpoint_effects.update(cached_interop.get('endpoint_effects', {}));
+    manifest.graph_schema.update(cached_interop.get('graph_schema', {}));
     return manifest;
 }
 

--- a/jac/jaclang/jac0core/passes/__init__.py
+++ b/jac/jaclang/jac0core/passes/__init__.py
@@ -17,6 +17,7 @@ from jaclang.jac0core.passes.ast_validation_pass import ASTValidationPass
 from jaclang.jac0core.passes.boundary_analysis_pass import BoundaryAnalysisPass
 from jaclang.jac0core.passes.decl_impl_match_pass import DeclImplMatchPass
 from jaclang.jac0core.passes.endpoint_effect_pass import EndpointEffectPass
+from jaclang.jac0core.passes.graph_schema_pass import GraphSchemaPass
 from jaclang.jac0core.passes.jcir_bc_gen_pass import JcirBytecodeGenPass
 from jaclang.jac0core.passes.jcir_gen_pass import JcirGenPass
 from jaclang.jac0core.passes.module_codegen_pass import ModuleCodegenPass
@@ -47,5 +48,6 @@ __all__ = [
     "BoundaryAnalysisPass",
     "PlacementApplyPass",
     "EndpointEffectPass",
+    "GraphSchemaPass",
     "ModuleCodegenPass",
 ]

--- a/jac/jaclang/jac0core/passes/graph_schema_pass.jac
+++ b/jac/jaclang/jac0core/passes/graph_schema_pass.jac
@@ -1,0 +1,404 @@
+"""Graph schema extraction.
+
+Derives the relational shape of a module's graph from what the program
+already declares: node/edge/obj archetypes with typed `has` fields, declared
+edge endpoints (`edge E: Src -> Tgt`), and — for edges declared without
+endpoints — the endpoint types observed at every connect site (`ConnectOp`).
+
+The result is written to `ir_in.gen.interop_manifest.graph_schema` as a
+plain JSON-serializable dict so it travels with the compiled module and the
+.jir cache, and can be consumed by the store (DDL derivation) and the query
+planner (join maps, untyped-hop pruning).
+
+Endpoint inference is best-effort by design: an operand whose static type
+cannot be resolved records `None` (an open endpoint). Consumers must treat
+an edge with any open observation as connecting unknown node types — this
+degrades planning, never correctness.
+"""
+
+import from jaclang.jac0core.unitree {
+    Ability,
+    Archetype,
+    AstSymbolNode,
+    AtomTrailer,
+    AtomUnit,
+    BinaryExpr,
+    ConnectOp,
+    EventSignature,
+    Expr,
+    FuncCall,
+    HasVar,
+    IndexSlice,
+    Name,
+    Null,
+    SpecialVarRef,
+    Token,
+    UniNode
+}
+import from jaclang.jac0core.constant { EdgeDir, SymbolType, Tokens as Tok }
+import from jaclang.jac0core.passes.uni_pass { UniPass }
+
+glob SCALAR_SQL: dict[str, str] = {
+         'str': 'text',
+         'int': 'bigint',
+         'float': 'double precision',
+         'bool': 'boolean',
+         'bytes': 'bytea',
+         'UUID': 'uuid',
+         'datetime': 'timestamptz',
+         'date': 'date',
+         'time': 'time',
+         'timedelta': 'interval',
+         'Decimal': 'numeric'
+     },
+     GENERIC_EDGE = 'GenericEdge',
+     ROOT_NODE = 'Root';
+
+
+class GraphSchemaPass(UniPass) {
+    def before_pass(self: GraphSchemaPass) {
+        self._nodes: dict[str, dict] = {};
+        self._edges: dict[str, dict] = {};
+        self._objs: dict[str, dict] = {};
+    }
+
+    def enter_archetype(self: GraphSchemaPass, nd: Archetype) -> None {
+        # arch_kind is None for obj/class archetypes, so key off the token
+        kind = nd.arch_type.name;
+        if kind not in [Tok.KW_NODE, Tok.KW_EDGE, Tok.KW_OBJECT, Tok.KW_CLASS] {
+            return;
+        }
+        if not isinstance(nd.name, Name) {
+            return;
+        }
+        spec = {
+            'module': self.ir_in.name,
+            'bases': self._base_names(nd),
+            'fields': [self._field_spec(hv) for hv in nd.get_has_vars()]
+        };
+        if kind == Tok.KW_NODE {
+            self._nodes[nd.name.sym_name] = spec;
+        } elif kind == Tok.KW_EDGE {
+            spec['declared'] = self._declared_endpoints(nd);
+            spec['observed'] = [];
+            spec['undirected_seen'] = False;
+            self._edges[nd.name.sym_name] = spec;
+        } else {
+            fields = spec['fields'];
+            spec['flat_scalar'] = bool(fields)
+                and all(f['tier'] in ['scalar', 'enum'] for f in fields);
+            self._objs[nd.name.sym_name] = spec;
+        }
+    }
+
+    def enter_binary_expr(self: GraphSchemaPass, nd: BinaryExpr) -> None {
+        if not isinstance(nd.op, ConnectOp) {
+            return;
+        }
+        edge_name = GENERIC_EDGE;
+        conn = nd.op.conn_type;
+        if conn is not None {
+            named = self._expr_type_name(conn);
+            if named {
+                edge_name = named;
+            }
+        }
+        entry = self._edges.get(edge_name);
+        if entry is None {
+            entry = {
+                'module': self.ir_in.name,
+                'bases': [],
+                'fields': [],
+                'declared': None,
+                'observed': [],
+                'undirected_seen': False
+            };
+            self._edges[edge_name] = entry;
+        }
+        left = self._node_type_of(nd.left);
+        right = self._node_type_of(nd.right);
+        if nd.op.edge_dir == EdgeDir.IN {
+            (src, dst) = (right, left);
+        } else {
+            (src, dst) = (left, right);
+        }
+        if nd.op.edge_dir == EdgeDir.ANY {
+            entry['undirected_seen'] = True;
+        }
+        pair = [src, dst];
+        if pair not in entry['observed'] {
+            entry['observed'].append(pair);
+        }
+    }
+
+    def after_pass(self: GraphSchemaPass) {
+        if not (self._nodes or self._edges or self._objs) {
+            return;
+        }
+        self.ir_in.gen.interop_manifest.graph_schema = {
+            'version': 1,
+            'module': self.ir_in.name,
+            'nodes': self._nodes,
+            'edges': self._edges,
+            'objs': self._objs
+        };
+    }
+
+    # ------------------------------------------------------------------
+    # declaration side
+
+    def _base_names(self: GraphSchemaPass, nd: Archetype) -> list[str] {
+        out: list[str] = [];
+        for b in (nd.base_classes or []) {
+            named = self._expr_type_name(b);
+            if named {
+                out.append(named);
+            }
+        }
+        return out;
+    }
+
+    def _declared_endpoints(self: GraphSchemaPass, nd: Archetype) -> (dict | None) {
+        if nd.src_endpoint is None and nd.tgt_endpoint is None {
+            return None;
+        }
+        return {
+            'src': self._expr_type_name(nd.src_endpoint),
+            'dst': self._expr_type_name(nd.tgt_endpoint)
+        };
+    }
+
+    def _field_spec(self: GraphSchemaPass, hv: HasVar) -> dict {
+        ann = hv.type_tag.tag if hv.type_tag else None;
+        info = self._classify_type(ann);
+        info['name'] = hv.name.sym_name;
+        info['has_default'] = hv.value is not None or hv.defer;
+        return info;
+    }
+
+    # Classify a type annotation into a storage tier:
+    #   scalar        -> typed column (SCALAR_SQL)
+    #   enum          -> text column
+    #   node_ref      -> uuid FK column into the node directory
+    #   node_ref_list -> uuid[] column
+    #   obj           -> flattenable side-table candidate (jsonb otherwise)
+    #   json          -> jsonb column (dicts, unions, unresolved, `any`)
+    def _classify_type(self: GraphSchemaPass, ann: (Expr | None)) -> dict {
+        out = {'tier': 'json', 'type': 'any', 'target': None, 'optional': False};
+        while isinstance(ann, AtomUnit) {
+            ann = ann.value;
+        }
+        if ann is None or not isinstance(ann, Expr) {
+            return out;
+        }
+        # unwrap (X | None) into optional X; wider unions stay json
+        if isinstance(ann, BinaryExpr)
+            and isinstance(ann.op, Token)
+            and ann.op.name == Tok.BW_OR {
+            parts = self._union_parts(ann);
+            non_null = [
+                p
+                for p in parts
+                if not self._is_null_expr(p)
+            ];
+            if len(non_null) == 1 and len(parts) > len(non_null) {
+                inner = self._classify_type(non_null[0]);
+                inner['optional'] = True;
+                return inner;
+            }
+            out['type'] = 'union';
+            return out;
+        }
+        if isinstance(ann, AtomTrailer) {
+            return self._classify_subscript(ann, out);
+        }
+        named = self._expr_type_name(ann);
+        if not named {
+            return out;
+        }
+        out['type'] = named;
+        if named in SCALAR_SQL {
+            out['tier'] = 'scalar';
+            return out;
+        }
+        if named == 'None' {
+            out['optional'] = True;
+            return out;
+        }
+        sym = self._resolve_symbol(ann);
+        if sym is None {
+            return out;
+        }
+        if sym.sym_type == SymbolType.NODE_ARCH {
+            out['tier'] = 'node_ref';
+            out['target'] = named;
+        } elif sym.sym_type == SymbolType.EDGE_ARCH {
+            out['tier'] = 'edge_ref';
+            out['target'] = named;
+        } elif sym.sym_type == SymbolType.ENUM_ARCH {
+            out['tier'] = 'enum';
+            out['target'] = named;
+        } elif sym.sym_type == SymbolType.OBJECT_ARCH {
+            out['tier'] = 'obj';
+            out['target'] = named;
+        }
+        return out;
+    }
+
+    def _classify_subscript(
+        self: GraphSchemaPass, ann: AtomTrailer, out: dict
+    ) -> dict {
+        base = self._expr_type_name(ann.target);
+        if not base or not isinstance(ann.right, IndexSlice) {
+            return out;
+        }
+        out['type'] = base;
+        if base not in ['list', 'set'] {
+            return out;
+        }
+        slices = ann.right.slices;
+        if len(slices) != 1 or slices[0].start is None {
+            return out;
+        }
+        elem = self._classify_type(slices[0].start);
+        if elem['tier'] == 'node_ref' {
+            out['tier'] = 'node_ref_list';
+            out['target'] = elem['target'];
+        } elif elem['tier'] == 'scalar' {
+            out['tier'] = 'scalar_list';
+            out['type'] = f"{base}[{elem['type']}]";
+        } elif elem['tier'] == 'obj' {
+            out['tier'] = 'obj_list';
+            out['target'] = elem['target'];
+        }
+        return out;
+    }
+
+    def _is_null_expr(self: GraphSchemaPass, nd: Expr) -> bool {
+        if isinstance(nd, Null) {
+            return True;
+        }
+        return isinstance(nd, Name) and nd.sym_name == 'None';
+    }
+
+    def _union_parts(self: GraphSchemaPass, nd: Expr) -> list[Expr] {
+        if isinstance(nd, BinaryExpr)
+            and isinstance(nd.op, Token)
+            and nd.op.name == Tok.BW_OR {
+            return self._union_parts(nd.left) + self._union_parts(nd.right);
+        }
+        return [nd];
+    }
+
+    # ------------------------------------------------------------------
+    # connect-site side
+
+    def _node_type_of(self: GraphSchemaPass, operand: (Expr | None)) -> (str | None) {
+        if operand is None {
+            return None;
+        }
+        # chained connect: the value of `a ++> b` is its target side
+        if isinstance(operand, BinaryExpr) and isinstance(operand.op, ConnectOp) {
+            return self._node_type_of(operand.right);
+        }
+        if isinstance(operand, FuncCall) {
+            sym = self._resolve_symbol(operand.target);
+            if sym and sym.sym_type == SymbolType.NODE_ARCH {
+                return sym.sym_name;
+            }
+            return None;
+        }
+        if isinstance(operand, SpecialVarRef) {
+            if operand.sym_name == 'root' {
+                return ROOT_NODE;
+            }
+            if operand.sym_name == 'self' {
+                arch = self._enclosing_archetype(operand);
+                if arch and arch.arch_kind == 'node' and isinstance(arch.name, Name) {
+                    return arch.name.sym_name;
+                }
+                return None;
+            }
+            if operand.sym_name == 'here' {
+                return self._here_type(operand);
+            }
+            return None;
+        }
+        if isinstance(operand, Name) {
+            sym = self._resolve_symbol(operand);
+            if sym and sym.sym_type == SymbolType.NODE_ARCH {
+                return sym.sym_name;
+            }
+        }
+        return None;
+    }
+
+    def _here_type(self: GraphSchemaPass, nd: UniNode) -> (str | None) {
+        cursor = nd.parent;
+        while cursor is not None and not isinstance(cursor, Ability) {
+            cursor = cursor.parent;
+        }
+        if cursor is None {
+            return None;
+        }
+        sig = cursor.signature;
+        if isinstance(sig, EventSignature) and isinstance(sig.arch_tag_info, Name) {
+            named = sig.arch_tag_info.sym_name;
+            return ROOT_NODE if named == 'root' else named;
+        }
+        return None;
+    }
+
+    def _enclosing_archetype(self: GraphSchemaPass, nd: UniNode) -> (Archetype | None) {
+        cursor = nd.parent;
+        while cursor is not None and not isinstance(cursor, Archetype) {
+            cursor = cursor.parent;
+        }
+        return cursor;
+    }
+
+    # ------------------------------------------------------------------
+    # shared helpers
+
+    def _expr_type_name(self: GraphSchemaPass, e: (Expr | None)) -> (str | None) {
+        if e is None {
+            return None;
+        }
+        if isinstance(e, Name) {
+            return e.sym_name;
+        }
+        if isinstance(e, FuncCall) {
+            return self._expr_type_name(e.target);
+        }
+        if isinstance(e, AtomTrailer) {
+            attrs = e.as_attr_list;
+            if attrs {
+                last = attrs[-1];
+                if isinstance(last, AstSymbolNode) {
+                    return last.sym_name;
+                }
+            }
+        }
+        return None;
+    }
+
+    def _resolve_symbol(self: GraphSchemaPass, e: (Expr | None)) -> (object | None) {
+        if isinstance(e, Name) {
+            sym = e.sym;
+            if not sym and e.sym_tab {
+                sym = e.sym_tab.lookup(e.sym_name, deep=True);
+            }
+            return sym;
+        }
+        if isinstance(e, AtomTrailer) {
+            attrs = e.as_attr_list;
+            if attrs {
+                last = attrs[-1];
+                if isinstance(last, AstSymbolNode) and last.sym {
+                    return last.sym;
+                }
+            }
+        }
+        return None;
+    }
+}

--- a/jac/jaclang/runtimelib/impl/relational.impl.jac
+++ b/jac/jaclang/runtimelib/impl/relational.impl.jac
@@ -1,0 +1,919 @@
+import hashlib;
+import json;
+import logging;
+import os;
+import threading;
+import datetime;
+import types as pytypes;
+import typing;
+import from dataclasses { is_dataclass }
+import from decimal { Decimal }
+import from enum { Enum }
+import from uuid { UUID }
+import from jaclang.jac0core.archetype { EdgeArchetype, NodeArchetype }
+
+glob logger = logging.getLogger(__name__),
+     # keep in sync with SCALAR_SQL in jac0core/passes/graph_schema_pass.jac
+     # (the pass cannot import runtimelib, so the map is duplicated)
+     SCALAR_SQL: dict[str, str] = {
+         'str': 'text',
+         'int': 'bigint',
+         'float': 'double precision',
+         'bool': 'boolean',
+         'bytes': 'bytea',
+         'UUID': 'uuid',
+         'datetime': 'timestamptz',
+         'date': 'date',
+         'time': 'time',
+         'timedelta': 'interval',
+         'Decimal': 'numeric'
+     },
+     _CAST_TYPES: set[str] = {
+         'uuid',
+         'uuid[]',
+         'jsonb',
+         'timestamptz',
+         'date',
+         'time',
+         'interval',
+         'numeric',
+         'bytea',
+         'smallint'
+     },
+     _plans: dict[str, TablePlan] = {},
+     _ready: set[str] = set(),
+     _lock = threading.RLock();
+
+glob _BASE_SQL: list[str] = [
+         """
+    CREATE TABLE IF NOT EXISTS nodes (
+        id          uuid PRIMARY KEY,
+        arch_type   text NOT NULL,
+        arch_module text NOT NULL DEFAULT '',
+        root_id     uuid,
+        seq         bigserial
+    )
+    """,
+         """
+    CREATE INDEX IF NOT EXISTS idx_nodes_type ON nodes (arch_type)
+    """,
+         """
+    CREATE INDEX IF NOT EXISTS idx_nodes_root
+        ON nodes (root_id) WHERE root_id IS NOT NULL
+    """,
+         """
+    CREATE TABLE IF NOT EXISTS edges (
+        id          uuid PRIMARY KEY,
+        edge_type   text NOT NULL,
+        arch_module text NOT NULL DEFAULT '',
+        src         uuid,
+        dst         uuid,
+        root_id     uuid,
+        undirected  boolean NOT NULL DEFAULT false,
+        seq         bigserial,
+        props       jsonb NOT NULL DEFAULT '{}'::jsonb
+    )
+    """,
+         """
+    CREATE INDEX IF NOT EXISTS idx_edges_src
+        ON edges (src, edge_type) INCLUDE (dst, seq) WHERE src IS NOT NULL
+    """,
+         """
+    CREATE INDEX IF NOT EXISTS idx_edges_dst
+        ON edges (dst, edge_type) INCLUDE (src, seq) WHERE dst IS NOT NULL
+    """,
+         """
+    CREATE TABLE IF NOT EXISTS graph_tables (
+        table_name  text PRIMARY KEY,
+        kind        text NOT NULL,
+        arch_type   text NOT NULL,
+        arch_module text NOT NULL DEFAULT ''
+    )
+    """
+     ];
+
+
+impl relational_enabled -> bool {
+    return os.environ.get('JAC_RELATIONAL', '').strip().lower()
+        in ['1', 'on', 'true', 'shadow'];
+}
+
+
+impl relational_reset_cache -> None {
+    with _lock {
+        _plans.clear();
+        _ready.clear();
+    }
+}
+
+
+def _ident(name: str) -> str {
+    cleaned = ''.join(ch if (ch.isalnum() or ch == '_') else '_' for ch in name);
+    if not cleaned or cleaned[0].isdigit() {
+        cleaned = 't_' + cleaned;
+    }
+    return cleaned.lower();
+}
+
+
+def _db_key(store: object, suffix: str) -> str {
+    return f"{store.conninfo.database}::{suffix}";
+}
+
+
+# ---------------------------------------------------------------------------
+# table plans: manifest first, runtime reflection fallback
+
+def _manifest_fields(arch_type: str, arch_module: str) -> (list | None) {
+    try {
+        import from jaclang.jac0core.runtime { JacRuntime }
+        prog = getattr(JacRuntime, 'program', None);
+        if prog is None {
+            return None;
+        }
+        for hub in prog._search_hubs() {
+            for mod in hub.values() {
+                if getattr(mod, 'name', None) != arch_module {
+                    continue;
+                }
+                gen = getattr(mod, 'gen', None);
+                man = getattr(gen, 'interop_manifest', None) if gen else None;
+                gs = getattr(man, 'graph_schema', None) if man else None;
+                if not gs {
+                    continue;
+                }
+                spec = (gs.get('nodes') or {}).get(arch_type);
+                if spec and isinstance(spec.get('fields'), list) {
+                    return spec['fields'];
+                }
+            }
+        }
+    } except Exception as e {
+        logger.debug(f"manifest schema lookup failed for {arch_type}: {e}");
+    }
+    return None;
+}
+
+
+glob _PY_SCALARS: dict[type, str] = {
+         str: 'str',
+         int: 'int',
+         float: 'float',
+         bool: 'bool',
+         bytes: 'bytes',
+         UUID: 'UUID',
+         datetime.datetime: 'datetime',
+         datetime.date: 'date',
+         datetime.time: 'time',
+         datetime.timedelta: 'timedelta',
+         Decimal: 'Decimal'
+     };
+
+
+def _spec_from_pytype(name: str, t: object) -> dict {
+    out = {
+        'name': name,
+        'tier': 'json',
+        'type': 'any',
+        'target': None,
+        'optional': False
+    };
+    origin = typing.get_origin(t);
+    if origin is typing.Union or origin is pytypes.UnionType {
+        args = [
+            a
+            for a in typing.get_args(t)
+            if a is not type(None)
+        ];
+        if len(args) == 1 and len(typing.get_args(t)) > 1 {
+            inner = _spec_from_pytype(name, args[0]);
+            inner['optional'] = True;
+            return inner;
+        }
+        out['type'] = 'union';
+        return out;
+    }
+    if origin in [list, set] {
+        args = typing.get_args(t);
+        if len(args) == 1 {
+            elem = _spec_from_pytype(name, args[0]);
+            if elem['tier'] == 'node_ref' {
+                out['tier'] = 'node_ref_list';
+                out['target'] = elem['target'];
+            } elif elem['tier'] == 'scalar' {
+                out['tier'] = 'scalar_list';
+                out['type'] = f"list[{elem['type']}]";
+            }
+        }
+        return out;
+    }
+    if not isinstance(t, type) {
+        return out;
+    }
+    # bool must win over int (bool subclasses int)
+    if t is bool {
+        out['tier'] = 'scalar';
+        out['type'] = 'bool';
+        return out;
+    }
+    if t in _PY_SCALARS {
+        out['tier'] = 'scalar';
+        out['type'] = _PY_SCALARS[t];
+        return out;
+    }
+    if issubclass(t, NodeArchetype) {
+        out['tier'] = 'node_ref';
+        out['type'] = t.__name__;
+        out['target'] = t.__name__;
+        return out;
+    }
+    if issubclass(t, EdgeArchetype) {
+        out['tier'] = 'edge_ref';
+        out['type'] = t.__name__;
+        out['target'] = t.__name__;
+        return out;
+    }
+    if issubclass(t, Enum) {
+        out['tier'] = 'enum';
+        out['type'] = t.__name__;
+        out['target'] = t.__name__;
+        return out;
+    }
+    if is_dataclass(t) {
+        out['tier'] = 'obj';
+        out['type'] = t.__name__;
+        out['target'] = t.__name__;
+        return out;
+    }
+    return out;
+}
+
+
+def _reflect_fields(arch_type: str, arch_module: str) -> (list | None) {
+    try {
+        import from jaclang.runtimelib.serializer { Serializer }
+        cls = Serializer._get_class(arch_module, arch_type);
+        if cls is None {
+            return None;
+        }
+        import from jaclang.runtimelib.typecache { get_field_types }
+        fts = get_field_types(cls);
+        return [
+            _spec_from_pytype(n, t)
+            for (n, t) in fts.items()
+            if not n.startswith('_')
+        ];
+    } except Exception as e {
+        logger.debug(f"reflection schema lookup failed for {arch_type}: {e}");
+        return None;
+    }
+}
+
+
+def _sql_type_for(spec: dict) -> str {
+    tier = spec.get('tier', 'json');
+    if tier == 'scalar' {
+        return SCALAR_SQL.get(spec.get('type'), 'text');
+    }
+    if tier == 'enum' {
+        return 'text';
+    }
+    if tier in ['node_ref', 'edge_ref'] {
+        return 'uuid';
+    }
+    if tier == 'node_ref_list' {
+        return 'uuid[]';
+    }
+    return 'jsonb';
+}
+
+
+impl plan_for(arch_type: str, arch_module: str) -> (TablePlan | None) {
+    key = f"{arch_module}::{arch_type}";
+    with _lock {
+        if key in _plans {
+            return _plans[key];
+        }
+    }
+    fields = _manifest_fields(arch_type, arch_module);
+    if fields is None {
+        fields = _reflect_fields(arch_type, arch_module);
+    }
+    if fields is None {
+        # not cached: the class may register later (import order, dynamic
+        # types); a permanent negative would silently starve the typed table
+        return None;
+    }
+    mod6 = hashlib.md5(arch_module.encode()).hexdigest()[:6];
+    cols = [
+        ColumnSpec(
+            name=str(f.get('name')),
+            col='f_' + _ident(str(f.get('name'))),
+            tier=str(f.get('tier', 'json')),
+            sql_type=_sql_type_for(f)
+        )
+        for f in fields
+        if f.get('name') and not str(f.get('name')).startswith('_')
+    ];
+    plan = TablePlan(
+        table=f"n_{_ident(arch_type.lower())}_{mod6}",
+        arch_type=arch_type,
+        arch_module=arch_module,
+        columns=cols
+    );
+    with _lock {
+        _plans[key] = plan;
+    }
+    return plan;
+}
+
+
+# ---------------------------------------------------------------------------
+# DDL
+
+def _ensure_base(store: object) -> None {
+    key = _db_key(store, '__base__');
+    with _lock {
+        if key in _ready {
+            return;
+        }
+    }
+    for sql in _BASE_SQL {
+        store._run(sql, {});
+    }
+    with _lock {
+        _ready.add(key);
+    }
+}
+
+
+def _ensure_table(store: object, plan: TablePlan) -> None {
+    key = _db_key(store, plan.table);
+    with _lock {
+        if key in _ready {
+            return;
+        }
+    }
+    store._run(
+        f"""
+        CREATE TABLE IF NOT EXISTS {plan.table} (
+            id       uuid PRIMARY KEY,
+            root_id  uuid,
+            acl_all  smallint NOT NULL DEFAULT -1,
+            acl_spec boolean NOT NULL DEFAULT false,
+            access   jsonb,
+            extra    jsonb NOT NULL DEFAULT '{{}}'::jsonb
+        )
+        """,
+        {}
+    );
+    for c in plan.columns {
+        store._run(
+            f"ALTER TABLE {plan.table} ADD COLUMN IF NOT EXISTS {c.col} {c.sql_type}",
+            {}
+        );
+    }
+    store._run(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_{plan.table}_root
+            ON {plan.table} (root_id) WHERE root_id IS NOT NULL
+        """,
+        {}
+    );
+    store._run(
+        """
+        INSERT INTO graph_tables (table_name, kind, arch_type, arch_module)
+        VALUES (:t, 'node', :at, :am)
+        ON CONFLICT (table_name) DO NOTHING
+        """,
+        {'t': plan.table, 'at': plan.arch_type, 'am': plan.arch_module}
+    );
+    with _lock {
+        _ready.add(key);
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# value extraction
+
+def _ref_uuid(v: object) -> (str | None) {
+    raw: object = v;
+    if isinstance(v, dict) {
+        raw = v.get('$ref');
+    }
+    if isinstance(raw, UUID) {
+        return str(raw);
+    }
+    if isinstance(raw, str) {
+        try {
+            return str(UUID(raw));
+        } except ValueError {
+            return None;
+        }
+    }
+    return None;
+}
+
+
+def _coerce(c: ColumnSpec, v: object) -> tuple {
+    if v is None {
+        return (True, None);
+    }
+    if c.tier == 'scalar' {
+        st = c.sql_type;
+        if st == 'text' {
+            return (True, v) if isinstance(v, str) else (False, None);
+        }
+        if st == 'bigint' {
+            ok = isinstance(v, int) and not isinstance(v, bool);
+            return (True, v) if ok else (False, None);
+        }
+        if st == 'double precision' {
+            ok = isinstance(v, (int, float)) and not isinstance(v, bool);
+            return (True, v) if ok else (False, None);
+        }
+        if st == 'boolean' {
+            return (True, v) if isinstance(v, bool) else (False, None);
+        }
+        if st == 'uuid' {
+            u = _ref_uuid(v);
+            return (True, u) if u else (False, None);
+        }
+        # timestamptz/date/time/interval/numeric/bytea travel as text and
+        # rely on the CAST; the serializer stringifies these types upstream
+        return (True, v) if isinstance(v, str) else (False, None);
+    }
+    if c.tier == 'enum' {
+        if isinstance(v, str) {
+            return (True, v);
+        }
+        if isinstance(v, (int, float)) and not isinstance(v, bool) {
+            return (True, str(v));
+        }
+        return (False, None);
+    }
+    if c.tier in ['node_ref', 'edge_ref'] {
+        u = _ref_uuid(v);
+        return (True, u) if u else (False, None);
+    }
+    if c.tier == 'node_ref_list' {
+        if not isinstance(v, list) {
+            return (False, None);
+        }
+        out: list[str] = [];
+        for item in v {
+            u = _ref_uuid(item);
+            if u is None {
+                return (False, None);
+            }
+            out.append(u);
+        }
+        return (True, out);
+    }
+    try {
+        return (True, json.dumps(v, default=str));
+    } except Exception {
+        return (False, None);
+    }
+}
+
+
+def _acl_scalars(props: dict) -> tuple {
+    a = props.get('access');
+    if not isinstance(a, dict) {
+        return (-1, False, None);
+    }
+    all_v = a.get('all');
+    acl_all = all_v if (isinstance(all_v, int) and not isinstance(all_v, bool)) else -1;
+    roots = a.get('roots');
+    anchors = roots.get('anchors') if isinstance(roots, dict) else None;
+    acl_spec = bool(anchors);
+    return (acl_all, acl_spec, json.dumps(a, default=str));
+}
+
+
+def _fields_dict(props: dict) -> dict {
+    arch = props.get('archetype');
+    if not isinstance(arch, dict) {
+        return {};
+    }
+    return {
+        k: v
+        for (k, v) in arch.items()
+        if not k.startswith('__')
+    };
+}
+
+
+def _cast_expr(pname: str, sql_type: str) -> str {
+    if sql_type in _CAST_TYPES {
+        return f"CAST(:{pname} AS {sql_type})";
+    }
+    return f":{pname}";
+}
+
+
+# ---------------------------------------------------------------------------
+# routing
+
+def _upsert_directory(store: object, rows: list) -> None {
+    if not rows {
+        return;
+    }
+    values: list[str] = [];
+    params: dict = {};
+    for (i, row) in enumerate(rows) {
+        values.append(
+            f"(CAST(:id{i} AS uuid), :at{i}, :am{i}, CAST(:root{i} AS uuid))"
+        );
+        params[f"id{i}"] = str(row.id);
+        params[f"at{i}"] = row.arch_type;
+        params[f"am{i}"] = row.arch_module;
+        params[f"root{i}"] = str(row.root_id) if row.root_id else None;
+    }
+    store._run(
+        'INSERT INTO nodes (id, arch_type, arch_module, root_id) VALUES '
+            + ', '.join(values)
+            + """
+        ON CONFLICT (id) DO UPDATE SET
+            arch_type = EXCLUDED.arch_type,
+            arch_module = EXCLUDED.arch_module,
+            root_id = EXCLUDED.root_id
+        """,
+        params
+    );
+}
+
+
+def _upsert_typed(store: object, plan: TablePlan, rows: list) -> None {
+    if not rows {
+        return;
+    }
+    col_names = ['id', 'root_id', 'acl_all', 'acl_spec', 'access', 'extra']
+        + [c.col for c in plan.columns];
+    values: list[str] = [];
+    params: dict = {};
+    for (i, row) in enumerate(rows) {
+        fieldsd = _fields_dict(row.props);
+        (acl_all, acl_spec, access_json) = _acl_scalars(row.props);
+        extra: dict = {};
+        exprs = [
+            f"CAST(:id{i} AS uuid)",
+            f"CAST(:root{i} AS uuid)",
+            f"CAST(:aall{i} AS smallint)",
+            f":aspec{i}",
+            f"CAST(:acc{i} AS jsonb)"
+        ];
+        params[f"id{i}"] = str(row.id);
+        params[f"root{i}"] = str(row.root_id) if row.root_id else None;
+        params[f"aall{i}"] = acl_all;
+        params[f"aspec{i}"] = acl_spec;
+        params[f"acc{i}"] = access_json;
+        planned: set[str] = set();
+        for (j, c) in enumerate(plan.columns) {
+            planned.add(c.name);
+            v = fieldsd.get(c.name);
+            (ok, coerced) = _coerce(c, v);
+            if not ok {
+                extra[c.name] = v;
+                coerced = None;
+            }
+            pname = f"c{i}_{j}";
+            exprs.append(_cast_expr(pname, c.sql_type));
+            params[pname] = coerced;
+        }
+        for (k, v) in fieldsd.items() {
+            if k not in planned {
+                extra[k] = v;
+            }
+        }
+        exprs.insert(5, f"CAST(:extra{i} AS jsonb)");
+        params[f"extra{i}"] = json.dumps(extra, default=str);
+        values.append('(' + ', '.join(exprs) + ')');
+    }
+    updates = ',\n'.join(
+        f"{c} = EXCLUDED.{c}"
+        for c in col_names
+        if c != 'id'
+    );
+    store._run(
+        f"INSERT INTO {plan.table} ({', '.join(col_names)}) VALUES\n"
+            + ',\n'.join(values)
+            + f"\nON CONFLICT (id) DO UPDATE SET {updates}",
+        params
+    );
+}
+
+
+def _upsert_edges(store: object, rows: list) -> None {
+    if not rows {
+        return;
+    }
+    values: list[str] = [];
+    params: dict = {};
+    for (i, row) in enumerate(rows) {
+        values.append(
+            f"(CAST(:id{i} AS uuid), :et{i}, :am{i}, CAST(:src{i} AS uuid), "
+            f"CAST(:dst{i} AS uuid), CAST(:root{i} AS uuid), :und{i}, "
+            f"CAST(:props{i} AS jsonb))"
+        );
+        params[f"id{i}"] = str(row.id);
+        params[f"et{i}"] = row.arch_type or 'GenericEdge';
+        params[f"am{i}"] = row.arch_module;
+        params[f"src{i}"] = str(row.src) if row.src else None;
+        params[f"dst{i}"] = str(row.dst) if row.dst else None;
+        params[f"root{i}"] = str(row.root_id) if row.root_id else None;
+        params[f"und{i}"] = row.undirected;
+        params[f"props{i}"] = json.dumps(_fields_dict(row.props), default=str);
+    }
+    store._run(
+        'INSERT INTO edges '
+        '(id, edge_type, arch_module, src, dst, root_id, undirected, props) '
+        'VALUES '
+            + ', '.join(values)
+            + """
+        ON CONFLICT (id) DO UPDATE SET
+            edge_type = EXCLUDED.edge_type,
+            arch_module = EXCLUDED.arch_module,
+            src = EXCLUDED.src,
+            dst = EXCLUDED.dst,
+            root_id = EXCLUDED.root_id,
+            undirected = EXCLUDED.undirected,
+            props = EXCLUDED.props
+        """,
+        params
+    );
+}
+
+
+impl relational_after_upsert(store: object, rows: list) -> None {
+    if not relational_enabled() {
+        return;
+    }
+    node_rows = [
+        r
+        for r in rows
+        if r.kind == 'NodeAnchor'
+    ];
+    edge_rows = [
+        r
+        for r in rows
+        if r.kind == 'EdgeAnchor'
+    ];
+    if not (node_rows or edge_rows) {
+        return;
+    }
+    _ensure_base(store);
+    _upsert_directory(store, node_rows);
+    groups: dict[tuple, list] = {};
+    for row in node_rows {
+        groups.setdefault((row.arch_type, row.arch_module), []).append(row);
+    }
+    for ((at, am), grp) in groups.items() {
+        plan = plan_for(at, am);
+        if plan is None {
+            # directory-only: no class and no manifest for this type yet
+            continue;
+        }
+        _ensure_table(store, plan);
+        _upsert_typed(store, plan, grp);
+    }
+    _upsert_edges(store, edge_rows);
+}
+
+
+impl relational_after_delete(store: object, ids: list[UUID]) -> None {
+    if not relational_enabled() or not ids {
+        return;
+    }
+    _ensure_base(store);
+    sids = [str(i) for i in ids];
+    store._run('DELETE FROM edges WHERE id = ANY(CAST(:ids AS uuid[]))', {'ids': sids});
+    returned = store._run(
+        """
+        DELETE FROM nodes WHERE id = ANY(CAST(:ids AS uuid[]))
+        RETURNING id, arch_type, arch_module
+        """,
+        {'ids': sids}
+    );
+    groups: dict[tuple, list] = {};
+    for r in returned {
+        groups.setdefault((str(r[1]), str(r[2])), []).append(str(r[0]));
+    }
+    for ((at, am), gids) in groups.items() {
+        plan = plan_for(at, am);
+        if plan is None {
+            continue;
+        }
+        _ensure_table(store, plan);
+        store._run(
+            f"DELETE FROM {plan.table} WHERE id = ANY(CAST(:ids AS uuid[]))",
+            {'ids': gids}
+        );
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# parity
+
+def _norm_uuid(v: object) -> (str | None) {
+    if v is None {
+        return None;
+    }
+    try {
+        return str(UUID(str(v)));
+    } except ValueError {
+        return str(v);
+    }
+}
+
+
+def _norm_json(v: object) -> object {
+    if isinstance(v, str) {
+        try {
+            return json.loads(v);
+        } except ValueError {
+            return v;
+        }
+    }
+    return v;
+}
+
+
+def _scalar_equal(sql_type: str, stored: object, expected: object) -> bool {
+    if stored is None or expected is None {
+        return stored is None and expected is None;
+    }
+    if sql_type == 'bigint' {
+        try {
+            return int(str(stored)) == int(str(expected));
+        } except ValueError {
+            return False;
+        }
+    }
+    if sql_type == 'double precision' {
+        try {
+            return abs(float(str(stored)) - float(str(expected))) < 1e-9;
+        } except ValueError {
+            return False;
+        }
+    }
+    if sql_type == 'boolean' {
+        return bool(stored) == bool(expected);
+    }
+    if sql_type == 'uuid' {
+        return _norm_uuid(stored) == _norm_uuid(expected);
+    }
+    return str(stored) == str(expected);
+}
+
+
+impl relational_parity(store: object, limit: int = 1000) -> list[str] {
+    # read-only: works regardless of JAC_RELATIONAL so `jac db parity` can
+    # inspect any database; absent tables are a finding, not a crash
+    present = store._run(
+        """
+        SELECT 1 FROM pg_tables
+        WHERE schemaname = current_schema() AND tablename = 'nodes'
+        """,
+        {}
+    );
+    if not present {
+        return [
+            'relational tables absent ' '(enable JAC_RELATIONAL=shadow and write first)'
+        ];
+    }
+    problems: list[str] = [];
+    arows = store._run(
+        """
+        SELECT id, kind, arch_type, arch_module, root_id, src, dst,
+               undirected, props
+        FROM anchors WHERE kind IN ('NodeAnchor', 'EdgeAnchor')
+        ORDER BY seq LIMIT :n
+        """,
+        {'n': limit}
+    );
+    node_anchors = [
+        r
+        for r in arows
+        if str(r[1]) == 'NodeAnchor'
+    ];
+    edge_anchors = [
+        r
+        for r in arows
+        if str(r[1]) == 'EdgeAnchor'
+    ];
+
+    dir_map: dict[str, tuple] = {};
+    if node_anchors {
+        for r in store._run(
+            'SELECT id, arch_type, root_id FROM nodes '
+            'WHERE id = ANY(CAST(:ids AS uuid[]))',
+            {'ids': [str(r[0]) for r in node_anchors]}
+        ) {
+            dir_map[_norm_uuid(r[0])] = (str(r[1]), _norm_uuid(r[2]));
+        }
+    }
+    edge_map: dict[str, tuple] = {};
+    if edge_anchors {
+        for r in store._run(
+            'SELECT id, edge_type, src, dst, undirected FROM edges '
+            'WHERE id = ANY(CAST(:ids AS uuid[]))',
+            {'ids': [str(r[0]) for r in edge_anchors]}
+        ) {
+            edge_map[_norm_uuid(r[0])] = (
+                str(r[1]),
+                _norm_uuid(r[2]),
+                _norm_uuid(r[3]),
+                bool(r[4])
+            );
+        }
+    }
+
+    groups: dict[tuple, list] = {};
+    for r in node_anchors {
+        rid = _norm_uuid(r[0]);
+        got = dir_map.get(rid);
+        if got is None {
+            problems.append(f"node {rid} ({r[2]}) missing from nodes directory");
+            continue;
+        }
+        if got[0] != str(r[2]) {
+            problems.append(f"node {rid}: directory type {got[0]} != {r[2]}");
+        }
+        if got[1] != _norm_uuid(r[4]) {
+            problems.append(f"node {rid}: directory root {got[1]} != {r[4]}");
+        }
+        groups.setdefault((str(r[2]), str(r[3])), []).append(r);
+    }
+
+    for r in edge_anchors {
+        rid = _norm_uuid(r[0]);
+        got = edge_map.get(rid);
+        if got is None {
+            problems.append(f"edge {rid} ({r[2]}) missing from edges table");
+            continue;
+        }
+        if got[0] != str(r[2]) {
+            problems.append(f"edge {rid}: edge_type {got[0]} != {r[2]}");
+        }
+        if got[1] != _norm_uuid(r[5]) or got[2] != _norm_uuid(r[6]) {
+            problems.append(
+                f"edge {rid}: endpoints ({got[1]}, {got[2]}) != "
+                f"({_norm_uuid(r[5])}, {_norm_uuid(r[6])})"
+            );
+        }
+        if got[3] != bool(r[7]) {
+            problems.append(f"edge {rid}: undirected {got[3]} != {bool(r[7])}");
+        }
+    }
+
+    for ((at, am), grp) in groups.items() {
+        plan = plan_for(at, am);
+        if plan is None {
+            continue;
+        }
+        cols = [
+            c
+            for c in plan.columns
+            if c.tier in ['scalar', 'enum', 'node_ref']
+        ];
+        sel = ['id'] + [c.col for c in cols];
+        typed: dict[str, tuple] = {};
+        for tr in store._run(
+            f"SELECT {', '.join(sel)} FROM {plan.table} "
+            'WHERE id = ANY(CAST(:ids AS uuid[]))',
+            {'ids': [str(r[0]) for r in grp]}
+        ) {
+            typed[_norm_uuid(tr[0])] = tr;
+        }
+        for r in grp {
+            rid = _norm_uuid(r[0]);
+            tr = typed.get(rid);
+            if tr is None {
+                problems.append(f"node {rid} ({at}) missing from {plan.table}");
+                continue;
+            }
+            raw_props = r[8];
+            props = (
+                raw_props if isinstance(raw_props, dict) else json.loads(str(raw_props))
+            );
+            fieldsd = _fields_dict(props);
+            for (j, c) in enumerate(cols) {
+                (ok, expected) = _coerce(c, fieldsd.get(c.name));
+                if not ok {
+                    continue;
+                }
+                if not _scalar_equal(c.sql_type, tr[j + 1], expected) {
+                    problems.append(
+                        f"node {rid} ({at}).{c.name}: "
+                        f"typed {tr[j + 1]!r} != props {expected!r}"
+                    );
+                }
+            }
+        }
+    }
+    return problems;
+}

--- a/jac/jaclang/runtimelib/impl/store.impl.jac
+++ b/jac/jaclang/runtimelib/impl/store.impl.jac
@@ -814,6 +814,8 @@ impl PgStore.upsert(rows_in: list[AnchorRow]) -> None {
             self._known_types.add(pair[0]);
         }
     }
+    import from jaclang.runtimelib.relational { relational_after_upsert }
+    relational_after_upsert(self, rows);
 }
 
 
@@ -825,6 +827,8 @@ impl PgStore.delete(ids: list[UUID]) -> None {
         'DELETE FROM anchors WHERE id = ANY(CAST(:ids AS uuid[]))',
         {'ids': [str(i) for i in ids]}
     );
+    import from jaclang.runtimelib.relational { relational_after_delete }
+    relational_after_delete(self, ids);
 }
 
 

--- a/jac/jaclang/runtimelib/relational.jac
+++ b/jac/jaclang/runtimelib/relational.jac
@@ -1,0 +1,56 @@
+"""Relational shadow store: typed tables derived from the graph schema.
+
+Routes anchor writes into the relational layout (nodes directory,
+per-node-archetype tables, one edges table) alongside the monolithic
+`anchors` table. Enabled by JAC_RELATIONAL=shadow|on; `anchors` remains
+the source of truth while parity is proven. Table plans come from the
+compiler-extracted graph_schema manifest when the defining module is
+loaded, with runtime reflection over the archetype class as fallback, so
+dynamically created types still route.
+
+No FK constraints in shadow phase: an edge may be flushed before its
+endpoints exist relationally (pre-enable rows, stubs). Constraints are a
+cutover step after backfill validates.
+"""
+
+import from uuid { UUID }
+
+glob __all__ = [
+         'ColumnSpec',
+         'TablePlan',
+         'relational_enabled',
+         'plan_for',
+         'relational_after_upsert',
+         'relational_after_delete',
+         'relational_parity',
+         'relational_reset_cache'
+     ];
+
+
+obj ColumnSpec {
+    has name: str,
+        col: str,
+        tier: str,
+        sql_type: str;
+}
+
+
+obj TablePlan {
+    has table: str,
+        arch_type: str,
+        arch_module: str,
+        columns: list[ColumnSpec];
+}
+
+
+def relational_enabled -> bool;
+
+def plan_for(arch_type: str, arch_module: str) -> (TablePlan | None);
+
+def relational_after_upsert(store: object, rows: list) -> None;
+
+def relational_after_delete(store: object, ids: list[UUID]) -> None;
+
+def relational_parity(store: object, limit: int = 1000) -> list[str];
+
+def relational_reset_cache -> None;

--- a/jac/tests/compiler/test_graph_schema_pass.jac
+++ b/jac/tests/compiler/test_graph_schema_pass.jac
@@ -1,0 +1,133 @@
+"""Graph schema extraction (GraphSchemaPass).
+
+The relational shape of a module's graph is derived from what the program
+already declares: node/edge/obj archetypes with typed `has` fields, declared
+edge endpoints (`edge E: Src --> Tgt`), and connect sites for edges declared
+without endpoints. The result lands in interop_manifest.graph_schema and is
+JSON-serializable so it can travel with the .jir cache.
+"""
+
+import json;
+import os;
+import tempfile;
+import from jaclang.jac0core.program { JacProgram }
+
+glob FIXTURE = (
+         "obj Settings {\n"
+         "    has theme: str = \"light\",\n"
+         "        lang: str = \"en\";\n"
+         "}\n"
+         "obj Payload {\n"
+         "    has data: dict = {},\n"
+         "        note: str = \"\";\n"
+         "}\n"
+         "node Profile {\n"
+         "    has username: str = \"\",\n"
+         "        followers: int = 0,\n"
+         "        settings: (Settings | None) = None,\n"
+         "        payload: Payload = Payload(),\n"
+         "        best_friend: (Tweet | None) = None;\n"
+         "}\n"
+         "node Tweet {\n"
+         "    has content: str = \"\",\n"
+         "        embedding: list[float] = [];\n"
+         "}\n"
+         "node Comment {\n"
+         "    has content: str = \"\";\n"
+         "}\n"
+         "edge Follow {}\n"
+         "edge Post: Profile --> Tweet {}\n"
+         "edge Like {\n"
+         "    has weight: float = 1.0;\n"
+         "}\n"
+         "walker add_profile {\n"
+         "    can build with `root entry {\n"
+         "        p = here ++> Profile(username=\"a\");\n"
+         "    }\n"
+         "}\n"
+         "walker interact {\n"
+         "    can act with Profile entry {\n"
+         "        t = Profile(username=\"b\") +>:Post():+> Tweet(content=\"hi\");\n"
+         "        here +>:Follow():+> Profile(username=\"c\");\n"
+         "        here +>:Like(weight=2.0):+> t[0];\n"
+         "        c = Comment(content=\"x\");\n"
+         "        here ++> c;\n"
+         "    }\n"
+         "}\n"
+     );
+
+
+def compile_fixture -> dict {
+    tmp = tempfile.mkdtemp(prefix="jac_graph_schema_");
+    path = os.path.join(tmp, "gsfix.jac");
+    with open(path, "w") as f {
+        f.write(FIXTURE);
+    }
+    prog = JacProgram();
+    mod = prog.compile(path);
+    assert not prog.errors_had , (
+        f"fixture must compile clean: {[str(e) for e in prog.errors_had]}"
+    );
+    return mod.gen.interop_manifest.graph_schema;
+}
+
+
+def field_map(spec: dict) -> dict {
+    return {f['name']: f for f in spec['fields']};
+}
+
+
+test "node has-fields classify into storage tiers" {
+    gs = compile_fixture();
+    assert set(gs['nodes'].keys()) == {'Profile', 'Tweet', 'Comment'};
+    prof = field_map(gs['nodes']['Profile']);
+    assert prof['username']['tier'] == 'scalar' and prof['username']['type'] == 'str';
+    assert prof['followers']['tier'] == 'scalar';
+    assert prof['settings']['tier'] == 'obj' and prof['settings']['optional'];
+    assert prof['settings']['target'] == 'Settings';
+    assert prof['payload']['tier'] == 'obj' and not prof['payload']['optional'];
+    assert prof['best_friend']['tier'] == 'node_ref';
+    assert prof['best_friend']['target'] == 'Tweet';
+    assert prof['best_friend']['optional'];
+    tweet = field_map(gs['nodes']['Tweet']);
+    assert tweet['embedding']['tier'] == 'scalar_list';
+}
+
+test "declared edge endpoints are authoritative and observations corroborate" {
+    gs = compile_fixture();
+    post = gs['edges']['Post'];
+    assert post['declared'] == {'src': 'Profile', 'dst': 'Tweet'};
+    assert ['Profile', 'Tweet'] in post['observed'];
+}
+
+test "undeclared edges get endpoints observed at connect sites" {
+    gs = compile_fixture();
+    follow = gs['edges']['Follow'];
+    assert follow['declared'] is None;
+    assert ['Profile', 'Profile'] in follow['observed'];
+
+    # `t[0]` is not statically resolvable: the destination must stay open,
+    # never guessed.
+    like = gs['edges']['Like'];
+    assert ['Profile', None] in like['observed'];
+    lf = field_map(like);
+    assert lf['weight']['tier'] == 'scalar';
+}
+
+test "bare ++> records against GenericEdge including root sources" {
+    gs = compile_fixture();
+    gen = gs['edges']['GenericEdge'];
+    assert ['Root', 'Profile'] in gen['observed'];
+    assert ['Profile', None] in gen['observed'];
+}
+
+test "objs report flat_scalar for side-table eligibility" {
+    gs = compile_fixture();
+    assert gs['objs']['Settings']['flat_scalar'];
+    assert not gs['objs']['Payload']['flat_scalar'];
+}
+
+test "graph schema is json-serializable for the jir cache" {
+    gs = compile_fixture();
+    assert json.loads(json.dumps(gs)) == gs;
+}

--- a/jac/tests/runtimelib/test_relational_shadow.jac
+++ b/jac/tests/runtimelib/test_relational_shadow.jac
@@ -1,0 +1,216 @@
+"""Relational shadow store (A2 of the relational schema program).
+
+With JAC_RELATIONAL=shadow every flush dual-writes anchors AND the
+relational layout (nodes directory, per-archetype typed tables, one edges
+table) in the same transaction; anchors stays the source of truth and
+relational_parity proves the copies agree. Every test runs against a real
+embedded Postgres.
+"""
+
+import os;
+import from pathlib { Path }
+import from tempfile { TemporaryDirectory }
+import from jaclang.jac0core.archetype { EdgeAnchor, NodeAnchor, Root }
+import from jaclang.jac0core.runtime { JacRuntime }
+import from jaclang.runtimelib.context { ExecutionContext }
+import from jaclang.runtimelib.relational { plan_for, relational_parity }
+
+node RItem {
+    has tag: str = "",
+        num: int = 0,
+        score: float = 0.0,
+        flag: bool = False,
+        blob: dict = {};
+}
+
+edge RRel {
+    has w: int = 0;
+}
+
+
+def _make_ctx(tmpdir: str) -> ExecutionContext {
+    target = str(Path(tmpdir) / "rel_app.jac");
+    return ExecutionContext(base_path_dir=tmpdir, full_target_path=target);
+}
+
+
+def _root(ctx: ExecutionContext) -> NodeAnchor {
+    ranch = Root().__jac__;
+    ranch.persistent = True;
+    ctx.mem.put(ranch);
+    return ranch;
+}
+
+
+def _attach(
+    ctx: ExecutionContext, ranch: NodeAnchor, tag: str, num: int
+) -> NodeAnchor {
+    nanch = RItem(tag=tag, num=num, score=1.5, flag=True, blob={'k': 1}).__jac__;
+    nanch.persistent = True;
+    eanch = EdgeAnchor(
+        archetype=RRel(w=num), source=ranch, target=nanch, is_undirected=False
+    );
+    eanch.persistent = True;
+    ranch.edges.append(eanch);
+    nanch.edges.append(eanch);
+    ctx.mem.put(nanch);
+    ctx.mem.put(eanch);
+    return nanch;
+}
+
+
+def _item_table(store: object) -> str {
+    rows = store.rows(
+        "SELECT table_name FROM graph_tables WHERE arch_type = 'RItem'", {}
+    );
+    assert rows , "RItem must be catalogued in graph_tables";
+    return str(rows[0][0]);
+}
+
+
+test "shadow flush lands nodes in directory and typed table, edges in edges" {
+    os.environ['JAC_RELATIONAL'] = 'shadow';
+    try {
+        with TemporaryDirectory() as td {
+            old = JacRuntime.exec_ctx;
+            ctx = _make_ctx(td);
+            JacRuntime.exec_ctx = ctx;
+            try {
+                ranch = _root(ctx);
+                it = _attach(ctx, ranch, "x", 7);
+                ctx.mem.commit();
+                st = ctx.mem.store;
+
+                dirr = st.rows(
+                    'SELECT arch_type, root_id FROM nodes WHERE id = CAST(:id AS uuid)',
+                    {'id': str(it.id)}
+                );
+                assert dirr and str(dirr[0][0]) == 'RItem' , (
+                    f"directory row missing/wrong: {dirr}"
+                );
+
+                t = _item_table(st);
+                tr = st.rows(
+                    f"SELECT f_tag, f_num, f_score, f_flag FROM {t} "
+                    'WHERE id = CAST(:id AS uuid)',
+                    {'id': str(it.id)}
+                );
+                assert tr , f"typed row missing from {t}";
+                assert str(tr[0][0]) == 'x';
+                assert int(str(tr[0][1])) == 7;
+                assert abs(float(str(tr[0][2])) - 1.5) < 1e-9;
+                assert bool(tr[0][3]);
+
+                er = st.rows("SELECT src, dst FROM edges WHERE edge_type = 'RRel'", {});
+                assert er , 'RRel edge row missing';
+                assert str(er[0][0]).replace('-', '') == ranch.id.hex;
+                assert str(er[0][1]).replace('-', '') == it.id.hex;
+
+                probs = relational_parity(st);
+                assert probs == [] , f"parity: {probs}";
+            } finally {
+                JacRuntime.exec_ctx = old;
+                ctx.close();
+            }
+        }
+    } finally {
+        os.environ.pop('JAC_RELATIONAL', None);
+    }
+}
+
+
+test "field update and delete propagate; parity stays clean" {
+    os.environ['JAC_RELATIONAL'] = 'shadow';
+    try {
+        with TemporaryDirectory() as td {
+            old = JacRuntime.exec_ctx;
+            ctx = _make_ctx(td);
+            JacRuntime.exec_ctx = ctx;
+            try {
+                ranch = _root(ctx);
+                it = _attach(ctx, ranch, "before", 1);
+                ctx.mem.commit();
+                st = ctx.mem.store;
+                t = _item_table(st);
+
+                it.archetype.tag = 'after';
+                it.archetype.num = 42;
+                ctx.mem.mark_dirty(it);
+                ctx.mem.commit();
+                tr = st.rows(
+                    f"SELECT f_tag, f_num FROM {t} WHERE id = CAST(:id AS uuid)",
+                    {'id': str(it.id)}
+                );
+                assert str(tr[0][0]) == 'after' and int(str(tr[0][1])) == 42 , (
+                    f"update did not propagate: {tr}"
+                );
+                assert relational_parity(st) == [];
+
+                for e in list(ranch.edges) {
+                    ranch.edges.remove(e);
+                    it.edges.remove(e);
+                    ctx.mem.delete(e.id);
+                }
+                ctx.mem.delete(it.id);
+                ctx.mem.commit();
+                assert st.rows(
+                    'SELECT id FROM nodes WHERE id = CAST(:id AS uuid)',
+                    {'id': str(it.id)}
+                )
+                    == [];
+                assert st.rows(
+                    f"SELECT id FROM {t} WHERE id = CAST(:id AS uuid)",
+                    {'id': str(it.id)}
+                )
+                    == [];
+                assert st.rows("SELECT id FROM edges WHERE edge_type = 'RRel'", {})
+                    == [];
+                assert relational_parity(st) == [];
+            } finally {
+                JacRuntime.exec_ctx = old;
+                ctx.close();
+            }
+        }
+    } finally {
+        os.environ.pop('JAC_RELATIONAL', None);
+    }
+}
+
+
+test "table plan derives typed columns for declared fields" {
+    plan = plan_for('RItem', RItem.__module__);
+    assert plan is not None , "plan must derive from manifest or reflection";
+    tiers = {c.name: (c.tier, c.sql_type) for c in plan.columns};
+    assert tiers['tag'] == ('scalar', 'text');
+    assert tiers['num'] == ('scalar', 'bigint');
+    assert tiers['score'] == ('scalar', 'double precision');
+    assert tiers['flag'] == ('scalar', 'boolean');
+    assert tiers['blob'][1] == 'jsonb';
+}
+
+
+test "disabled flag writes nothing relational" {
+    os.environ.pop('JAC_RELATIONAL', None);
+    with TemporaryDirectory() as td {
+        old = JacRuntime.exec_ctx;
+        ctx = _make_ctx(td);
+        JacRuntime.exec_ctx = ctx;
+        try {
+            ranch = _root(ctx);
+            _attach(ctx, ranch, "x", 1);
+            ctx.mem.commit();
+            st = ctx.mem.store;
+            present = st.rows(
+                """
+                SELECT tablename FROM pg_tables
+                WHERE schemaname = current_schema() AND tablename = 'nodes'
+                """,
+                {}
+            );
+            assert present == [] , "nodes table must not exist when disabled";
+        } finally {
+            JacRuntime.exec_ctx = old;
+            ctx.close();
+        }
+    }
+}


### PR DESCRIPTION
Part of the relational-schema program (RFC: jaseci-labs/jac#8366 is PR1). **Not GitHub-stacked** — targets `main`, merges **after** #8366. Its diff includes #8366's commits until that merges.

## What

A relational **shadow store**: with `JAC_RELATIONAL=shadow`, every `PgStore.upsert`/`delete` also routes rows into the relational layout **in the same transaction** as the `anchors` write, so the two copies cannot diverge across a commit boundary.

The layout: a `nodes` directory (id -> arch_type/root, the global FK target), one `edges` table, and one lazily-created typed table per node archetype (typed column per scalar/enum/ref field, per-field jsonb otherwise, `acl_all`/`acl_spec`/`access` scalars, `extra` jsonb spillover).

## How it stays correct

- **Anchors remains the source of truth**; reads are unchanged in this PR.
- Table plans resolve manifest-first (the `graph_schema` from PR1) and fall back to runtime reflection, so dynamically created types still route.
- Coercion is guarded per tier: a value that does not fit its column lands in `extra` instead of failing the write.
- No FK constraints yet — shadow must accept everything `anchors` accepts.

`relational_parity(store)` / `jac db parity` compare the two copies (directory presence/type/root, edge endpoints, typed columns vs the props projection).

## Safety & cost

Off unless `JAC_RELATIONAL` is set. Measured write cost of the dual-write: ~2% (littleX 100-user seed).

## Testing

4 tests in `tests/runtimelib/test_relational_shadow.jac`. The existing PG persistence surface (42 tests) passes with the flag ON, turning each into a dual-write parity exercise. Parity on a 100-user graph: 729/729 nodes, 730/730 edges, 0 problems.
