### PR TITLE
Revert "ci(native): remove the aarch64 cross lane (#8394)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,15 @@ jobs:
             installer:
               - 'scripts/install.sh'
             # NARROWING filter (like `installer`, unlike `scale`/`byllm`, which
-            # only ever widen `core`). The macOS native lane costs a macOS
-            # runner, and `core: jac/**` fired it on every runtimelib/scale PR
-            # that could not possibly move Mach-O linking or the na->wasm floor.
+            # only ever widen `core`). The macOS and aarch64 native lanes cost a
+            # macOS runner and a qemu-user cross build, and `core: jac/**` fired
+            # them on every runtimelib/scale PR that could not possibly move
+            # Mach-O linking, the na->wasm floor, or MOVW_UABS relocations.
             # Deliberately excludes ci.yml (matching every other narrow filter
             # here) and jac0core/** -- payload-compiler regressions surface in
             # test-compiler/test-runtime, which are not path-filtered off. To
-            # exercise this lane on a PR that touches none of these paths, use
-            # workflow_dispatch; push-to-main always runs it.
+            # exercise these lanes on a PR that touches none of these paths, use
+            # workflow_dispatch; push-to-main always runs them.
             native:
               - 'jac/jaclang/compiler/passes/native/**'
               - 'jac/tests/compiler/passes/native/**'
@@ -877,6 +878,51 @@ jobs:
           .jac-xdg/jac/jir
           jac/.jac/cache
         key: jac-jir-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
+
+  # aarch64 cross lane (#7626 C1): cross-compile with the in-house ELF linker
+  # (MOVW_UABS relocation family) + arch-parameterized vendored musl, run the
+  # binaries under qemu-user. This was the native suite's last environmental
+  # skip: without qemu + cross libc the #6366 runtime tests never execute.
+  test-native-aarch64:
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
+    runs-on: ubuntu-latest
+    # Dev lane: run THIS checkout's compiler (see test-compiler).
+    env:
+      JAC_NO_DEV_SOURCE: ""
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v5
+      with:
+        submodules: true
+
+    - name: Install qemu-user and aarch64 cross libc
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends qemu-user-static libc6-arm64-cross
+
+    - name: Set up jac (dev lane)
+      uses: ./.github/actions/setup-jac-dev
+
+    - name: Set up Zig 0.16.0 (vendor cross musl)
+      uses: mlugg/setup-zig@v2
+      with:
+        version: 0.16.0
+        use-cache: false
+
+    - name: Vendor cross musl (aarch64)
+      working-directory: jac
+      run: zig build -Dno-ninja vendor-musl-linux-aarch64 --summary all
+
+    - name: Run aarch64 cross tests under qemu
+      env:
+        JAC_TEST_JOBS: "0"
+        # The sealed CI binary's pkg_root only bundles host-arch musl; point
+        # the static-link search at the repo-vendored cross runtime.
+        JAC_NATIVE_MUSL_DIR: ${{ github.workspace }}/jac/.pbs-build/linux-aarch64/musl/lib
+      run: >-
+        jac test jac/tests/compiler/passes/native/test_native_gen_pass.jac
+        -f aarch64
 
   # Launcher unit tests: trailer codec + `.jab`-overlay round-trip
   # (append / detect / materialize-steps-over-overlay / graft). runtime.zig is
@@ -1734,6 +1780,7 @@ jobs:
       - test-client
       - test-packages-and-docs
       - test-native-macos
+      - test-native-aarch64
       - test-launcher
       - test-cef-build
       - test-scale


### PR DESCRIPTION
Reverts a9938ce72 (#8394). `ci.yml` is byte-identical to its state before that merge — verified by diff against 2a5ab3450.

Restores `test-native-aarch64`, its entry in the `Everything Passed` gate, and the `native` filter comment describing both native lanes.

## Why

The lane is the only one in CI that executes native-compiled code on a non-x86 architecture. It cross-compiles a module-level-global fixture to `aarch64-unknown-linux-gnu` (in-house ELF linker) and `aarch64-unknown-linux-musl` (vendored cross musl), runs each under `qemu-user`, and asserts exit 42 — the fixture returns the computed value as its exit code so a pass proves the global round-tripped, not just that the process avoided a crash.

It guards the `R_AARCH64_MOVW_UABS_G0..G3` relocation family, which exists only on ARM64 and which no x86 lane can regress-test, while `build-binaries.yml` ships `linux-aarch64` and `macos-aarch64` legs.

## The actual problem, which is separate

The lane's cost profile, not its coverage. Its `apt-get` step is unbounded and twice ran to GitHub's 6h job ceiling:

| run | aarch64 lane |
|---|---|
| [32084692251](https://github.com/jaseci-labs/jac/actions/runs/32084692251) | `00:29 -> 06:17` |
| [32233728853](https://github.com/jaseci-labs/jac/actions/runs/32233728853) | `08:42 -> 14:42` |

Because push-to-main runs share the `ci-refs/heads/main` concurrency group with `cancel-in-progress: false`, each hang held that group for six hours, and GitHub keeps only one pending run per group — so four commits merged during the second hang landed on main with zero jobs.

#8392 bounds the job at 30 minutes and is the fix for that. It applies cleanly again once this lands.

No release-note fragment: `scripts/check-release-notes.sh` triggers on `jac/jaclang/` paths, and this touches only `.github/workflows/ci.yml`.
