### PR TITLE
experiment: read the box's memory before the native lane kills its runner

### DIFF
--- a/jac/jaclang/runtimelib/impl/test_runner.impl.jac
+++ b/jac/jaclang/runtimelib/impl/test_runner.impl.jac
@@ -293,6 +293,46 @@ impl install_warning_filters -> None {
     }
 }
 
+impl _mem_available_bytes -> int {
+    avail = 0;
+    try {
+        with open("/proc/meminfo", encoding="utf-8") as f {
+            for line in f {
+                if line.startswith("MemAvailable:") {
+                    avail = int(line.split()[1]) * 1024;
+                    break;
+                }
+            }
+        }
+    } except Exception {
+        avail = 0;
+    }
+    return avail;
+}
+
+impl _pid_rss_mb(pid: int) -> int {
+    try {
+        with open(f"/proc/{pid}/status", encoding="utf-8") as f {
+            for line in f {
+                if line.startswith("VmRSS:") {
+                    return int(line.split()[1]) // 1024;
+                }
+            }
+        }
+    } except Exception {
+        return 0;
+    }
+    return 0;
+}
+
+impl _loadavg -> float {
+    try {
+        return os.getloadavg()[0];
+    } except Exception {
+        return 0.0;
+    }
+}
+
 impl default_jobs -> int {
     cpus = os.cpu_count() or 1;
     avail = 0;
@@ -872,7 +912,66 @@ impl Reporter.summarize(elapsed: float) -> int {
 }
 
 impl ForkPool.postinit -> None {
+    import time;
     self.kids = [];
+    self.started = time.monotonic();
+    self.mem_last = 0.0;
+    self.mem_trail = [];
+}
+
+impl ForkPool._memory_watchdog -> None {
+    import sys;
+    import time;
+    now = time.monotonic();
+    if (now - self.mem_last) < _MEM_POLL_SECONDS {
+        return;
+    }
+    self.mem_last = now;
+    avail = _mem_available_bytes();
+    rss = 0;
+    live = 0;
+    for k in self.kids {
+        if k["alive"] {
+            live += 1;
+            rss += _pid_rss_mb(k["pid"]);
+        }
+    }
+    elapsed = now - self.started;
+    line = (
+        f"[mem] t={int(elapsed)}s avail={avail // (1024 * 1024)}MB "
+        f"workers={live} worker_rss={rss}MB load={_loadavg():.1f} "
+        f"done={self.cursor}/{len(self.plan.files)}"
+    );
+    self.mem_trail.append(line);
+    sys.stderr.write(line + "\n");
+    sys.stderr.flush();
+    starved = (avail > 0) and (avail < _MEM_FLOOR_BYTES);
+    if not starved and (elapsed < _MEM_DEADLINE_SECONDS) {
+        return;
+    }
+    why = (
+        f"available memory fell to {avail // (1024 * 1024)} MB"
+            if starved
+            else f"the run passed {int(_MEM_DEADLINE_SECONDS)}s without finishing"
+    );
+    sys.stderr.write(
+        f"\n[mem] STOPPING: {why}. The runner is killed at this point with no "
+        f"step log, so the pool stops here and reports instead.\n"
+    );
+    for sample in self.mem_trail[-40:] {
+        sys.stderr.write("  " + sample + "\n");
+    }
+    sys.stderr.flush();
+    self.stopping = True;
+    for k in self.kids {
+        if k["alive"] {
+            try {
+                os.kill(k["pid"], 9);
+            } except OSError {
+                ;
+            }
+        }
+    }
 }
 
 impl ForkPool._should_stop -> bool {
@@ -1154,10 +1253,11 @@ impl ForkPool._pump -> None {
         }
         fds = [k["result_fd"] for k in busy];
         try {
-            (ready, _, _) = select.select(fds, [], []);
+            (ready, _, _) = select.select(fds, [], [], _MEM_POLL_SECONDS);
         } except OSError {
             break;
         }
+        self._memory_watchdog();
         for fd in ready {
             owners = [
                 k

--- a/jac/jaclang/runtimelib/test_runner.jac
+++ b/jac/jaclang/runtimelib/test_runner.jac
@@ -31,6 +31,9 @@ glob _WARNING_IGNORES: list[tuple[str, str, str]] = [
 
 glob _WORKER_MEM_BYTES: int = 2 * 1024 * 1024 * 1024,
      _MEM_HEADROOM: float = 0.6,
+     _MEM_POLL_SECONDS: float = 5.0,
+     _MEM_FLOOR_BYTES: int = 1536 * 1024 * 1024,
+     _MEM_DEADLINE_SECONDS: float = 1500.0,
      _MAX_AUTO_JOBS: int = 12,
      _PROGRESS_WIDTH: int = 72;
 
@@ -99,7 +102,10 @@ obj ForkPool {
         maxfail: (int | None) = None,
         cursor: int = 0,
         stopping: bool = False,
-        kids: list[dict[(str, any)]] postinit;
+        kids: list[dict[(str, any)]] postinit,
+        started: float postinit,
+        mem_last: float postinit,
+        mem_trail: list[str] postinit;
 
     def postinit -> None;
     def run -> None;
@@ -110,6 +116,7 @@ obj ForkPool {
     def _handle_record(kid: dict[(str, any)], line: str) -> None;
     def _reap(kid: dict[(str, any)]) -> None;
     def _should_stop -> bool;
+    def _memory_watchdog -> None;
     def _shutdown -> None;
 }
 
@@ -149,6 +156,12 @@ def run_tests(
 ) -> int;
 
 def default_jobs -> int;
+
+def _mem_available_bytes -> int;
+
+def _pid_rss_mb(pid: int) -> int;
+
+def _loadavg -> float;
 
 def resolve_jobs(requested: (str | int | None) = None) -> int;
 


### PR DESCRIPTION
**Not for merge.** Instrumentation to find why `test-native (passes-native)` kills its runner.

## Why

The job fails with `conclusion: failure`, **no failed step**, and a log blob that 404s, because the runner process dies before anything uploads. 20 of the last 40 pull-request runs died this way, on unrelated branches. The cause has never been read off a real run, because a dead runner leaves no log.

Two facts narrow it:

| lane | `JAC_NO_DEV_SOURCE` | duration | outcome |
|---|---|---|---|
| `test-native` | unset (dev reroute) | 31-41 min | 9/9 die |
| `test-native-sealed` | `"1"` | 9.9-11.9 min | 4/4 survive |

Durations spread rather than cluster, and no job timeout exists, so it is resource exhaustion rather than a limit.

## What this does

The pool's parent samples every 5s and writes one stderr line:

```
[mem] t=35s avail=3574MB workers=2 worker_rss=3618MB load=1.0 done=2/3
```

If available memory drops under 1536 MB, or the run passes 1500s, it prints the last 40 samples, kills the workers and stops. The step then ends normally and **its log survives**, which is the whole point.

Instrumentation only. Worker count and retirement are untouched.

## What it should settle

- Whether available memory actually approaches zero, or stays healthy while the runner dies anyway.
- Whether load average shows all four vCPUs saturated, starving the runner agent.
- What a worker really costs on this box, rather than on a smaller local one.

Note that `.github/workflows/ci.yml` sits in both the `core` and `native` path filters, so instrumenting the workflow would flip this PR to the sealed lane and measure the one that does not fail. Hence the probe lives in the test runner.