### PR TITLE
ci: give test-runtime the swap headroom and worker cap the compiler lanes have

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,13 +727,42 @@ jobs:
           node-version: "20"
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+      # Same swap floor test-compiler and test-native run, for the same
+      # reason: with inference on the critical path (#8398) every compile is
+      # heavier, and a memory spike on this swapless box does not fail the
+      # step -- it kills the runner agent ("lost communication", no step log).
+      # Swap converts that into a slow test instead of a dead runner.
+      - name: Swap headroom for checked fixture compiles
+        run: |
+          set -euo pipefail
+          SWAP_DIR="$RUNNER_TEMP"
+          AVAIL_GB=$(( $(df -Pk "$SWAP_DIR" | awk 'NR==2 {print $4}') / 1048576 ))
+          SIZE_GB=$(( AVAIL_GB - 25 ))
+          if [ "$SIZE_GB" -gt 16 ]; then
+            SIZE_GB=16
+          fi
+          if [ "$SIZE_GB" -lt 4 ]; then
+            echo "::warning::only ${AVAIL_GB}G free in $SWAP_DIR; running without extra swap"
+            exit 0
+          fi
+          SWAP_FILE="$SWAP_DIR/jac-test-swap"
+          sudo fallocate -l "${SIZE_GB}G" "$SWAP_FILE" \
+            || sudo dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$(( SIZE_GB * 1024 ))
+          sudo chmod 600 "$SWAP_FILE"
+          sudo mkswap "$SWAP_FILE"
+          sudo swapon "$SWAP_FILE"
+          free -h
       # test_auth_models.jac runs in test-reroute-gaps (see there).
+      # jobs: 2, not auto, for the reason the compiler lanes already cap: the
+      # pool's long-lived fork workers accumulate each compile's inference
+      # weight across files, and four of them exhaust the box. This is the
+      # widest suite in the file and the last one running at auto.
       - name: Runtime suite via the binary
         working-directory: jac
         run: |
           set -uxo pipefail
           WORK="$(mktemp -d)"
-          HOME="$WORK" JAC_TEST_JOBS=auto jac test tests/ \
+          HOME="$WORK" JAC_TEST_JOBS=2 jac test tests/ \
             --ignore tests/compiler tests/runtimelib/test_auth_models.jac
 
   # Tests that do not yet pass through the reroute, run here against the


### PR DESCRIPTION
## What

`test-runtime` is failing on main and on PRs, and it is not failing a test:

```json
{"steps": ["Set up job: success", ..., "Set up Bun: success",
           "Runtime suite via the binary: null",
           "Post Set up Bun: null", "Complete runner: null"]}
```

`gh run view --job` answers `log not found`. This is the signature #8615 wrote up: the runner agent is killed, so there is no failing assertion to read.

## Evidence

A passing run of this lane takes ~9 minutes. Every failure runs 20-22 and then loses the runner:

| Where | Result | Wall clock |
| --- | --- | --- |
| main @ `04d821e56` (run 32664202279) | dead runner | 22m |
| main @ `21da8c790` (run 32652974609) | dead runner | 21m |
| #8617 (job 97277649840) | dead runner | 20m |
| main @ `bcca7c5a7` (run 32657098052) | passed | 9m |
| main @ `75358eba3` (run 32654720059) | passed | 9m |

Both main runs and a PR that touches only two optional-dependency shims. The long runs are the lane already thrashing before it goes.

## Cause

The one the repo has now diagnosed three times, in `test-native-sealed`'s matrix comment, in #8615 for `test-compiler`, and in #8598 for `test-native`:

> at auto (4 workers) the swapless runner exhausts memory ~12 minutes in and the runner agent itself is killed ("lost communication", no step log)

`test-runtime` never got the treatment. After #8598 it is the last lane in the file on `JAC_TEST_JOBS=auto` with no swap step, and it runs the whole `tests/` tree bar the compiler suite, so it is the widest pool on the box and has the most weight to accumulate.

## Change

The same two things, unchanged:

- the `Swap headroom for checked fixture compiles` step, byte-identical to the three already in this file (verified by extraction: all four compare equal)
- `JAC_TEST_JOBS=2`

## Cost

Two workers instead of four should take the healthy run from ~9 minutes to under twenty. That is about what a dead run already costs, except this one ends with output.