### PR TITLE
ci: give test-native the swap headroom and worker cap its sealed sibling already has

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,10 +590,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # jobs: 2, not auto, for the reason test-native-sealed caps the same
+          # chunk: the long-lived fork workers accumulate each compile's
+          # inference weight across files, and four of them exhaust the box.
           - chunk: passes-native
             paths: tests/compiler/passes/native tests/compiler/passes/tool
+            jobs: "2"
           - chunk: equivalence
             paths: jaclang/compiler/tests
+            jobs: auto
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/jac-kit
@@ -603,12 +608,37 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+      # Same swap floor test-native-sealed runs over these same paths: with
+      # inference on the critical path (#8398) every fixture compile is
+      # heavier, and a memory spike on this swapless box does not fail the
+      # step -- it kills the runner agent ("lost communication", no step log).
+      # Swap converts that into a slow test instead of a dead runner.
+      - name: Swap headroom for checked fixture compiles
+        run: |
+          set -euo pipefail
+          SWAP_DIR="$RUNNER_TEMP"
+          AVAIL_GB=$(( $(df -Pk "$SWAP_DIR" | awk 'NR==2 {print $4}') / 1048576 ))
+          SIZE_GB=$(( AVAIL_GB - 25 ))
+          if [ "$SIZE_GB" -gt 16 ]; then
+            SIZE_GB=16
+          fi
+          if [ "$SIZE_GB" -lt 4 ]; then
+            echo "::warning::only ${AVAIL_GB}G free in $SWAP_DIR; running without extra swap"
+            exit 0
+          fi
+          SWAP_FILE="$SWAP_DIR/jac-test-swap"
+          sudo fallocate -l "${SIZE_GB}G" "$SWAP_FILE" \
+            || sudo dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$(( SIZE_GB * 1024 ))
+          sudo chmod 600 "$SWAP_FILE"
+          sudo mkswap "$SWAP_FILE"
+          sudo swapon "$SWAP_FILE"
+          free -h
       - name: Run ${{ matrix.chunk }} chunk
         working-directory: jac
         run: |
           set -uxo pipefail
           WORK="$(mktemp -d)"
-          HOME="$WORK" JAC_TEST_JOBS=auto jac test ${{ matrix.paths }}
+          HOME="$WORK" JAC_TEST_JOBS=${{ matrix.jobs }} jac test ${{ matrix.paths }}
 
   test-native-sealed:
     needs: [changes, build-kit]


### PR DESCRIPTION
## What

`test-native (passes-native)` does not fail a test, it kills the runner:

```json
{"conclusion": "failure",
 "started_at": "2026-08-23T20:04:36Z", "completed_at": "2026-08-23T20:18:37Z",
 "steps": [ ... {"name": "Run passes-native chunk", "conclusion": null},
                {"name": "Post Set up Node.js (ES backend)", "conclusion": null}, ...]}
```

Steps 1-5 succeed, the chunk step is left with a null conclusion, the post/cleanup steps never run, and `gh run view --job` returns `log not found`.

## Cause

This is #8615's mechanism, on #8615's own evidence, one lane over. `test-native` and `test-native-sealed` run the **identical chunk** (`tests/compiler/passes/native tests/compiler/passes/tool`) on the identical swapless `blacksmith-4vcpu-ubuntu-2404`. The sealed one caps its pool and lays down swap, and its matrix comment already states why:

> jobs: 2, not auto. Type checking on the critical path (#8398) made every fixture compile carry inference, and the pool's long-lived fork workers accumulate that weight across files: at auto (4 workers) the swapless runner exhausts memory ~12 minutes in and the runner agent itself is killed ("lost communication", no step log). Two workers keep the aggregate under the box.

`test-native` is the copy that never got it. It is now the last compiler lane on `auto` with no swap step. It runs only on PRs (`github.event_name == 'pull_request' && ... native != 'true'`), which is why main's push lane, where `test-native-sealed` runs instead, never showed this.

## Occurrences

All on the `passes-native` chunk, all ending at 14m00-14m01, all with no step log:

| Where | Result |
| --- | --- |
| #8617 first attempt | dead runner |
| #8617 rerun | dead runner |
| #8619 first attempt | dead runner |
| #8620 first attempt | dead runner |

Four PRs, none touching the native backend: two optional-dependency shims, an escape in a generated string, and a client test fixture. The `equivalence` chunk in the same matrix passes every time, as it does in the sealed lane at `auto`.

## Change

The same two things #8615 applied to `test-compiler`:

- the `Swap headroom for checked fixture compiles` step, byte-identical to the two already in this file (verified by extraction, all three compare equal)
- `JAC_TEST_JOBS` from a matrix `jobs` key: `2` for `passes-native`, `auto` for `equivalence`, matching the split `test-native-sealed` already uses

## Cost

Two workers instead of four roughly doubles wall clock for the `passes-native` chunk. `test-native-sealed` and `test-compiler` both already took that trade for this exact failure.