### PR TITLE
fix(payload): the pin table travels with the package it is read from

### DIFF
--- a/jac/jaclang/payload/impl/assemble.impl.jac
+++ b/jac/jaclang/payload/impl/assemble.impl.jac
@@ -104,6 +104,11 @@ impl assemble_site(repo_root: str, site: str, opts: MkPayloadOpts) {
             os.path.join(site, "jaclang"),
             skip_jaclang
         );
+
+        copy_file(
+            os.path.join(repo_root, "bootstrap", "pins.json"),
+            os.path.join(site, "jaclang", "payload", "pins.json")
+        );
     } else {
         log(
             f"==> linked-source mode: NOT bundling jaclang (compiler served from {opts.link_source})"

--- a/jac/jaclang/payload/pins.jac
+++ b/jac/jaclang/payload/pins.jac
@@ -1,10 +1,13 @@
 import os;
 
-glob PINS_FILE: str = os.path.join(
-         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-         "bootstrap",
-         "pins.json"
-     );
+glob _PKG_DIR: str = os.path.dirname(os.path.abspath(__file__));
+
+glob _PKG_PINS: str = os.path.join(_PKG_DIR, "pins.json");
+
+glob _REPO_PINS: str = os.path.join(
+         os.path.dirname(os.path.dirname(_PKG_DIR)), "bootstrap", "pins.json"
+     ),
+     PINS_FILE: str = _PKG_PINS if os.path.exists(_PKG_PINS) else _REPO_PINS;
 
 obj PbsPins {
     has tag: str,

--- a/release_notes/unreleased/jaclang/8622.bugfix.md
+++ b/release_notes/unreleased/jaclang/8622.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: payload pin table ships with the module that reads it**: `jaclang.payload.pins` resolved `bootstrap/pins.json` from the checkout layout, so every payload entry point died with `PayloadDie: pins: cannot read .../site/bootstrap/pins.json` in a sealed install. mkpayload now stages the table beside the module, and the checkout layout stays as the fallback.


### PR DESCRIPTION
## What

Six of the nightly `sealed-suite` failures are one root cause:

```
PayloadDie: pins: cannot read /tmp/.../site/bootstrap/pins.json: [Errno 2] No such file or directory
```

`jaclang.payload.pins` computes `PINS_FILE` three directories up from its own module. In a checkout that is `jac/bootstrap/pins.json`, sitting beside `jac/jaclang/`. The payload copies `jaclang/` into the site on its own, without the checkout's `bootstrap/` around it, so the same walk lands on `<site>/bootstrap/pins.json` and nothing ever writes there.

So `jaclang.payload` ships in every binary without the data file it cannot run without. `tests/payload/{test_fetch,test_fetch_flows,test_cli,test_assemble}.jac` are what notice.

## Fix

`assemble_site` copies the table next to the module that reads it (`site/jaclang/payload/pins.json`), and `PINS_FILE` prefers that copy, falling back to the checkout layout when it is absent.

Shipping it inside the package rather than as `site/bootstrap/` keeps the site root clean: no new top-level directory joins `sys.path`, where it would shadow an `import bootstrap`.

Linked-source mode is untouched, since there `jaclang` is served from the checkout and the fallback already resolves.

## Verification

Rebuilt the binary (`zig build`) and ran `tests/payload/` both ways:

| lane | before | after |
| --- | --- | --- |
| sealed (`JAC_NO_DEV_SOURCE=1`) | 21 passed, 6 failed | **27 passed** |
| dev (checkout fallback) | 27 passed | **27 passed** |

The shipped copy is byte-identical to `jac/bootstrap/pins.json` (`cmp` clean), and `jaclang/payload/pins.json` does not exist in the source tree, so the dev run above is exercising the fallback branch.