### PR TITLE
chore(ci): refactor and docs release-note fragments are rejected

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,8 +148,12 @@ Every PR that changes package code must include a release note fragment file:
 1. Create a file at `release_notes/unreleased/<package>/<PR#>.<category>.md`
    - **Packages**: `jaclang`, `byllm`
    - **Note**: The Jac client and desktop runtimes, the `scale` deployment subsystem, and the MCP server are now part of `jaclang` core (under `jac/jaclang/client/`, `jac/jaclang/scale/`, and `jac/jaclang/cli/mcp/`); changes to them use the `jaclang` package fragment.
-   - **Categories**: `feature`, `bugfix`, `breaking`, `refactor`, or `docs`
+   - **Categories**: `feature`, `bugfix`, or `breaking`
    - **Example**: `release_notes/unreleased/jaclang/1234.bugfix.md`
+   - `refactor` and `docs` fragments are rejected by CI: release notes
+     carry user-facing changes only. A PR that is a pure internal
+     refactor or a docs-only edit files no fragment and takes the
+     `skip-release-notes-check` label instead.
 
 2. Add one or more bullet points:
 

--- a/release_notes/unreleased/README.md
+++ b/release_notes/unreleased/README.md
@@ -6,8 +6,9 @@ Every PR that changes package code must include a release note fragment file.
 
 1. Create a file at `release_notes/unreleased/<package>/<PR#>.<category>.md`
    - **Packages**: `jaclang`, `byllm`, `jac-scale`, `jac-mcp` (the former `jac-client` / `jac-desktop` plugins are now part of `jaclang` core -- file their fragments under `jaclang`)
-   - **Categories**: `feature`, `bugfix`, `breaking`, `refactor`, or `docs`
+   - **Categories**: `feature`, `bugfix`, or `breaking`
    - **Example**: `release_notes/unreleased/jaclang/1234.bugfix.md`
