### PR TITLE
ci: the darwin native lane moves to nightly, and the PR graph stops waiting on it

### DIFF
--- a/.github/workflows/_macos-native.yml
+++ b/.github/workflows/_macos-native.yml
@@ -1,0 +1,98 @@
+name: macOS native
+
+# The darwin native lane: the sealed macOS kit and the Mach-O / wasm-floor /
+# libSystem-equivalence tests that consume it. Two callers share this one copy:
+#   - nightly.yml (macos-native): daily, the default home for this lane.
+#   - ci.yml      (macos-native): PR lane, OPT-IN via the `macos` label, plus
+#     workflow_dispatch.
+#
+# Why it is not on every PR: the macOS kit is 44-68 min of critical path
+# (macos-26-arm64, ~3x the Linux leg for the same cold 622-module
+# precompile+seal) and it gated merge. Over 60 consecutive CI runs it refused
+# 12 seals -- and Linux `build-kit` refused in all 12 of the same runs, so the
+# darwin leg contributed no unique signal while costing the whole graph its
+# wall clock. `test-native-macos` failed once in the same window, on a
+# type-check diagnostic that is platform-independent.
+#
+# That is an argument about WHERE it runs, not about whether it matters:
+# Mach-O linking and the musl-vs-libSystem binding divergence are real
+# darwin-only surfaces, which is why this runs nightly and stays one label
+# away on any PR that touches them.
+#
+# Nightly runs on main, so it is also what seeds the shared macOS caches
+# (setup-jac gates every cache save to main).
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build-kit-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build the jac binary (cached)
+        uses: ./.github/actions/setup-jac
+
+      - name: Set up Zig 0.16.0
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Materialize typeshed + wasm libc floor
+        working-directory: jac
+        run: |
+          zig build fetch-typeshed --summary all
+          zig build vendor-wasm-libc --summary all
+
+      - name: Verify the kit is complete
+        working-directory: jac
+        run: |
+          set -euo pipefail
+          for p in zig-out/bin/jac jaclang/vendor/typeshed/stdlib \
+                   .pbs-build/wasm32/libc; do
+            [ -e "$p" ] || { echo "::error::kit is missing $p"; exit 1; }
+          done
+
+      - name: Upload the kit
+        uses: actions/upload-artifact@v4
+        with:
+          name: jac-kit-macos
+          path: |
+            jac/zig-out/bin/jac
+            jac/jaclang/vendor/typeshed/stdlib
+            jac/.pbs-build/wasm32/libc
+          include-hidden-files: true
+          retention-days: 1
+          if-no-files-found: error
+
+  test-native-macos:
+    needs: build-kit-macos
+    runs-on: macos-latest
+    env:
+      JAC_NO_DEV_SOURCE: "1"
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+      - uses: ./.github/actions/jac-kit
+        with:
+          name: jac-kit-macos
+      - name: Run native Mach-O linker regression tests
+        run: |
+          jac test jac/tests/compiler/passes/native/test_shared_lib.jac
+          jac test jac/tests/compiler/passes/native/test_exec_link.jac
+      - name: Run na->wasm floor + import-contract tests
+        run: jac test jac/tests/compiler/passes/native/test_wasm_build.jac
+      - name: Run bundled-stdlib equivalence pins (darwin)
+        env:
+          JAC_TEST_JOBS: "0"
+        # Pure-compute na modules that must agree on darwin; str/bytes guard
+        # the libc-binding divergence (musl static vs libSystem).
+        run: >-
+          jac test jac/jaclang/compiler/tests/test_prim_equivalence.jac
+          -f "shutil or path or textwrap or keyword or str or bytes"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ name: CI
 # PR-time failure) and the jobs that validate the sealed artifact itself
 # consume it. Both producers publish the same five-path kit, so every consumer
 # is checkout -> jac-kit -> run. Deep/exotic sweeps (including the full suite
-# against the sealed binary) live in nightly.yml.
+# against the sealed binary, and the whole darwin native lane) live in
+# nightly.yml; `macos-native` below reruns the darwin lane on a `macos` label.
 
 on:
   workflow_dispatch:
@@ -68,9 +69,10 @@ jobs:
               # runs must run it -- same reasoning as `native` listing ci.yml.
               # Without this an edit to the installer test ships unexercised.
               - '.github/workflows/_installer.yml'
