### PR TITLE
ci(native): remove the aarch64 cross lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,14 @@ jobs:
             installer:
               - 'scripts/install.sh'
             # NARROWING filter (like `installer`, unlike `scale`/`byllm`, which
-            # only ever widen `core`). The macOS and aarch64 native lanes cost a
-            # macOS runner and a qemu-user cross build, and `core: jac/**` fired
-            # them on every runtimelib/scale PR that could not possibly move
-            # Mach-O linking, the na->wasm floor, or MOVW_UABS relocations.
+            # only ever widen `core`). The macOS native lane costs a macOS
+            # runner, and `core: jac/**` fired it on every runtimelib/scale PR
+            # that could not possibly move Mach-O linking or the na->wasm floor.
             # Deliberately excludes ci.yml (matching every other narrow filter
             # here) and jac0core/** -- payload-compiler regressions surface in
             # test-compiler/test-runtime, which are not path-filtered off. To
-            # exercise these lanes on a PR that touches none of these paths, use
-            # workflow_dispatch; push-to-main always runs them.
+            # exercise this lane on a PR that touches none of these paths, use
+            # workflow_dispatch; push-to-main always runs it.
             native:
               - 'jac/jaclang/compiler/passes/native/**'
               - 'jac/tests/compiler/passes/native/**'
@@ -878,51 +877,6 @@ jobs:
           .jac-xdg/jac/jir
           jac/.jac/cache
         key: jac-jir-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
-
-  # aarch64 cross lane (#7626 C1): cross-compile with the in-house ELF linker
-  # (MOVW_UABS relocation family) + arch-parameterized vendored musl, run the
-  # binaries under qemu-user. This was the native suite's last environmental
-  # skip: without qemu + cross libc the #6366 runtime tests never execute.
-  test-native-aarch64:
-    needs: changes
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
-    runs-on: ubuntu-latest
-    # Dev lane: run THIS checkout's compiler (see test-compiler).
-    env:
-      JAC_NO_DEV_SOURCE: ""
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v5
-      with:
-        submodules: true
-
-    - name: Install qemu-user and aarch64 cross libc
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends qemu-user-static libc6-arm64-cross
-
-    - name: Set up jac (dev lane)
-      uses: ./.github/actions/setup-jac-dev
-
-    - name: Set up Zig 0.16.0 (vendor cross musl)
-      uses: mlugg/setup-zig@v2
-      with:
-        version: 0.16.0
-        use-cache: false
-
-    - name: Vendor cross musl (aarch64)
-      working-directory: jac
-      run: zig build -Dno-ninja vendor-musl-linux-aarch64 --summary all
-
-    - name: Run aarch64 cross tests under qemu
-      env:
-        JAC_TEST_JOBS: "0"
-        # The sealed CI binary's pkg_root only bundles host-arch musl; point
-        # the static-link search at the repo-vendored cross runtime.
-        JAC_NATIVE_MUSL_DIR: ${{ github.workspace }}/jac/.pbs-build/linux-aarch64/musl/lib
-      run: >-
-        jac test jac/tests/compiler/passes/native/test_native_gen_pass.jac
-        -f aarch64
 
   # Launcher unit tests: trailer codec + `.jab`-overlay round-trip
   # (append / detect / materialize-steps-over-overlay / graft). runtime.zig is
@@ -1780,7 +1734,6 @@ jobs:
       - test-client
       - test-packages-and-docs
       - test-native-macos
-      - test-native-aarch64
       - test-launcher
       - test-cef-build
       - test-scale


### PR DESCRIPTION
Removes the `test-native-aarch64` job, its entry in the `Everything Passed` gate, and the half of the `native` filter comment that described it. Net 52 lines deleted, and 5.3 min/run of CI time.

## What it did, and what is lost

This was the only lane in CI that executed native-compiled code on a non-x86 architecture. It cross-compiled a module-level-global fixture to both `aarch64-unknown-linux-gnu` (in-house ELF linker) and `aarch64-unknown-linux-musl` (vendored cross musl), ran each under `qemu-user`, and asserted exit 42 — the fixture returns the computed value as its exit code precisely so a pass proves the global round-tripped rather than merely that the process avoided a crash.

What it guarded, per the fixture's own docstring:

> `total` is a module-level global, so storing and reloading it emits a movz/movk absolute-address chain relocated by `R_AARCH64_MOVW_UABS_G0..G3`. If the in-house linker drops those relocations the address stays NULL and the binary segfaults at entry.

That relocation family only exists on ARM64. No x86 lane can regress-test it, and `build-binaries.yml` still ships `linux-aarch64` and `macos-aarch64` legs — so Apple Silicon and ARM Linux users have no CI coverage of native codegen on their architecture after this.

Raising that so the tradeoff is explicit and on the record, not to block the change.

## What survives

The tests stay in `tests/compiler/passes/native/test_native_gen_pass.jac`. `test-compiler` runs that file via `run_chunk passes-native`, so **`clib AArch64 AAPCS ABI lowering` keeps running** on every native PR and every push to main — it is compile-only and asserts the module retargets.

The two execution tests probe for `qemu-aarch64-static` and the vendored cross musl and call `testskip()` when absent, so they now skip everywhere in CI while remaining usable locally for anyone who installs qemu-user. If the intent is to drop the coverage permanently rather than park it, those two tests should probably be deleted too — happy to follow up.

## Cost recovered

```
 51s  Install qemu-user and aarch64 cross libc
 29s  Set up jac (dev lane)
 79s  Vendor cross musl (aarch64)
143s  Run aarch64 cross tests under qemu
      ------ 5.3m total
```

Two thirds of the lane was building the environment rather than testing anything.

## Interaction with #8392

#8392 adds `timeout-minutes: 30` to this job, to bound the `apt-get` hang that twice ran to GitHub's 6h job ceiling and held the `ci-refs/heads/main` concurrency group, dropping four merged commits with zero CI. **If this PR lands, #8392 is moot and should be closed.** If this lane is kept instead, #8392 is the fix for the reason it was painful.