+   - `refactor` and `docs` are not accepted (see [Skipping](#skipping))
 
 2. Add one or more bullet points in the file.
 
@@ -43,18 +44,6 @@ assembled page.
 - **Breaking: Brief title**: What changed and what users need to do.
 ```
 
-**Refactor** (`release_notes/unreleased/jaclang/1234.refactor.md`):
-
-```markdown
-- **Refactor: Brief title**: Description of the internal change.
-```
-
-**Documentation** (`release_notes/unreleased/jaclang/1234.docs.md`):
-
-```markdown
-- **Docs: Brief title**: Description of the documentation update.
-```
-
 ## Example PR
 
 See [#5573](https://github.com/jaseci-labs/jaseci/pull/5573) for a real example of a PR with a release note fragment.
@@ -62,3 +51,9 @@ See [#5573](https://github.com/jaseci-labs/jaseci/pull/5573) for a real example 
 ## Skipping
 
 To skip this check, add the `skip-release-notes-check` label to your PR.
+
+That label is also the answer for refactors and docs. Release notes carry
+user-facing changes only, so `<PR#>.refactor.md` and `<PR#>.docs.md` fragments
+are rejected by the Contribution Checks lane. If the change has nothing to tell
+a user, file no fragment and add the label; if it does, write it up under
+`feature`, `bugfix`, or `breaking`.

--- a/scripts/check-release-notes.sh
+++ b/scripts/check-release-notes.sh
@@ -74,15 +74,47 @@ if [ ${#DIRECTLY_MODIFIED[@]} -gt 0 ]; then
 fi
 
 # Fragment path with the PR number captured in group 1.
-FRAGMENT_REGEX='release_notes/unreleased/[^/]+/([0-9]+)\.(feature|bugfix|breaking|refactor|docs)\.md$'
+FRAGMENT_REGEX='release_notes/unreleased/[^/]+/([0-9]+)\.(feature|bugfix|breaking)\.md$'
+
+# Categories the release notes no longer carry. A PR that is only an internal
+# refactor or a docs edit has nothing to tell a user at release time, so it
+# takes the skip label instead of filing a fragment.
+REJECTED_REGEX='release_notes/unreleased/[^/]+/([0-9]+)\.(refactor|docs)\.md$'
 
 CHANGED_FRAGMENTS=()
+REJECTED_FRAGMENTS=()
 while IFS= read -r file; do
     [ -z "$file" ] && continue
     # Deleted fragments (cleanup of stale entries) are not "this PR's fragment"
     [ -f "$file" ] || continue
     [[ "$file" =~ $FRAGMENT_REGEX ]] && CHANGED_FRAGMENTS+=("$file")
+    [[ "$file" =~ $REJECTED_REGEX ]] && REJECTED_FRAGMENTS+=("$file")
 done <<< "$CHANGED_FILES"
+
+if [ ${#REJECTED_FRAGMENTS[@]} -gt 0 ]; then
+    echo ""
+    echo "=========================================="
+    echo "ERROR: 'refactor' and 'docs' release notes are not accepted!"
+    echo "=========================================="
+    echo ""
+    echo "This PR adds or edits fragments in a retired category:"
+    echo ""
+    for item in "${REJECTED_FRAGMENTS[@]}"; do
+        echo "  - $item"
+    done
+    echo ""
+    echo "Release notes carry user-facing changes only. The accepted"
+    echo "categories are: feature, bugfix, breaking."
+    echo ""
+    echo "If the change IS user-facing, rename the fragment to the category"
+    echo "that fits:"
+    echo "  release_notes/unreleased/<package>/<PR#>.<feature|bugfix|breaking>.md"
+    echo ""
+    echo "If it is a pure internal refactor or a docs-only edit, do not file a"
+    echo "fragment at all: add the 'skip-release-notes-check' label to your PR."
+    echo ""
+    exit 1
+fi
 
 # A PR may only add/edit a fragment named after its own number; skipped locally
 # where PR_NUMBER is unknown.
@@ -131,7 +163,7 @@ for folder in "${!FOLDER_TO_FRAGMENTS[@]}"; do
         if [[ "$file" == "${folder}"* ]] && [[ "$file" != */tests/* ]]; then
             folder_changed=true
         fi
-        if [[ "$file" == "${fragments_dir}"* ]] && [[ "$file" =~ /([0-9]+)\.(feature|bugfix|breaking|refactor|docs)\.md$ ]]; then
+        if [[ "$file" == "${fragments_dir}"* ]] && [[ "$file" =~ /([0-9]+)\.(feature|bugfix|breaking)\.md$ ]]; then
             if [ -z "$PR_NUMBER" ] || [ "${BASH_REMATCH[1]}" == "$PR_NUMBER" ]; then
                 fragment_added=true
             fi
@@ -139,7 +171,7 @@ for folder in "${!FOLDER_TO_FRAGMENTS[@]}"; do
     done <<< "$CHANGED_FILES"
 
     if $folder_changed && ! $fragment_added; then
-        MISSING_NOTES+=("${folder} -> ${fragments_dir}<PR#>.<feature|bugfix|breaking|refactor|docs>.md")
+        MISSING_NOTES+=("${folder} -> ${fragments_dir}<PR#>.<feature|bugfix|breaking>.md")
     fi
 done
 


### PR DESCRIPTION
## **Description**

Release notes are read by users at release time, so a fragment whose only content is "an internal thing moved" or "a page was edited" costs a reader their attention and tells them nothing. Two of the five accepted categories were exactly that, and with `refactor` on the menu a contributor files `<PR#>.refactor.md` instead of deciding whether the change is worth announcing at all.

**Contribution Checks now fails a PR that adds or edits a `.refactor.md` or `.docs.md` fragment.** The error names the offending files, states the accepted set (`feature`, `bugfix`, `breaking`), and gives both exits:

```
==========================================
ERROR: 'refactor' and 'docs' release notes are not accepted!
==========================================

This PR adds or edits fragments in a retired category:

  - release_notes/unreleased/jaclang/1234.refactor.md

Release notes carry user-facing changes only. The accepted
categories are: feature, bugfix, breaking.

If the change IS user-facing, rename the fragment to the category
that fits:
  release_notes/unreleased/<package>/<PR#>.<feature|bugfix|breaking>.md

If it is a pure internal refactor or a docs-only edit, do not file a
fragment at all: add the 'skip-release-notes-check' label to your PR.
```

The rejection runs ahead of the PR-number and missing-fragment rules, so the category error is what the contributor sees rather than a confusing "fragment not added" for a file they just added. The accepted-category regex and the missing-fragment hint drop the two categories as well, so a `.refactor.md` no longer satisfies the requirement either.

Deletions stay exempt via the existing `-f` guard: cleaning up the stale `.refactor.md` fragments already sitting in `release_notes/unreleased/jaclang/` does not trip the new rule, and release PRs still short-circuit at the `release:` title gate.

`CONTRIBUTING.md` and `release_notes/unreleased/README.md` list three categories now, and the README's Skipping section explains that the label is the answer for refactor and docs work.

## **Deliberately left alone**

`collect_release_notes.jac` and `validate_fragments.jac` still accept both categories, because a release still has to render the ten-plus `.refactor.md` fragments already committed to `unreleased/`. Both can be narrowed once those drain at the next release. (`validate_fragments.jac` is also dead code -- nothing invokes it.)

## **Verification**

Exercised in a throwaway git repo against the real script:

| case | result |
| --- | --- |
| adds `1234.refactor.md` | exit 1, new message |
| adds `1234.docs.md` | exit 1, new message |
| adds `1234.bugfix.md` | exit 0 |
| code change, no fragment | exit 1, old error with the narrowed hint |
| deletes stale `999.refactor.md` + adds own `1234.bugfix.md` | exit 0 |

This PR touches only `scripts/` and docs, so it needs no fragment of its own.