### PR TITLE
[DO NOT MERGE] ci: verification run for #8689's reroute-native swap floor and worker cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,12 +573,39 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+      # This lane kept the death #8676 removed the crutches for: at auto on
+      # this swapless box the reroute-native chunk still spikes past the
+      # runner agent, which dies with "lost communication" and no step log
+      # (observed on every PR whose merge ref carries #8676). The lane runs
+      # only on PRs with core-but-not-native changes, so the removal's own
+      # PR never exercised it. Floor and cap restored for this one lane;
+      # JAC_TEST_RSS_LOG's per-file trail from a completed run is the path
+      # to retiring them again.
+      - name: Swap headroom for checked fixture compiles
+        run: |
+          set -euo pipefail
+          SWAP_DIR="$RUNNER_TEMP"
+          AVAIL_GB=$(( $(df -Pk "$SWAP_DIR" | awk 'NR==2 {print $4}') / 1048576 ))
+          SIZE_GB=$(( AVAIL_GB - 25 ))
+          if [ "$SIZE_GB" -gt 16 ]; then
+            SIZE_GB=16
+          fi
+          if [ "$SIZE_GB" -lt 4 ]; then
+            echo "::warning::only ${AVAIL_GB}G free in $SWAP_DIR; running without extra swap"
+            exit 0
+          fi
+          SWAP_FILE="$SWAP_DIR/jac-test-swap"
+          sudo fallocate -l "${SIZE_GB}G" "$SWAP_FILE" \
+            || sudo dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$(( SIZE_GB * 1024 ))
+          sudo chmod 600 "$SWAP_FILE"
+          sudo mkswap "$SWAP_FILE"
+          sudo swapon "$SWAP_FILE"
       - name: Run ${{ matrix.chunk }} chunk
         working-directory: jac
         run: |
           set -uxo pipefail
           WORK="$(mktemp -d)"
-          HOME="$WORK" JAC_TEST_RSS_LOG=1 JAC_TEST_JOBS=auto jac test ${{ matrix.paths }}
+          HOME="$WORK" JAC_TEST_RSS_LOG=1 JAC_TEST_JOBS=2 jac test ${{ matrix.paths }}
 
   test-native-sealed:
     needs: [changes, build-kit]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,11 @@ jobs:
   # `needs` cannot be conditional.
   test-native:
     needs: [changes, host-kit]
-    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.core == 'true' && needs.changes.outputs.native != 'true' }}
+    # TEMPORARY, DO NOT MERGE: the `native` filter lists ci.yml, so any PR
+    # carrying the swap/cap restore is routed to test-native-sealed and the
+    # lane under test never runs. Dropping the clause here is the only way to
+    # exercise it before merge. Restore the full condition before landing.
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false


### PR DESCRIPTION
**Disposable. Do not merge. Do not review.**

Sole purpose: prove that [#8689](https://github.com/jaseci-labs/jac/pull/8689) actually fixes the `test-native (passes-native)` runner deaths, before it lands.

## Why #8689 cannot test itself

`.github/workflows/ci.yml` is listed in the `native` path filter, and `test-native` runs only when `core == 'true' && native != 'true'`. Any PR that touches `ci.yml` therefore flips `native` true and is routed to `test-native-sealed` instead. #8689's own checks show `test-native  skipping`. This is the same blind spot that let #8676 remove the crutches without the lane ever being exercised.

## What this branch is

1. #8689 cherry-picked verbatim (`16194b8c7`).
2. One temporary edit: `&& needs.changes.outputs.native != 'true'` dropped from `test-native`'s condition, so the lane runs despite `ci.yml` being in the diff.

## Read the result as

- `test-native (passes-native)` green -> the swap floor and `JAC_TEST_JOBS=2` do fix it; land #8689.
- Still "The self-hosted runner lost communication with the server" at ~32m -> they do not; #8689 needs more.

Closing this once the lane reports either way.