### PR TITLE
fix(tests): the clib bytes fixture returns the u64 that crc32_z hands back

### DIFF
--- a/jac/tests/compiler/passes/native/fixtures/clib_bytes_buffer.jac
+++ b/jac/tests/compiler/passes/native/fixtures/clib_bytes_buffer.jac
@@ -12,6 +12,6 @@ zlib/zipfile tier.
 
 import from z { def crc32_z(crc: u64, buf: bytes, len: u64) -> u64;  }
 
-def checksum(data: bytes) -> int {
+def checksum(data: bytes) -> u64 {
     return crc32_z(0, data, u64(len(data)));
 }


### PR DESCRIPTION
## Why

`test-native (passes-native, tests/compiler/passes/native tests/compiler/passes/tool)`
is red on `main` (run 32767821057, `a3e35e967e`), and every PR opened since
inherits it through the merge ref:

```
FAILED tests/compiler/passes/native/test_native_gen_pass.jac::clib bytes argument
lowers to a raw data pointer (issue #6940 Phase 2)
  test_native_gen_pass.jac:3156 in test_clib_bytes_argument_lowers_to_a_raw_data_pointer_issue_6940_phase_2
    assert not prog.errors_had , f"Errors: {prog.errors_had}";
E   AssertionError: Errors: [error[E1127]: Cannot implicitly convert u64 to int;
    the conversion is not value-preserving
  --> tests/compiler/passes/native/fixtures/clib_bytes_buffer.jac:16:12]

1603 passed, 1 failed, 152 skipped
```

## What

The fixture's wrapper returns `crc32_z`'s result — declared `-> u64` on the
foreign signature — out of a `-> int` signature:

```jac
import from z { def crc32_z(crc: u64, buf: bytes, len: u64) -> u64;  }

def checksum(data: bytes) -> int {
    return crc32_z(0, data, u64(len(data)));
}
```

#8666 made fixed-width numerics real types with one conversion rule, so u64 to
int is no longer something the checker will do implicitly — u64's upper half does
not survive the trip into a signed 64-bit int. The fixture predates that rule and
was not swept with it.

## Fix

Give the wrapper the return type its callee already has: `-> u64`.

The test asserts on the extern `declare` and the call site's data pointer, and
the wrapper's own return type feeds neither — both still lower identically:

```llvm
declare i64 @"crc32_z"(i64 %"crc", i8* %"buf", i64 %"len")
call i64 @"crc32_z"(i64 0, i8* %"by.data.i8" ...
```

So the case still tests what it was written to test: that a `bytes` parameter on
a foreign signature lowers to a raw `i8*` and the call site passes the data
pointer rather than the `jacbytes { i64 len, [n x i8] }` struct pointer.

## Verification

Reproduced the failure on `main` and confirmed the fix, running the case by name:

```
$ jac test tests/compiler/passes/native/test_native_gen_pass.jac -f "clib bytes"
FAILED   clib bytes argument lowers to a raw data pointer (issue #6940 Phase 2)   # before
PASSED   clib bytes argument lowers to a raw data pointer (issue #6940 Phase 2)   # after
```

`main`'s other current failure — `test-runtime`'s
`test_language.jac::dynamic archetype creation` — is unrelated and fixed in #8677.
