### PR TITLE
ci: jac check sweeps the whole repo on PRs too, so a green PR predicts a green main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,10 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      # On PRs, scope fmt/check to .jac files changed vs the merge-base.
+      # On PRs, scope fmt to .jac files changed vs the merge-base. `jac check`
+      # is deliberately NOT scoped: a type error is a property of the whole
+      # program, so a scoped run answers a different question than the push
+      # sweep and a green PR stops predicting a green main.
       - name: Determine changed .jac files
         id: changes
         run: |
@@ -435,15 +438,7 @@ jobs:
         run: |
           set -euo pipefail
           IGNORE_ARGS="tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ')"
-          if [ "${{ steps.changes.outputs.mode }}" = "scoped" ]; then
-            if [ "${{ steps.changes.outputs.any }}" != "true" ]; then
-              echo "No .jac files changed in this PR; skipping jac check."
-              exit 0
-            fi
-            jac check $(cat changed-jac.txt) --ignore $IGNORE_ARGS --nowarn
-          else
-            jac check . --ignore $IGNORE_ARGS --nowarn
-          fi
+          jac check . --ignore $IGNORE_ARGS --nowarn
 
       - name: Error-code breakdown (label "type-error-report")
         if: contains(github.event.pull_request.labels.*.name, 'type-error-report')


### PR DESCRIPTION
## Why

`jac check` is scoped to a PR's changed `.jac` files, and sweeps the repo only on push:

```bash
if [ "$mode" = "scoped" ]; then
  jac check $(cat changed-jac.txt) --ignore $IGNORE_ARGS --nowarn
else
  jac check . --ignore $IGNORE_ARGS --nowarn
fi
```

Those answer different questions, and the PR gate is the weaker one. A type error is a property of the whole program, not of the file that moved. So a green PR does not predict a green main, and the gap leaks in both directions:

- **A pre-existing sweep failure is invisible to every PR**, because no PR happens to touch the file. `_optdeps/pillow.jac` and `_optdeps/opentelemetry.jac` have failed the push sweep since `86b0c25da` (Aug 22) with two `E1001`s. No scoped run has looked at either file since, because nobody edits optional-dependency shims.
- **A PR changing a widely-used declaration passes its own scoped check** and breaks files it never touched, which only the next push sweep sees.

The practical consequence: "merge only green PRs" cannot keep main's jac-check green, because the check gating the merge is not the check gating main.

## What

Drop the scoped branch; always `jac check .`.

`jac fmt` stays scoped. Formatting is per-file — a file does not become unformatted because another file changed — so the same argument does not apply, and the fmt autofix-push path is untouched.

## Cost

Measured on this repo:

| | files | duration |
| --- | --- | --- |
| scoped (PR #8617) | 2 | 2m23s |
| full (main) | 617 | 8m37s |

Six minutes, against a `build-kit` that already runs 23 and a `test-native-sealed` that runs 13. jac-check does not become the critical path.

## Expect this PR's own jac-check to fail

It will report exactly the two errors above:

```
error[E1001]: Cannot assign _PillowUnavailable to Image
error[E1001]: Cannot assign object to IdGenerator
615 passed, 2 failed
```

That is the change working — this PR is the first one whose jac-check can see them. #8617 fixes both; once it lands, this goes green. If you would rather see it green first, merge #8617 ahead of this one.