-            # Narrowing filter: the macOS and aarch64 lanes only run when a
-            # path that can move them changes (or on push/dispatch), and the
-            # native suite takes the sealed kit instead of the host kit.
+            # Narrowing filter: the aarch64 lane only runs when a path that
+            # can move it changes (or on push/dispatch), and the native suite
+            # takes the sealed kit instead of the host kit. The darwin lane no
+            # longer reads this filter -- it is nightly + `macos`-label only.
             native:
               - 'jac/jaclang/compiler/passes/native/**'
               - 'jac/tests/compiler/passes/native/**'
@@ -283,49 +285,6 @@ jobs:
             jac/jaclang/vendor/typeshed/stdlib
             jac/.pbs-build/linux-x86_64/musl/lib
             jac/.pbs-build/linux-aarch64/musl/lib
-            jac/.pbs-build/wasm32/libc
-          include-hidden-files: true
-          retention-days: 1
-          if-no-files-found: error
-
-  build-kit-macos:
-    needs: changes
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Build the jac binary (cached)
-        uses: ./.github/actions/setup-jac
-
-      - name: Set up Zig 0.16.0
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
-          use-cache: false
-
-      - name: Materialize typeshed + wasm libc floor
-        working-directory: jac
-        run: |
-          zig build fetch-typeshed --summary all
-          zig build vendor-wasm-libc --summary all
-
-      - name: Verify the kit is complete
-        working-directory: jac
-        run: |
-          set -euo pipefail
-          for p in zig-out/bin/jac jaclang/vendor/typeshed/stdlib \
-                   .pbs-build/wasm32/libc; do
-            [ -e "$p" ] || { echo "::error::kit is missing $p"; exit 1; }
-          done
-
-      - name: Upload the kit
-        uses: actions/upload-artifact@v4
-        with:
-          name: jac-kit-macos
-          path: |
-            jac/zig-out/bin/jac
-            jac/jaclang/vendor/typeshed/stdlib
             jac/.pbs-build/wasm32/libc
           include-hidden-files: true
           retention-days: 1
@@ -1046,34 +1005,6 @@ jobs:
       - name: Fused-runtime boot of a fresh na host
         run: jac test jac/tests/runtimelib/client/test_fused_runtime_boot.jac
 
-  test-native-macos:
-    needs: [changes, build-kit-macos]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
-    runs-on: macos-latest
-    env:
-      JAC_NO_DEV_SOURCE: "1"
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: true
-      - uses: ./.github/actions/jac-kit
-        with:
-          name: jac-kit-macos
-      - name: Run native Mach-O linker regression tests
-        run: |
-          jac test jac/tests/compiler/passes/native/test_shared_lib.jac
-          jac test jac/tests/compiler/passes/native/test_exec_link.jac
-      - name: Run na->wasm floor + import-contract tests
-        run: jac test jac/tests/compiler/passes/native/test_wasm_build.jac
-      - name: Run bundled-stdlib equivalence pins (darwin)
-        env:
-          JAC_TEST_JOBS: "0"
-        # Pure-compute na modules that must agree on darwin; str/bytes guard
-        # the libc-binding divergence (musl static vs libSystem).
-        run: >-
-          jac test jac/jaclang/compiler/tests/test_prim_equivalence.jac
-          -f "shutil or path or textwrap or keyword or str or bytes"
-
   # Bootstrap unit tests: the Zig seed that fetches the pbs CPython before any
   # Python exists (bootstrap/fetch_pbs.zig). Cross-platform on purpose. The
   # launcher itself is Jac; its trailer codec, payload tool and boot path are
@@ -1380,6 +1311,17 @@ jobs:
     with:
       shellcheck: true
 
+  # The darwin native lane (sealed macOS kit + Mach-O / wasm-floor /
+  # libSystem-equivalence tests) lives in nightly.yml; see _macos-native.yml
+  # for why. It stays one label away here: add `macos` to a PR that touches
+  # Mach-O linking or the musl-vs-libSystem binding and it gates that PR like
+  # any other job. Not gated on the `native` path filter -- that filter fires
+  # on ordinary compiler churn, which is what put a 44-68 min leg on the
+  # critical path of every native PR to begin with.
+  macos-native:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'macos')) }}
+    uses: ./.github/workflows/_macos-native.yml
+
   # Aggregate gate: branch protection requires only this context. A NEW job
   # must be added to needs below by hand; always() so failures upstream fail
   # the gate instead of skipping it (skipped required checks count as passing).
@@ -1390,7 +1332,7 @@ jobs:
       - changes
       - host-kit
       - build-kit
-      - build-kit-macos
+      - macos-native
       - jac-check
       - contribution-checks
       - test-compiler
@@ -1405,7 +1347,6 @@ jobs:
       - test-scale
       - test-scale-k8s
       - test-native-aarch64
