### PR TITLE
test(native): the libexpat case asserts the closure it can actually prove

### DIFF
--- a/jac/tests/compiler/passes/native/test_ar_archive.jac
+++ b/jac/tests/compiler/passes/native/test_ar_archive.jac
@@ -115,10 +115,15 @@ test "ar transitive member selection over bundled libexpat (skip if absent)" {
     ];
     assert defining == ["xmlparse.o"] , f"XML_ExpatVersion defined in {defining}";
 
-    # Transitive closure must pull the defining member, chase its own undefined
-    # symbols, and still leave at least one unrelated member out (proof it
-    # narrows rather than dragging in the whole archive).
+    # What only a real archive can show: the closure starts at the defining
+    # member and chases its own undefined symbols into the members that satisfy
+    # them (the ELF/Mach-O scan). The narrowing half -- selection is a strict
+    # subset -- is the synthetic case's to pin: libexpat is four members that
+    # all reach each other, so its closure is legitimately the whole archive.
     sel = [m.name for m in select_ar_members(data, [ver])];
     assert "xmlparse.o" in sel , f"selection missing xmlparse.o: {sel}";
-    assert len(sel) < len(members) , f"selection {sel} should be a strict subset";
+    for dep in ["xmltok.o", "xmlrole.o"] {
+        assert dep in sel , f"closure did not chase {dep}: {sel}";
+    }
+    assert set(sel) <= set(names) , f"selection {sel} is not drawn from {names}";
 }


### PR DESCRIPTION
## What

The last non-payload `sealed-suite` failure:

```
FAILED tests/compiler/passes/native/test_ar_archive.jac::ar transitive member selection over bundled libexpat (skip if absent)
    assert len(sel) < len(members) , f"selection {sel} should be a strict subset";
E   AssertionError: selection ['xmlparse.o', 'xmltok.o', 'xmlrole.o', 'random_dev_urandom.o'] should be a strict subset
```

The assertion cannot hold for the archive it runs against. Bundled libexpat is four members that all reach each other, so the closure from `XML_ExpatVersion` correctly pulls every one of them. The test guards on `_find_bundled_expat()` and returns early when no pbs build is staged, which is every lane except sealed, so this has been red only there.

The assertion also rewarded the wrong outcome: if the undefined-symbol scan silently found nothing, the selection would be the single defining member, `1 < 4` would hold, and the test would pass.

## Fix

Assert what only a real archive can show, which is the ELF/Mach-O undefined-symbol scan: the closure chases `xmlparse.o`'s own undefined symbols into `xmltok.o` and `xmlrole.o`, and stays drawn from the archive's own members. The synthetic GNU case directly above already pins the narrowing claim, over an archive deliberately built so that it holds.

## Verification

`JAC_NO_DEV_SOURCE=1 jac test tests/compiler/passes/native/test_ar_archive.jac`: 2 passed, was 1 passed / 1 failed.