### PR TITLE
fix(test): size the test pool to what a worker costs, and report before the box dies

### DIFF
--- a/jac/jaclang/testing/impl/test_runner.impl.jac
+++ b/jac/jaclang/testing/impl/test_runner.impl.jac
@@ -293,8 +293,86 @@ impl install_warning_filters -> None {
     }
 }
 
-impl default_jobs -> int {
-    cpus = os.cpu_count() or 1;
+impl _limit_from_text(text: str) -> int {
+    raw = text.strip();
+    if (not raw) or (raw == "max") {
+        return 0;
+    }
+    try {
+        value = int(raw);
+    } except ValueError {
+        return 0;
+    }
+    return value if (value > 0) and (value < (1 << 60)) else 0;
+}
+
+impl _cgroup_limit_bytes -> int {
+    for path in [
+        "/sys/fs/cgroup/memory.max",
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+    ] {
+        try {
+            with open(path, encoding="utf-8") as f {
+                limit = _limit_from_text(f.read());
+            }
+            if limit {
+                return limit;
+            }
+        } except Exception {
+            ;
+        }
+    }
+    return 0;
+}
+
+impl _cgroup_available_bytes -> int {
+    limit = _cgroup_limit_bytes();
+    if not limit {
+        return 0;
+    }
+    used = 0;
+    for path in [
+        "/sys/fs/cgroup/memory.current",
+        "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+    ] {
+        try {
+            with open(path, encoding="utf-8") as f {
+                used = int(f.read().strip());
+            }
+            break;
+        } except Exception {
+            used = 0;
+        }
+    }
+    return max(0, limit - used);
+}
+
+impl _shed_threshold(mem_start: int) -> int {
+    return max(int(mem_start * _MEM_SHED_FRACTION), 2 * _MEM_FLOOR_BYTES);
+}
+
+impl _mem_budget_bytes -> int {
+    return int(_mem_available_bytes() * _MEM_HEADROOM);
+}
+
+impl _rss_cap_for(budget: int, jobs: int) -> int {
+    share = (budget // max(1, jobs)) if budget else _WORKER_MEM_BYTES;
+    return int(share // (1024 * 1024));
+}
+
+impl _resolve_rss_cap(jobs: int) -> int {
+    raw = os.environ.get("JAC_TEST_RECYCLE_MB", "");
+    if raw {
+        try {
+            return max(0, int(raw));
+        } except ValueError {
+            ;
+        }
+    }
+    return _rss_cap_for(_mem_budget_bytes(), jobs);
+}
+
+impl _mem_available_bytes -> int {
     avail = 0;
     try {
         with open("/proc/meminfo", encoding="utf-8") as f {
@@ -315,9 +393,42 @@ impl default_jobs -> int {
             avail = 0;
         }
     }
+    cg = _cgroup_available_bytes();
+    if cg and ((not avail) or (cg < avail)) {
+        avail = cg;
+    }
+    return avail;
+}
+
+impl _pid_rss_mb(pid: int) -> int {
+    try {
+        with open(f"/proc/{pid}/status", encoding="utf-8") as f {
+            for line in f {
+                if line.startswith("VmRSS:") {
+                    return int(line.split()[1]) // 1024;
+                }
+            }
+        }
+    } except Exception {
+        return 0;
+    }
+    return 0;
+}
+
+impl _loadavg -> float {
+    try {
+        return os.getloadavg()[0];
+    } except Exception {
+        return 0.0;
+    }
+}
+
+impl default_jobs -> int {
+    cpus = os.cpu_count() or 1;
+    budget = _mem_budget_bytes();
     cap = cpus;
-    if avail {
-        cap = max(1, int((avail * _MEM_HEADROOM) // _WORKER_MEM_BYTES));
+    if budget {
+        cap = max(1, int(budget // _WORKER_MEM_BYTES));
     }
     return max(1, min(cpus, cap, _MAX_AUTO_JOBS));
 }
@@ -382,6 +493,10 @@ impl _log_worker_footprint(
 impl _worker_rss_mb -> int {
     import resource;
     import sys;
+    mine = _pid_rss_mb(os.getpid());
+    if mine {
+        return mine;
+    }
     peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss;
     return int(peak // (1024 * 1024))
         if sys.platform == "darwin"
@@ -895,7 +1010,88 @@ impl Reporter.summarize(elapsed: float) -> int {
 }
 
 impl ForkPool.postinit -> None {
+    import time;
     self.kids = [];
+    self.started = time.monotonic();
+    self.mem_last = 0.0;
+    self.mem_trail = [];
+    self.mem_start = 0;
+    self.shed_pending = 0;
+    self.rss_cap_mb = _resolve_rss_cap(self.jobs);
+}
+
+impl ForkPool._memory_watchdog -> None {
+    import sys;
+    import time;
+    now = time.monotonic();
+    if (now - self.mem_last) < _MEM_POLL_SECONDS {
+        return;
+    }
+    self.mem_last = now;
+    avail = _mem_available_bytes();
+    rss = 0;
+    live = 0;
+    for k in self.kids {
+        if not k["alive"] {
+            continue;
+        }
+        held = _pid_rss_mb(k["pid"]);
+        if (held == 0) and (k["inflight"] is None) {
+            self._reap(k);
+            continue;
+        }
+        live += 1;
+        rss += held;
+    }
+    elapsed = now - self.started;
+    line = (
+        f"[mem] t={int(elapsed)}s avail={avail // (1024 * 1024)}MB "
+        f"workers={live} worker_rss={rss}MB load={_loadavg():.1f} "
+        f"done={self.cursor}/{len(self.plan.files)}"
+    );
+    self.mem_trail.append(line);
+    sys.stderr.write(line + "\n");
+    sys.stderr.flush();
+    if self.mem_start == 0 {
+        self.mem_start = avail;
+    }
+    if (
+        (avail > 0)
+        and (live > 1)
+        and (self.shed_pending == 0)
+        and (avail < _shed_threshold(self.mem_start))
+    ) {
+        self.shed_pending = 1;
+        sys.stderr.write(
+            f"[mem] shedding one of {live} workers: "
+            f"{avail // (1024 * 1024)} MB left of the "
+            f"{self.mem_start // (1024 * 1024)} MB this run started with\n"
+        );
+        sys.stderr.flush();
+    }
+    if (avail <= 0) or (avail >= _MEM_FLOOR_BYTES) {
+        return;
+    }
+    sys.stderr.write(
+        f"\n[mem] STOPPING: available memory fell to "
+        f"{avail // (1024 * 1024)} MB with {live} worker(s) holding {rss} MB. "
+        f"The runner is killed at this point with no step log, so the pool "
+        f"stops here and reports instead.\n"
+    );
+    for sample in self.mem_trail[-40:] {
+        sys.stderr.write("  " + sample + "\n");
+    }
+    sys.stderr.flush();
+    self.stopping = True;
+    for k in self.kids {
+        if k["alive"] {
+            try {
+                os.kill(k["pid"], 9);
+            } except OSError {
+                ;
+            }
+        }
+    }
 }
 
 impl ForkPool._should_stop -> bool {
@@ -969,12 +1165,7 @@ impl ForkPool._worker_loop(dispatch_fd: int, result_fd: int) -> None {
     } except ValueError {
         _recycle = 25;
     }
-    _rss_cap = 8192;
-    try {
-        _rss_cap = int(os.environ.get("JAC_TEST_RECYCLE_MB", "8192") or "8192");
-    } except ValueError {
-        _rss_cap = 8192;
-    }
+    _rss_cap = self.rss_cap_mb;
     _served = 0;
     reader = os.fdopen(dispatch_fd, "r", encoding="utf-8");
     while True {
@@ -1083,6 +1274,19 @@ impl ForkPool._handle_record(kid: dict[(str, any)], line: str) -> None {
     for item in record.get("outcomes", []) {
         self.reporter.record(TestOutcome.from_wire(item));
     }
+    live = len(
+        [
+            k
+            for k in self.kids
+            if k["alive"]
+        ]
+    );
+    if (self.shed_pending > 0) and (live > 1) and not record.get("retire") {
+        self.shed_pending -= 1;
+        kid["retired"] = True;
+        self._reap(kid);
+        return;
+    }
     if record.get("retire") {
         kid["retired"] = True;
         if not self._should_stop() and (self.cursor < len(self.plan.files)) {
@@ -1180,10 +1384,11 @@ impl ForkPool._pump -> None {
         }
         fds = [k["result_fd"] for k in busy];
         try {
-            (ready, _, _) = select.select(fds, [], []);
+            (ready, _, _) = select.select(fds, [], [], _MEM_POLL_SECONDS);
         } except OSError {
             break;
         }
+        self._memory_watchdog();
         for fd in ready {
             owners = [
                 k

--- a/jac/jaclang/testing/test_runner.jac
+++ b/jac/jaclang/testing/test_runner.jac
@@ -28,8 +28,11 @@ glob _WARNING_IGNORES: list[tuple[str, str, str]] = [
          ("", "DeprecationWarning", "cattrs")
      ];
 
-glob _WORKER_MEM_BYTES: int = 2 * 1024 * 1024 * 1024,
+glob _WORKER_MEM_BYTES: int = 3 * 1024 * 1024 * 1024,
      _MEM_HEADROOM: float = 0.6,
+     _MEM_POLL_SECONDS: float = 5.0,
+     _MEM_FLOOR_BYTES: int = 1536 * 1024 * 1024,
+     _MEM_SHED_FRACTION: float = 0.3,
      _MAX_AUTO_JOBS: int = 12,
      _PROGRESS_WIDTH: int = 72;
 
@@ -102,7 +105,13 @@ obj ForkPool {
         maxfail: (int | None) = None,
         cursor: int = 0,
         stopping: bool = False,
-        kids: list[dict[(str, any)]] postinit;
+        kids: list[dict[(str, any)]] postinit,
+        started: float postinit,
+        mem_last: float postinit,
+        mem_trail: list[str] postinit,
+        mem_start: int postinit,
+        shed_pending: int postinit,
+        rss_cap_mb: int postinit;
 
     def postinit -> None;
     def run -> None;
@@ -113,6 +122,7 @@ obj ForkPool {
     def _handle_record(kid: dict[(str, any)], line: str) -> None;
     def _reap(kid: dict[(str, any)]) -> None;
     def _should_stop -> bool;
+    def _memory_watchdog -> None;
     def _shutdown -> None;
 }
 
@@ -163,6 +173,26 @@ def _load_last_failed -> str;
 def _store_run_state(plan: TestPlan, reporter: Reporter) -> None;
 
 def default_jobs -> int;
+
+def _limit_from_text(text: str) -> int;
+
+def _cgroup_limit_bytes -> int;
+
+def _cgroup_available_bytes -> int;
+
+def _shed_threshold(mem_start: int) -> int;
+
+def _mem_budget_bytes -> int;
+
+def _rss_cap_for(budget: int, jobs: int) -> int;
+
+def _resolve_rss_cap(jobs: int) -> int;
+
+def _mem_available_bytes -> int;
+
+def _pid_rss_mb(pid: int) -> int;
+
+def _loadavg -> float;
 
 def resolve_jobs(requested: (str | int | None) = None) -> int;
 

--- a/jac/tests/runtimelib/test_worker_retirement.jac
+++ b/jac/tests/runtimelib/test_worker_retirement.jac
@@ -9,9 +9,29 @@ output at all.
 
 Retirement therefore takes whichever bound trips first. `JAC_TEST_RECYCLE_MB`
 carries the memory bound; either can be disabled with 0.
+
+The memory bound is a share of the same budget `default_jobs` divides to pick
+the worker count, so `jobs * cap` cannot exceed it whatever the box. A fixed
+default cannot hold that: shipped at 8192 MB against a per-worker sizing
+assumption of 2 GiB, the bound sat four times above the budget and never once
+fired in CI, leaving the file count as the only real limit.
+
+Sizing and shedding are the other half. A `passes-native` runner with 14.6 GB
+free admitted four workers that together reached 12.2 GB and exhausted the box
+in 218 seconds, so `_WORKER_MEM_BYTES` now carries the measured per-worker cost
+rather than half of it. Where a lane is heavier still, the pool sheds a worker
+on real memory pressure, and `_shed_threshold` keeps that ahead of the point
+where the run has to stop.
 """
 
-import from jaclang.testing.test_runner { _should_retire, _worker_rss_mb }
+import from jaclang.testing.test_runner {
+    _limit_from_text,
+    _mem_budget_bytes,
+    _shed_threshold,
+    _rss_cap_for,
+    _should_retire,
+    _worker_rss_mb
+}
 
 test "a worker under both bounds keeps serving" {
     assert not _should_retire(served=3, recycle=25, rss_mb=400, rss_cap=2048);
@@ -39,4 +59,67 @@ test "the worker can read its own footprint" {
     mb = _worker_rss_mb();
     assert mb > 0 , "a live worker reports no resident memory";
     assert mb < 1024 * 1024 , f"implausible footprint {mb} MB: check the unit";
+}
+
+test "the cap is the budget split across the workers sharing the box" {
+    gib = 1024 * 1024 * 1024;
+    assert _rss_cap_for(budget=9 * gib, jobs=4) == 2304;
+    assert _rss_cap_for(budget=9 * gib, jobs=2) == 4608;
+}
+
+test "workers cannot together outgrow the budget that sized the pool" {
+    gib = 1024 * 1024 * 1024;
+    for (budget, jobs) in [(9 * gib, 4), (4 * gib, 2), (60 * gib, 12)] {
+        cap = _rss_cap_for(budget=budget, jobs=jobs);
+        assert (cap * jobs * 1024 * 1024) <= budget , (
+            f"{jobs} workers capped at {cap} MB each exceed the "
+            f"{budget // gib} GiB budget the pool sized itself against"
+        );
+    }
+}
+
+test "an unreadable budget falls back to the per-worker sizing assumption" {
+    assert _rss_cap_for(budget=0, jobs=4) == 3072;
+}
+
+test "this box budgets a cap its own worker count can live inside" {
+    assert _mem_budget_bytes() > 0 , "no memory budget could be read";
+    assert _rss_cap_for(budget=_mem_budget_bytes(), jobs=1) > 0;
+}
+
+test "the footprint is what the worker holds, not its high-water mark" {
+    import os;
+    if not os.path.exists("/proc/self/status") {
+        return;
+    }
+    before = _worker_rss_mb();
+    blob = bytearray(256 * 1024 * 1024);
+    held = _worker_rss_mb();
+    del blob;
+    freed = _worker_rss_mb();
+    assert (held - before) >= 200 , "a 256 MB allocation did not move the footprint";
+    assert (held - freed) >= 200 , (
+        "the footprint stayed at its high-water mark after the memory went "
+        "back, so a worker that spiked once would read as oversized forever"
+    );
+}
+
+test "a cgroup ceiling is read, and an absent one reads as no ceiling" {
+    assert _limit_from_text("6442450944\n") == 6442450944;
+    assert _limit_from_text("max\n") == 0;
+    assert _limit_from_text("9223372036854771712\n") == 0 , (
+        "cgroup v1 spells unlimited as a near-maxint sentinel, which would "
+        "otherwise be taken for a real ceiling"
+    );
+}
+
+test "a pool sheds a worker before it reaches the stop threshold" {
+    gib = 1024 * 1024 * 1024;
+    assert _shed_threshold(mem_start=15 * gib) > (1536 * 1024 * 1024) , (
+        "shedding must get a chance on a large box before the run is stopped"
+    );
+    assert _shed_threshold(mem_start=2 * gib) == (3072 * 1024 * 1024) , (
+        "on a small box the proportional threshold falls under the stop "
+        "threshold, so it floors at twice it and the pool still sheds first"
+    );
 }

--- a/release_notes/unreleased/jaclang/8703.bugfix.md
+++ b/release_notes/unreleased/jaclang/8703.bugfix.md
@@ -1,0 +1,4 @@
+The test pool sizes itself to what a worker actually costs and sheds a worker
+when the box reports memory pressure, so a large suite no longer exhausts its
+runner. If memory still runs out the pool reports its trail and stops, instead
+of the runner being killed with no log.


### PR DESCRIPTION
Fixes the `test-native (passes-native)` runner deaths. Cause measured on the runner itself.

## The failure

The job reports `conclusion: failure` with **no failed step**, the step it died in stays `null`, and the log blob 404s because nothing uploads it. **20 of the last 40 pull-request runs** died this way, across unrelated branches. Filed as #8583.

No job timeout exists in `ci.yml`, and lifetimes spread over 31-41 min rather than clustering, so it is resource exhaustion rather than a limit. Nobody could see which resource, because a dead runner leaves no log.

## What the box was doing

The parent now samples every 5s and stops *before* the kill, so the step ends normally and its log survives. On the failing lane:

```
t=  4s  avail=13505MB workers=4 worker_rss= 1755MB load=1.1 done= 4/181
t= 88s  avail= 9989MB workers=4 worker_rss= 5160MB load=4.6 done=20/181
t=113s  avail= 5171MB workers=4 worker_rss= 9959MB load=5.1 done=20/181
t=129s  avail= 2954MB workers=4 worker_rss=12162MB load=5.2 done=21/181
t=218s  avail=  632MB workers=4 worker_rss=11304MB load=5.5 done=33/181
```

**Four workers reach 12.2 GB on a box with 14.6 GB free and exhaust it in 218 seconds**, 33 files into 181. Load peaks at 5.5 on four vCPUs and never diverges, so the runner is not starved of CPU. The 31-41 minute lifetimes are the box limping near zero on page-cache reclaim until the agent is taken.

## Cause

`default_jobs` admits `MemAvailable * _MEM_HEADROOM // _WORKER_MEM_BYTES` workers, and that constant said a worker costs **2 GiB**. The measurement says `12162/4` = **3040 MB**, so the pool admitted four where two fit.

That is the lever `jobs: "2"` pinned by hand until it was removed in #8666, which is why removing it broke this lane.

## Fix

**Size to what a worker costs.** `_WORKER_MEM_BYTES` carries the measured cost.

**Shed on what the box reports.** One constant cannot fit every lane, so the parent also acts on observation: when available memory falls under `_shed_threshold`, a worker is retired without replacement at its next result and the pool converges to a width the box carries. Light suites never reach the threshold and keep every worker. Shedding is floored at twice the stop threshold, so a run always sheds before it has to give up.

**One budget, two consumers.** The retirement bound is a share of the same budget that picks the worker count, so `jobs * cap` cannot exceed it on any box. It shipped at 8192 MB against a 2 GiB sizing assumption, four times the budget, and **never once fired in CI**: every retirement I could inspect came from the file counter, with workers at 5571 MB. #8666 documents this default as 2048, and its own tests all pass 2048.

**Right instrument.** `_worker_rss_mb` returned `ru_maxrss`, a high-water mark, to answer how much a worker holds *now*. It reads `VmRSS` where `/proc` exists. Without this a single long fixture and accumulation across many files are indistinguishable in the trail.

**Cgroup ceiling.** `_mem_budget_bytes` read `MemAvailable`, which reports the host even when the process is confined. A container limited to 6 GiB budgeted 4.8 GiB from the VM's 8 GiB.

## Verified on the runner

The lane **completes 181/181 without killing the runner**, and memory never approaches the floor. That is the first time this suite has reached the end.

It then reports 7 failures which are **pre-existing and unrelated to this change**, and have been invisible because the lane has never survived long enough to report them:

```
2 waived seam(s) are reachable:  BuiltinType.lit_value.__get__, Ellipsis.lit_value.__get__
type_evaluator.jac's native closure changed: 'keyword.jac' present, absent from the baseline
```

Both are compiler-source facts, not scheduling: those two seams appear verbatim as `un-lowerable` demotion warnings, and the closure differs by one added module. Filed separately rather than carried here.

## Also verified

- `tests/runtimelib/test_worker_retirement.jac`: 12 pass on macOS and in a Linux container.
- Negative control: reverting the instrument to `ru_maxrss` fails the high-water-mark test with its intended message.
- Shedding observed firing under real pressure in a memory-limited container.
- Cgroup ceiling checked at three limits: unconfined 4257 MB, `--memory=6g` 3686 MB, `--memory=3g` 1843 MB.
- `jac fmt --check --lintfix` clean; the two `too-many-params` warnings on `run_tests` pre-exist.

## Not addressed

Seven of 177 fixtures cost 2.9-4.8 GB each, and `test_demotion_link_consistency.jac` alone takes a worker from 341 MB to 4403 MB. Bounding that means fixing what they retain, which is #8665 / #8354 / #8146. `_run_serial` can neither retire nor shed, since one process has nothing to fork from, so `jac test` at `jobs=1` over a large directory has no protection.