### PR TITLE
fix(cli): `jac create` restores the config pin, not the ambient config

### DIFF
--- a/jac/jaclang/cli/commands/impl/project.impl.jac
+++ b/jac/jaclang/cli/commands/impl/project.impl.jac
@@ -931,9 +931,9 @@ impl install(
 }
 
 def _bootstrap_project_deps(project_path: Path) -> bool {
-    import from jaclang.project.config { get_config, set_config }
+    import from jaclang.project.config { get_config, get_explicit_config, set_config }
     prev = os.getcwd();
-    prev_cfg = get_config();
+    prev_pin = get_explicit_config();
     try {
         os.chdir(str(project_path));
 
@@ -947,7 +947,7 @@ def _bootstrap_project_deps(project_path: Path) -> bool {
         return False;
     } finally {
         os.chdir(prev);
-        set_config(prev_cfg);
+        set_config(prev_pin);
     }
 }
 

--- a/jac/tests/project/test_config.jac
+++ b/jac/tests/project/test_config.jac
@@ -262,6 +262,34 @@ test "explicit set_config overrides file-anchored resolution" {
     assert get_explicit_config() is None;
 }
 
+test "jac create leaves no explicit config pin behind" {
+    # `jac create` bootstraps the new project's dependencies with the config
+    # temporarily pinned to that project. Restoring the pin afterwards must
+    # restore the ABSENCE of one -- promoting the ambient config to an explicit
+    # pin would make it win over file-anchored resolution for every path in the
+    # process, including files that belong to no project at all.
+    import from jaclang.cli.commands { project }
+    import from jaclang.project.template_registry { initialize_template_registry }
+    config_mod._config = None;
+    config_mod._config_explicit = False;
+    config_mod._config_by_root = {};
+    initialize_template_registry();
+    orig_cwd = os.getcwd();
+    with TemporaryDirectory() as tmpdir {
+        os.chdir(tmpdir);
+        try {
+            assert project.create(name="pinprobe") == 0;
+        } finally {
+            os.chdir(orig_cwd);
+        }
+    }
+    assert get_explicit_config() is None;
+    with TemporaryDirectory() as outsider {
+        # No jac.toml anywhere above it, so it resolves to no config at all.
+        assert get_config_for_path(Path(outsider) / "stray.jac") is None;
+    }
+}
+
 # ===========================================================================
 # TestJacConfigLoad
 # ===========================================================================


### PR DESCRIPTION
## Why

`test-runtime` is red on `main`:

```
FAILED jac/tests/language/test_language.jac::dynamic archetype creation
  jac/tests/language/fixtures/create_dynamic_archetype.jac:23 in <module>
    assert node_arch is not None;
E   AssertionError:
--- captured output ---
note: /tmp/jac-test-base-ad2du60f/_dynamic_module_13_rqpoaej_.jac preferred native
but did not lower; compiled in the server codespace (error[E3012]: Calling print()
is disallowed by rule [no-print])
ERROR - Error importing dynamic module '_dynamic_module_13': ... failed to compile:
error[E3012]: Calling print() is disallowed by rule [no-print]
  --> /tmp/jac-test-base-ad2du60f/_dynamic_module_13_rqpoaej_.jac:5:1
    5 | print("Dynamic Node Value:", f'{self.value}');
```

The file passes on its own, so this reads as a flake. It is not — it is a
process-wide config pin leaking out of an earlier test in the same worker.

## The bug

`_bootstrap_project_deps` installs a freshly created project's dependencies with
the config temporarily pinned to that project, then restores what was there
before:

```jac
prev_cfg = get_config();
try {
    os.chdir(str(project_path));
    set_config(get_config(start_path=project_path, force_discover=True));
    return install() == 0;
} finally {
    os.chdir(prev);
    set_config(prev_cfg);
}
```

`get_config()` returns the **ambient** config discovered from the cwd, and
`set_config()` is the thing that marks a config *explicit*. So the restore does
not undo the pin — it installs one. After any in-process `jac create` that
bootstraps deps, `_config_explicit` stays true, and `get_config_for_path()`
short-circuits to that config for every path in the process:

```
$ rc 0 | explicit after: True | root: /home/marsninja/repos/jaseci2
        | select: ['all', 'strip-comments', 'strip-docstrings']
```

## How that reaches the dynamic-archetype test

`create_archetype_from_source` writes the module it synthesizes to a temp file
under the runtime base dir. That path belongs to no project, so it normally
resolves to no config at all and gets the default lint set — where `no-print` is
opt-in and therefore off.

With this repo's config pinned process-wide it instead inherits
`[check.lint] select = ["all"]`, while the excludes that would have spared it
(`*/tests/*`) are repo-relative and cannot match a path outside the repo. So
`print()` inside a dynamically created archetype becomes a hard `E3012`, the
module fails to compile, and `create_archetype_from_source` returns `None`.

Reproduced end to end on `main`, byte-identical to CI:

```python
set_config(get_config())          # the finally in _bootstrap_project_deps
JacRuntime.set_base_path(tempfile.mkdtemp(prefix='jac-test-base-'))
JacRuntime.create_archetype_from_source(src_with_a_print)
# note: /tmp/jac-test-base-m1hfrah0/_dynamic_module_0_*.jac preferred native but did not lower...
# error[E3012]: Calling print() is disallowed by rule [no-print]
# RESULT module: None
```

The ordering dependence is real: `tests/language/test_cli.jac::jac create and run
no root files` calls `project.create(name)` with no `--skip`, so it is the one
suite caller that reaches the bootstrap (`test_create_kinds`, `test_create_nested`
and friends all skip deps). It shares `tests/language/` with `test_language.jac`,
so a two-worker split lands them in the same process often enough to flip the job
red — and `jac test tests/language/test_language.jac` alone stays green.

## The fix

Save the **pin**, not the value. `get_explicit_config()` returns `None` when
nothing was pinned, and restoring `None` clears the pin so the next
`get_config()` rediscovers from the cwd that the same `finally` just restored.

```diff
-    import from jaclang.project.config { get_config, set_config }
+    import from jaclang.project.config { get_config, get_explicit_config, set_config }
     prev = os.getcwd();
-    prev_cfg = get_config();
+    prev_pin = get_explicit_config();
...
     } finally {
         os.chdir(prev);
-        set_config(prev_cfg);
+        set_config(prev_pin);
     }
```

An explicit pin set by a caller that wants one (`--config`, MCP mode,
`JacTestClient`) is unaffected: it is saved and restored as itself.

## Test

`tests/project/test_config.jac`: after a bare `jac create`, nothing is pinned and
a path outside any project still resolves to no config. Fails on `main` (the
first assert), passes here.

## Verification

- `jac test tests/project/test_config.jac tests/cli/test_create_nested.jac
  tests/language/test_create_kinds.jac tests/project/test_dependencies.jac
  tests/language/test_language.jac` — 342 passed
- the end-to-end repro above now returns a live module instead of `None`
- `jac fmt --check --lintfix` and `jac check` clean on both changed files
