### PR TITLE
docs(skills): fix jac-cl-components using capital Any instead of any

### DIFF
--- a/jac/jaclang/cli/skills/jac-cl-components.md
+++ b/jac/jaclang/cli/skills/jac-cl-components.md
@@ -72,7 +72,7 @@ def:pub Card(title: str, children: any = None) -> JsxElement {
 
 **`children` parameter:** always declare it `children: any = None` with `= None` default. Omitting the default makes `children` a required prop - every call site that passes no nested content fails with `error[E1102]`. Use `{children}` in the JSX body to render it.
 
-**`props: any` bundle:** `def:pub Comp(props: any)` is allowed but emits `W5015` and disables per-prop type checking. Prefer named typed parameters. Use lowercase `any` — capital `Any` is not a real Jac type; it resolves to Unknown and any attribute access on it (`props.title`) fails with a hard `error[E1032]`.
+**`props: any` bundle:** `def:pub Comp(props: any)` is allowed but emits `W5015` and disables per-prop type checking. Prefer named typed parameters. Use lowercase `any` - capital `Any` is not a real Jac type; it resolves to Unknown and any attribute access on it (`props.title`) fails with a hard `error[E1032]`.
 
 **`{name}` shorthand:** when an attribute's value is a bare variable of the same name, `<BookCard {title} {onDelete} />` expands to `title={title} onDelete={onDelete}`. Pure sugar - the type-checker validates it per-attribute exactly like the explicit form. Distinct from the spread, which forwards a whole object: use `{**props}` (the canonical Jac form) - the JS-idiomatic `{...props}` also works but earns a `W0063` warning ("prefer `{**expr}`").
 

--- a/jac/jaclang/cli/skills/jac-cl-components.md
+++ b/jac/jaclang/cli/skills/jac-cl-components.md
@@ -72,7 +72,7 @@ def:pub Card(title: str, children: any = None) -> JsxElement {
 
 **`children` parameter:** always declare it `children: any = None` with `= None` default. Omitting the default makes `children` a required prop - every call site that passes no nested content fails with `error[E1102]`. Use `{children}` in the JSX body to render it.
 
-**`props: Any` bundle:** `def:pub Comp(props: Any)` is allowed but emits `W5015` and disables per-prop type checking. Prefer named typed parameters.
+**`props: any` bundle:** `def:pub Comp(props: any)` is allowed but emits `W5015` and disables per-prop type checking. Prefer named typed parameters. Use lowercase `any` — capital `Any` is not a real Jac type; it resolves to Unknown and any attribute access on it (`props.title`) fails with a hard `error[E1032]`.
 
 **`{name}` shorthand:** when an attribute's value is a bare variable of the same name, `<BookCard {title} {onDelete} />` expands to `title={title} onDelete={onDelete}`. Pure sugar - the type-checker validates it per-attribute exactly like the explicit form. Distinct from the spread, which forwards a whole object: use `{**props}` (the canonical Jac form) - the JS-idiomatic `{...props}` also works but earns a `W0063` warning ("prefer `{**expr}`").
 

--- a/release_notes/unreleased/jaclang/8667.docs.md
+++ b/release_notes/unreleased/jaclang/8667.docs.md
@@ -1,0 +1,1 @@
+- **Docs: fixed `jac-cl-components` skill using capital `Any` instead of `any`**: `Any` isn't a real Jac type and errors on attribute access; example now uses `any`.


### PR DESCRIPTION
## What was wrong

The `props` bundle example told the agent `def:pub Comp(props: Any)` was
allowed. Capital `Any` isn't a real Jac type — it resolves to Unknown, so
any attribute access on it (`props.title`) fails with a hard `error[E1032]`.
Every other example in this skill already used lowercase `any` correctly.

## What this PR does

Changes the example to `props: any` and adds a one-line note explaining why
`Any` fails on attribute access.
