### PR TITLE
fix(compiler): a module resolves its own package's dotted imports in its own tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,15 @@ jobs:
             jac/tests/cli/test_manifest_parity.jac \
             jac/tests/cli/test_startup_isolation.jac
 
+      # The targets ARE jaclang's source, and jaclang.* belongs to the running
+      # compiler: checked sealed, a checkout module's `import from
+      # jaclang.x` resolves into the kit's bundled copy, and one class gets two
+      # identities ("Cannot assign ServingApp to parameter of type
+      # ServingApp"). Check the tree with its own compiler instead (sealed:
+      # "" clears JAC_NO_DEV_SOURCE, as the equivalence chunk does).
       - name: Run jac check (using .jacignore)
+        env:
+          JAC_NO_DEV_SOURCE: ""
         run: |
           set -euo pipefail
           IGNORE_ARGS="tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ')"

--- a/jac/jaclang/jac0core/modresolver.jac
+++ b/jac/jaclang/jac0core/modresolver.jac
@@ -5,7 +5,8 @@ import from pathlib { Path }
 import from jaclang.jac0core.ext_registry { MODULE_SUFFIXES, language_of }
 
 glob _project_root_cache: dict = {},
-     _import_base_stack: list = [];
+     _import_base_stack: list = [],
+     COMPILER_PACKAGE: str = 'jaclang';
 
 def push_import_base(base_dir: str) {
     _import_base_stack.append(base_dir);
@@ -123,6 +124,28 @@ def _candidate_from(base: str, parts: list[str]) -> (tuple[(str, str)] | None) {
         return ((candidate + '.js'), 'js');
     }
     return None;
+}
+
+def _self_tree_candidate(
+    base_dir: str, actual_parts: list[str]
+) -> (tuple[(str, str)] | None) {
+    if actual_parts[0] == COMPILER_PACKAGE {
+        return None;
+    }
+    cur = os.path.abspath(base_dir);
+    while True {
+        parent = os.path.dirname(cur);
+        if parent == cur {
+            return None;
+        }
+        if os.path.basename(cur) == actual_parts[0] {
+            res = _candidate_from(parent, actual_parts);
+            if res {
+                return res;
+            }
+        }
+        cur = parent;
+    }
 }
 
 def _resolve_jac_virtual_module(target: str) -> (tuple[(str, str)] | None) {
@@ -297,6 +320,10 @@ def resolve_module(
         }
         actual_parts = parts[level:];
         res = _candidate_from(base_dir, actual_parts);
+        if res {
+            return res;
+        }
+        res = _self_tree_candidate(base_dir, actual_parts);
         if res {
             return res;
         }

--- a/jac/tests/compiler/test_self_tree_resolution.jac
+++ b/jac/tests/compiler/test_self_tree_resolution.jac
@@ -1,0 +1,118 @@
+"""A module inside a package resolves that package's dotted imports in its own tree.
+
+When two content-identical copies of a package are reachable -- the file
+being compiled sits in one, while importlib can reach the other (the sealed
+binary's bundled jaclang against a checked-out jaclang source tree, or an
+installed wheel of the project being checked) -- every dotted self-import
+must resolve inside the tree the compiled file belongs to. Splitting the
+resolution across copies hands one program two identities for the same
+class, which surfaces as nonsense diagnostics of the shape "Cannot assign
+ServingApp to parameter of type ServingApp" (E1053).
+
+The one package exempt from this rule is the compiler's own: jaclang.* is
+whatever tree the running compiler was loaded from, because jac0core is
+compiled under the self-compile rules that `is_compiler_source_path`
+gates, and a second copy of it is a different compiler's source, not a
+module of this one. A checkout of jaclang checks itself through the
+`[dev] jaclang_source` reroute, never through a sealed binary.
+"""
+
+import os;
+import shutil;
+import sys;
+import tempfile;
+import importlib;
+import jaclang;
+import from pathlib { Path }
+import from jaclang.jac0core.modresolver { resolve_relative_path }
+import from jaclang.jac0core.program { JacProgram }
+import from jaclang.jac0core.compile_options { CompileOptions }
+
+glob PKG_FILES: dict[str, str] = {
+         '__init__.jac': '',
+         'app.jac': (
+             'obj Gadget { has n: int = 0; }\n\n'
+             'def use_gadget -> int {\n'
+             '    import from dup_pkg.helper { widget_id }\n'
+             '    return widget_id(Gadget());\n'
+             '}\n'
+         ),
+         'helper.jac': (
+             'import from dup_pkg.app { Gadget }\n\n'
+             'def widget_id(g: Gadget) -> int { return g.n; }\n'
+         ),
+
+     };
+
+def _write_copy(base: str) -> Path {
+    pkg = Path(base) / 'dup_pkg';
+    pkg.mkdir(parents=True);
+    for (rel, content) in PKG_FILES.items() {
+        (pkg / rel).write_text(content);
+    }
+    return pkg;
+}
+
+def _with_shadow_copy(body: callable) {
+    home = tempfile.mkdtemp();
+    shadow = tempfile.mkdtemp();
+    home_pkg = _write_copy(home);
+    _write_copy(shadow);
+    sys.path.insert(0, shadow);
+    importlib.invalidate_caches();
+    try {
+        body(home_pkg, shadow);
+    } finally {
+        sys.path.remove(shadow);
+        sys.modules.pop('dup_pkg', None);
+        sys.modules.pop('dup_pkg.app', None);
+        sys.modules.pop('dup_pkg.helper', None);
+        importlib.invalidate_caches();
+        shutil.rmtree(home, ignore_errors=True);
+        shutil.rmtree(shadow, ignore_errors=True);
+    }
+}
+
+test "dotted self-import resolves in the importing file's own tree" {
+    def body(home_pkg: Path, shadow: str) {
+        resolved = resolve_relative_path('dup_pkg.helper', str(home_pkg / 'app.jac'));
+        assert os.path.realpath(resolved)
+            == os.path.realpath(str(home_pkg / 'helper.jac')) , f"resolved into the shadow copy: {resolved}";
+    }
+    _with_shadow_copy(body);
+}
+
+test "type check holds one identity per class across a self-import cycle" {
+    def body(home_pkg: Path, shadow: str) {
+        prog = JacProgram();
+        prog.compile(
+            file_path=str(home_pkg / 'app.jac'),
+            options=CompileOptions(
+                type_check=True, no_cgen=True, force_target_program=True
+            )
+        );
+        errs = [str(e) for e in prog.errors_had];
+        assert not errs , f"identity split across package copies: {errs}";
+    }
+    _with_shadow_copy(body);
+}
+
+test "the compiler's own package stays with the running compiler" {
+    home = tempfile.mkdtemp();
+    copy = Path(home) / 'jaclang' / 'runtimelib' / 'serving';
+    copy.mkdir(parents=True);
+    (Path(home) / 'jaclang' / '__init__.jac').write_text('');
+    (copy / 'app.jac').write_text('obj ServingApp {}\n');
+    (copy / 'openapi.jac').write_text(
+        'import from jaclang.runtimelib.serving.app { ServingApp }\n'
+    );
+    try {
+        resolved = resolve_relative_path(
+            'jaclang.runtimelib.serving.openapi', str(copy / 'app.jac')
+        );
+        running = os.path.dirname(os.path.realpath(jaclang.__file__));
+        assert os.path.realpath(resolved).startswith(running + os.sep) , f"resolved into the foreign copy: {resolved}";
+    } finally {
+        shutil.rmtree(home, ignore_errors=True);
+    }
+}

--- a/release_notes/unreleased/jaclang/8448.bugfix.md
+++ b/release_notes/unreleased/jaclang/8448.bugfix.md
@@ -1,0 +1,1 @@
+- **A module resolves its own package's dotted imports in its own tree**: when a second copy of the package is reachable (a sealed binary's bundled jaclang, an installed wheel of the project being checked), `jac check` no longer splits one class into two identities and fails with "Cannot assign X to parameter of type X".