-      - test-native-macos
       - test-bootstrap
       - test-cef-build
       - test-jac-pack-smoke

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,6 +80,16 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '17 8 * * *' }}
     uses: ./.github/workflows/_installer.yml
 
+  # The darwin native lane: sealed macOS kit + the Mach-O / wasm-floor /
+  # libSystem-equivalence tests that consume it. Off the PR critical path
+  # (44-68 min, and 60 runs of evidence that it duplicated the Linux seal
+  # refusal); see _macos-native.yml. ci.yml still runs it on a `macos` label.
+  # This is also the only caller that runs on main, so it is what seeds the
+  # shared macOS caches -- setup-jac gates every cache save to main.
+  macos-native:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 3 * * *' }}
+    uses: ./.github/workflows/_macos-native.yml
+
   # PR CI runs the suite chunked across runners; this is the unchunked
   # single-process full-suite run (materializer-leak watchdog) against a
   # cold sealed build.


### PR DESCRIPTION
`build-kit-macos` is the wall clock of every native PR. It gated merge, and nothing downstream of it could start.

## Why it costs what it costs

On `macos-26-arm64` it runs **44-68 min** against the Linux leg's 16-26 for the same work. Both legs compile 622 modules cold on every push, because `setup-jac`'s caches cannot hit on a compiler branch:

- the binary cache is exact-key with saves gated to `main`, so any branch touching `jac/jaclang/**` misses every time;
- the precompile tree misses **even its `restore-keys` prefix** — that prefix carries the compiler fingerprint, which any compiler edit rolls. This is deliberate ("a compiler-touching commit starts cold rather than dragging a tree it cannot use"), and it is why the prefix cannot save the run.

Observed on a representative run, with `jac-shim` / `pbs` / `bun` / `payload-layers` / `zig-pkgs` all *hitting*:

```
Cache not found for input keys:
  jac-bin-macOS-ARM64-f5d69da9...
  jac-precompiled-macOS-ARM64-c6a134382f45ac513-f40040af...,
  jac-precompiled-macOS-ARM64-c6a134382f45ac513-
```

57.6 of the job's 57.9 minutes are the one `zig build` step. The LLVM fetch and shim link are not involved.

## What the lane actually caught

Across 60 consecutive CI runs:

| | success | failure | skipped |
| --- | --- | --- | --- |
| `build-kit-macos` | 12 | 12 | 14 |
| `test-native-macos` | 11 | 1 | 26 |

**All 12 macOS seal refusals co-occurred with a Linux `build-kit` refusal in the same run.** Not one unique catch. The single `test-native-macos` failure was `test_wasm_build.jac` hitting type-check diagnostics (E1053/E1054/E1010/E1032) — platform-independent, and an artifact of the #8399 burndown rather than a darwin defect.

Replaying a representative run with the darwin jobs removed puts the critical path at **30m12s** against the **59m23s** it actually took.

## What changed

`_macos-native.yml` holds both jobs, using the same reusable-workflow shape as `_installer.yml`. Step bodies are byte-identical to what `main` defines today (verified by parsing both files and comparing the `steps` lists); only `needs`/`if` were re-homed to the callers.

- **nightly.yml** runs it on the 03:00 cron, alongside the other deep sweeps. Since that is now the only caller that runs on `main`, it is also what seeds the shared macOS caches — `setup-jac` gates every cache save to `main`.
- **ci.yml** keeps it one label away: `macos` on a PR gates that PR exactly as before. `everything-passed` swaps `build-kit-macos` → `macos-native` and drops `test-native-macos`; when the label is absent the job skips, and the gate only fails on `failure`/`cancelled`.

This puts the lane where ci.yml's own header already says deep sweeps belong.

The label escape is deliberately **not** wired to the `native` path filter. That filter fires on ordinary compiler churn, which is what put an hour of darwin build on the critical path of every native PR to begin with.

## Scope

This is an argument about *where* the lane runs, not whether it matters. Mach-O linking and the musl-vs-libSystem binding divergence are real darwin-only surfaces; they stay covered nightly and on demand. The 60-run window is also short and dominated by one branch's churn — it supports "this should not block every PR", not "this never catches anything".

## Before merging

- The **`macos` label does not exist** in this repo yet. The `if:` simply evaluates false until it is created, which is a safe default (nightly still covers the lane), but the escape hatch is inert until then.
- Branch protection on `main` requires only `Everything Passed`, so no required status context is orphaned by removing the two job names.

## Unrelated pre-existing gap

`test-launcher-jac` is defined in ci.yml but missing from `everything-passed`'s `needs` — it can fail without blocking merge, which is exactly what that list's comment warns about. Present before this change; left alone here.
