### PR TITLE
fix(tests): the clib bytes fixture casts its u64 return at the boundary

### DIFF
--- a/jac/tests/compiler/passes/native/fixtures/clib_bytes_buffer.jac
+++ b/jac/tests/compiler/passes/native/fixtures/clib_bytes_buffer.jac
@@ -13,5 +13,5 @@ zlib/zipfile tier.
 import from z { def crc32_z(crc: u64, buf: bytes, len: u64) -> u64;  }
 
 def checksum(data: bytes) -> int {
-    return crc32_z(0, data, u64(len(data)));
+    return int(crc32_z(0, data, u64(len(data))));
 }


### PR DESCRIPTION
## **Description**

#8666 merged with `test-native-sealed` still red on one fixture, so `main` currently fails that lane.

`crc32_z` is declared `-> u64` and `checksum` returns `int`. #8666 made `int` an ordinary member of the fixed-width lattice, so that conversion needs the same cast `u64 -> i64` already did -- and it is the same shape as the zlib, zstd and OpenSSL wrappers that PR fixed in `na_stdlib`.

```
error[E1127]: Cannot implicitly convert u64 to int; the conversion is not value-preserving
  --> jac/tests/compiler/passes/native/fixtures/clib_bytes_buffer.jac:16:12
```

It was missed because the whole-tree check sweep carries CI's ignore list, which excludes `tests/` -- so fixtures never saw the new lattice. A sweep of `jac/tests` for `E1126`-`E1130` now comes back clean, so this is the only one.

## **Test plan**

- `jac check` on the fixture: clean.
- `jac test jac/tests/compiler/passes/native/test_native_gen_pass.jac --test_name "clib bytes argument"`: passes (it was the single failure in `test-native-sealed`, which was otherwise 1603 passed).
- `jac check jac/tests/ --nowarn`: no `E1126`-`E1130`.