### PR DESCRIPTION
## Why main's jac-check is red

Every push to main since #8264 fails jac-check on one diagnostic:

```
error[E1053]: Cannot assign ServingApp to parameter 'app' of type ServingApp
  --> jac/jaclang/runtimelib/serving/app.jac:178:30
```

#8264 sets `JAC_NO_DEV_SOURCE=1` workflow-wide, so jac-check now runs the sealed kit's **bundled** jaclang while sweeping the **checkout**. For a dotted target like `jaclang.runtimelib.serving.openapi`, `resolve_module` falls through to `importlib.util.find_spec`, which answers from wherever the running compiler's `jaclang` package lives: the bundled copy. So the checked `app.jac` is the checkout copy, the `openapi.jac` it pulls in is the bundled copy, and that copy's `import from jaclang.runtimelib.serving.app { ServingApp }` closes the cycle on a *second* `ServingApp`. One program, two identities for one class; `build_openapi(self)` cannot type.

PRs never see it because the PR-scoped check only compiles the PR's changed files, and nobody has touched `app.jac`. (The first day of red was a different, since-fixed break: #8315 made `entry` a hard keyword and `prefix_flip.jac` still used it; that syntax error masked this one until #8425.)

## Fix -- one change per half of the problem

**Resolver.** `resolve_module` probes the importing file's own tree before the typeshed and importlib steps: when the file lives under a directory named like the target's head package, the candidate is built from that directory's parent. A module that names its own package gets the copy it belongs to, whichever other copy importlib can reach (an installed wheel of the project being checked, a bundled snapshot).

The compiler's own package is the one exemption: `jaclang.*` is whatever tree the running compiler was loaded from. jac0core is compiled under the self-compile rules `is_compiler_source_path` gates, so a second copy of it is a different compiler's source, not a module of this one. Without the exemption, the sealed kit running `jac run jac/jaclang/utils/precompile_bytecode.jac` pulled the checkout's jac0core in as user code and rejected `anchor.root = ...` / `pass;` in `runtime.impl.jac` (E0024, E0010) -- which is what `test-jac-pack-smoke` and `test-scale (microservices)` caught on the first revision of this PR.

**CI.** jac-check's `jac check` step clears `JAC_NO_DEV_SOURCE`, the way the equivalence chunk already does: its targets *are* jaclang's source, so the tree is checked with its own compiler through the `[dev] jaclang_source` reroute, and there is one jaclang tree in the program. Every other job keeps the sealed consumer shape #8264 established.

## Verification

- Reproduced byte-for-byte with the failing run's own `jac-kit` artifact: `JAC_NO_DEV_SOURCE=1 jac check jac/jaclang/runtimelib/serving/app.jac` -> the E1053 above. The precompile regression of revision 1 reproduced the same way with this PR's first kit.
- Full-tree `jac check .` with CI's ignore set: 564 passed before and after.
- `jac test tests/compiler/test_*.jac` 792 passed; `tests/compiler/passes/main tests/compiler/passes/ecmascript` 1110 passed; `tests/language` 377 passed (the passes-native chunk passed in CI on revision 1, whose resolver change was a superset of this one).
- New `tests/compiler/test_self_tree_resolution.jac`: plants a second copy of a package on `sys.path` and asserts the dotted self-import resolves in the importing file's copy and that a type check across the import cycle is clean (both fail without the probe); and asserts a foreign copy of `jaclang` still resolves `jaclang.*` into the running compiler's tree.
