### PR TITLE
test(scale): name the parsed value in the storage-quantity helper

### DIFF
--- a/jac/jaclang/scale/tests/test_k8s_utils.jac
+++ b/jac/jaclang/scale/tests/test_k8s_utils.jac
@@ -78,8 +78,8 @@ test "resize pvc if needed: increase patches, no-op skips, decrease raises" {
 def _test_parse_storage_valid(pair: tuple) {
     raw = pair[0];
     expected = pair[1];
-    result = parse_storage_quantity(raw);
-    assert result == expected , f"parse_storage_quantity({raw!r}) = {result}, expected {expected}";
+    parsed = parse_storage_quantity(raw);
+    assert parsed == expected , f"parse_storage_quantity({raw!r}) = {parsed}, expected {expected}";
 }
 
 with entry {

--- a/release_notes/unreleased/jaclang/8690.refactor.md
+++ b/release_notes/unreleased/jaclang/8690.refactor.md
@@ -1,0 +1,1 @@
+- **Tests: the storage-quantity helper names its parsed value**: `_test_parse_storage_valid` in the scale k8s-utils suite held the return of `parse_storage_quantity` in a local named `result`, which the assertion message then interpolated. It is now `parsed`, so the failure text reads against a name that says what the value is. Test-only, no behavior change.


### PR DESCRIPTION
## What

Renames the local `result` to `parsed` in `_test_parse_storage_valid` in [test_k8s_utils.jac](jac/jaclang/scale/tests/test_k8s_utils.jac), so the assertion message reads against a name that says what the value is.

Test-only, no behavior change.

## Validation

- `jac fmt jac/jaclang/scale/tests/test_k8s_utils.jac` -- clean, no reformatting beyond the edit
- `jac check jac/jaclang/scale/tests/test_k8s_utils.jac` -- passes (the remaining W1036/W1051 warnings are pre-existing and untouched)
- `jac test jac/jaclang/scale/tests/test_k8s_utils.jac` -- 17 passed