### PR TITLE
ci(native): the aarch64 lane is bounded, so an apt stall stops eating a morning of main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,6 +887,15 @@ jobs:
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
     runs-on: ubuntu-latest
+    # The apt step below has twice hung until GitHub's 6h job ceiling killed it
+    # (runs 32084692251 and 32233728853, both stuck on `apt-get`). Nothing here
+    # legitimately runs longer than ~10 min. The ceiling is not just wasted
+    # runner time: push-to-main serializes on the `ci-refs/heads/main`
+    # concurrency group, so a 6h job holds the group for 6h, and GitHub keeps
+    # only one pending run per group -- every commit merged in that window is
+    # dropped with zero jobs. Bound it here so the blast radius of an apt stall
+    # is one red lane, not a morning of untested commits.
+    timeout-minutes: 30
     # Dev lane: run THIS checkout's compiler (see test-compiler).
     env:
       JAC_NO_DEV_SOURCE: ""


### PR DESCRIPTION
`test-native-aarch64` has no `timeout-minutes`, so when its `apt-get install qemu-user-static libc6-arm64-cross` step stalls, it runs until GitHub's 6h job ceiling. That has happened twice in two days, both cancelled at the ceiling on that one step:

| run | aarch64 lane | outcome |
|---|---|---|
| [32084692251](https://github.com/jaseci-labs/jac/actions/runs/32084692251) | `00:29 -> 06:17` | cancelled at ceiling |
| [32233728853](https://github.com/jaseci-labs/jac/actions/runs/32233728853) | `08:42 -> 14:42` | cancelled at ceiling |

The lane's normal duration is 5-8 min. It is stalled on that same step right now in [32267539497](https://github.com/jaseci-labs/jac/actions/runs/32267539497), where every other job in the run finished within 90 min.

## Why this matters more than the wasted runner time

Push-to-main runs share the `ci-refs/heads/main` concurrency group with `cancel-in-progress: false`, so a 6h job holds that group for 6h. GitHub keeps only **one** pending run per group: each new merge cancels the previously pending one. So every commit merged during a hang is silently dropped.

During 32233728853's hold, four consecutive main pushes ran **zero jobs**. The cancellations land 1-2s after the next push's run is created, which is the concurrency queue evicting the pending run:

| dropped run | created | cancelled | next run created |
|---|---|---|---|
| 32242566558 | 10:25:00 | 11:29:01 | 11:29:00 |
| 32247790608 | 11:29:00 | 11:55:03 | 11:55:01 |
| 32249954323 | 11:55:01 | 11:56:05 | 11:56:03 |
| 32250044559 | 11:56:03 | 13:01:11 | 13:01:10 |

Four commits landed on main with no CI at all, reported as `cancelled` rather than as a failure, so nothing surfaces it.

Across the last 60 main pushes: 35 success, 10 failure, 13 cancelled. **10 of those cancelled ran zero jobs**, and 5 of the 10 were behind one of these two hangs.

## The fix

`timeout-minutes: 30` on the job. That is ~4x headroom over the lane's real runtime, and it caps the blast radius of an apt stall at one red lane instead of a morning of untested commits.

## Out of scope

The other 5 dropped commits were behind ordinary-length runs (23-67 min) during merge bursts, against a median main merge gap of 32 min. Those need a concurrency-policy change rather than a timeout, and that is deliberately not in this PR.
