### PR TITLE
ci: give test-compiler the swap headroom and worker cap test-native-sealed already has

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,10 +525,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # jobs: 2, not auto, for the same reason test-native-sealed caps
+          # its pool: the long-lived fork workers accumulate each compile's
+          # inference weight across files, and four of them exhaust the box.
           - chunk: passes-main
             paths: tests/compiler/passes/main tests/compiler/passes/ecmascript
+            jobs: "2"
           - chunk: toplevel
             paths: tests/compiler/test_*.jac
+            jobs: "2"
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/jac-kit
@@ -538,12 +543,37 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+      # Same swap floor test-native-sealed runs, for the same reason: with
+      # inference on the critical path (#8398) every fixture compile is
+      # heavier, and a memory spike on this swapless box does not fail the
+      # step -- it kills the runner agent ("lost communication", no step log).
+      # Swap converts that into a slow test instead of a dead runner.
+      - name: Swap headroom for checked fixture compiles
+        run: |
+          set -euo pipefail
+          SWAP_DIR="$RUNNER_TEMP"
+          AVAIL_GB=$(( $(df -Pk "$SWAP_DIR" | awk 'NR==2 {print $4}') / 1048576 ))
+          SIZE_GB=$(( AVAIL_GB - 25 ))
+          if [ "$SIZE_GB" -gt 16 ]; then
+            SIZE_GB=16
+          fi
+          if [ "$SIZE_GB" -lt 4 ]; then
+            echo "::warning::only ${AVAIL_GB}G free in $SWAP_DIR; running without extra swap"
+            exit 0
+          fi
+          SWAP_FILE="$SWAP_DIR/jac-test-swap"
+          sudo fallocate -l "${SIZE_GB}G" "$SWAP_FILE" \
+            || sudo dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$(( SIZE_GB * 1024 ))
+          sudo chmod 600 "$SWAP_FILE"
+          sudo mkswap "$SWAP_FILE"
+          sudo swapon "$SWAP_FILE"
+          free -h
       - name: Run ${{ matrix.chunk }} chunk
         working-directory: jac
         run: |
           set -uxo pipefail
           WORK="$(mktemp -d)"
-          HOME="$WORK" JAC_TEST_JOBS=auto jac test ${{ matrix.paths }}
+          HOME="$WORK" JAC_TEST_JOBS=${{ matrix.jobs }} jac test ${{ matrix.paths }}
 
   # Native-backend validation: the passes-native chunk and the na/sv
   # equivalence pins. The LLVM shim these bind is the one inside the host


### PR DESCRIPTION
`test-compiler` dies on the runner rather than failing a test:

```
The self-hosted runner lost communication with the server.
```

The job record shows why it is not a test failure. Steps 1-5 complete, step 6 "Run toplevel chunk" is still `in_progress`, and the post/cleanup steps never run. There is no test output, no failing assertion, and no step log.

## Cause

Both `test-compiler` chunks run `JAC_TEST_JOBS=auto`, so four pytest workers on a swapless `blacksmith-4vcpu-ubuntu-2404` box. Since type checking joined the critical path (#8398) every fixture compile carries inference, and the pool's long-lived fork workers accumulate that weight across files. Partway through the run the aggregate walks off the end of the box, and a memory spike there does not fail the step: it kills the runner agent.

This is not a new diagnosis. `test-native-sealed` hit exactly this and fixed it, and its matrix comment already records the mechanism:

> at auto (4 workers) the swapless runner exhausts memory ~12 minutes in and the runner agent itself is killed ("lost communication", no step log). Two workers keep the aggregate under the box.

`test-compiler` never got the same treatment. It is the one remaining compiler lane on `auto` with no swap step.

## Change

The same two things `test-native-sealed` does, copied to `test-compiler`:

- the `Swap headroom for checked fixture compiles` step, which turns a spike into a slow test instead of a dead runner
- `JAC_TEST_JOBS=2` via a matrix `jobs` key, which keeps the aggregate under the box in the first place

Applied to both chunks, since `passes-main` runs the same pool on the same box and is under the same pressure; it has simply been luckier.

## Occurrences

| Where | Result |
| --- | --- |
| main @ `b99c0a30c` (run 32642490792) | dead runner |
| #8601 head 1, first attempt | dead runner |
| #8601 head 1, rerun | passed |
| #8601 head 2, first attempt | dead runner |
| #8601 head 2, rerun | dead runner |

Four different runners, both `main` and a PR branch. The one pass is what makes this read as flake rather than breakage, and it is why the lane has stayed like this.

## Cost

Two workers instead of four roughly doubles wall clock for these chunks; `test-native-sealed` already accepted that trade for the same reason. A lane that finishes slowly is worth more than one that ends with no output.
