### PR TITLE
fix(native): the aarch64 outline-atomics helpers reach the executable link path, keyed on the target (#8727)

### DIFF
--- a/.github/workflows/experimental-image.yml
+++ b/.github/workflows/experimental-image.yml
@@ -6,6 +6,10 @@ name: Experimental jac image (per-PR)
 #   action=build  -> publish jaseci/jaclang:experimental-<PR#> from the PR's HEAD
 #   action=delete -> remove that tag from Docker Hub once the PR is done
 # Deploy from it with [experimental] pr = <PR#> in jac.toml.
+#
+# `platforms` narrows the image to one arch. The default builds both, but an
+# arch whose binary is broken on the PR's HEAD otherwise fails the whole build
+# for consumers who only ever pull the other one.
 
 on:
   workflow_dispatch:
@@ -19,6 +23,14 @@ on:
         description: "PR number (image tag is experimental-<PR#>)"
         required: true
         type: string
+      platforms:
+        description: "Platforms the image is built for"
+        type: choice
+        default: linux/amd64,linux/arm64
+        options:
+          - linux/amd64,linux/arm64
+          - linux/amd64
+          - linux/arm64
 
 permissions:
   contents: read
@@ -34,6 +46,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       pr: ${{ inputs.pr }}
+      matrix: ${{ steps.matrix.outputs.include }}
     steps:
       - name: Verify the PR is open
         env:
@@ -49,17 +62,30 @@ jobs:
           fi
           echo "PR #$PR is open; building refs/pull/$PR/head."
 
+      # One native runner per requested arch: setup-jac builds host-native with
+      # no cross-compile, so the matrix follows the platform list.
+      - name: Resolve the build matrix
+        id: matrix
+        env:
+          PLATFORMS: ${{ inputs.platforms }}
+        run: |
+          set -euo pipefail
+          rows=""
+          for p in ${PLATFORMS//,/ }; do
+            case "$p" in
+              linux/amd64) rows="${rows}{\"os\":\"ubuntu-latest\",\"platform\":\"amd64\"}," ;;
+              linux/arm64) rows="${rows}{\"os\":\"ubuntu-24.04-arm\",\"platform\":\"arm64\"}," ;;
+              *) echo "::error::unsupported platform '$p'"; exit 1 ;;
+            esac
+          done
+          echo "include=[${rows%,}]" >> "$GITHUB_OUTPUT"
+
   build:
     needs: resolve
     strategy:
       fail-fast: false
       matrix:
-        # One native runner per arch: setup-jac builds host-native, no cross-compile.
-        include:
-          - os: ubuntu-latest
-            platform: amd64
-          - os: ubuntu-24.04-arm
-            platform: arm64
+        include: ${{ fromJSON(needs.resolve.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -108,12 +134,14 @@ jobs:
           exit 1
 
       - name: Fetch the amd64 binary
+        if: contains(inputs.platforms, 'amd64')
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: jac-experimental-amd64
           path: ctx/amd64
 
       - name: Fetch the arm64 binary
+        if: contains(inputs.platforms, 'arm64')
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: jac-experimental-arm64
@@ -122,7 +150,7 @@ jobs:
       - name: Stage the build context
         run: |
           set -euxo pipefail
-          chmod +x ctx/amd64/jac ctx/arm64/jac
+          chmod +x ctx/*/jac
           cp docker/jaclang.Dockerfile ctx/Dockerfile
 
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
@@ -137,12 +165,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push (linux/amd64, linux/arm64)
+      - name: Build and push
         if: env.DOCKERHUB_USERNAME != ''
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ctx
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ inputs.platforms }}
           push: true
           tags: jaseci/jaclang:experimental-${{ needs.resolve.outputs.pr }}
 
@@ -150,11 +178,14 @@ jobs:
         if: env.DOCKERHUB_USERNAME != ''
         env:
           PR: ${{ needs.resolve.outputs.pr }}
+          PLATFORMS: ${{ inputs.platforms }}
         run: |
           {
             echo "## Experimental image published"
             echo ""
             echo '`jaseci/jaclang:experimental-'"$PR"'`'
+            echo ""
+            echo "Platforms: \`$PLATFORMS\`"
             echo ""
             echo "Point a deploy at it with \`[experimental] pr = $PR\` in jac.toml."
             echo "When done, delete it by re-running this workflow with action=delete."

--- a/jac/jaclang/cli/commands/impl/nacompile.impl.jac
+++ b/jac/jaclang/cli/commands/impl/nacompile.impl.jac
@@ -204,6 +204,36 @@ def _inject_entry_pe(llvm_ir_str: str) -> str {
 }
 
 
+def _finalize_native_ir(
+    llvm_ir_str: str,
+    triple: str,
+    clib_paths: list[str],
+    manifest: any,
+    shared: bool,
+    is_windows: bool,
+    is_macos: bool,
+    static_musl: bool
+) -> tuple[str, list[str]] {
+    import from jaclang.compiler.backends.native.shared_emit {
+        aarch64_floor_atomics_ir,
+        inject_shared_init
+    }
+    extra_exports: list[str] = [];
+    if shared {
+        (llvm_ir_str, extra_exports) = inject_shared_init(llvm_ir_str, manifest);
+    } elif is_windows {
+        llvm_ir_str = _inject_entry_pe(llvm_ir_str);
+    } elif is_macos {
+        llvm_ir_str = _inject_entry_macho(llvm_ir_str);
+    } elif static_musl {
+        llvm_ir_str = _inject_entry_elf_static(llvm_ir_str);
+    } else {
+        llvm_ir_str = _inject_entry_elf(llvm_ir_str, triple);
+    }
+    return (llvm_ir_str + aarch64_floor_atomics_ir(triple, clib_paths), extra_exports);
+}
+
+
 impl nacompile(
     filename: str,
     output: str = "",
@@ -522,12 +552,17 @@ impl nacompile(
     _is_linux_exec = (not shared) and (not is_windows) and (not is_macos);
     _static_musl = _is_linux_exec and (len(needed_libs) == 0);
 
+    (llvm_ir_str, _extra_exports) = _finalize_native_ir(
+        llvm_ir_str,
+        triple,
+        clib_paths or [],
+        ir_module.gen.interop_manifest,
+        shared,
+        is_windows,
+        is_macos,
+        _static_musl
+    );
     if shared {
-        _mf = ir_module.gen.interop_manifest;
-        import from jaclang.compiler.backends.native.shared_emit {
-            inject_shared_init as _inject_shared_init
-        }
-        (llvm_ir_str, _extra_exports) = _inject_shared_init(llvm_ir_str, _mf);
         init_funcs = ["__jac_shared_init"];
         for _s in ir_module.gen._exported_symbols {
             if _s not in export_symbols {
@@ -550,14 +585,6 @@ impl nacompile(
             f"  Exporting {len(export_symbols)} C-ABI symbol(s): "
                 + ", ".join(export_symbols)
         );
-    } elif is_windows {
-        llvm_ir_str = _inject_entry_pe(llvm_ir_str);
-    } elif is_macos {
-        llvm_ir_str = _inject_entry_macho(llvm_ir_str);
-    } elif _static_musl {
-        llvm_ir_str = _inject_entry_elf_static(llvm_ir_str);
-    } else {
-        llvm_ir_str = _inject_entry_elf(llvm_ir_str, triple);
     }
 
     if (shared or (_is_linux_exec and not _static_musl))

--- a/jac/jaclang/compiler/backends/native/shared_emit.jac
+++ b/jac/jaclang/compiler/backends/native/shared_emit.jac
@@ -192,6 +192,20 @@ def _lse_sym(nm: str) -> list[str] {
     return [f"  .weak {nm}", f"  .hidden {nm}", f"  .type {nm},%function", f"{nm}:"];
 }
 
+def aarch64_floor_atomics_ir(triple: str, clib_paths: list[str]) -> str {
+    import from jaclang.runtime.graph_utils { triple_arch }
+    if not clib_paths or triple_arch(triple) != "aarch64" {
+        return "";
+    }
+    tl = triple.lower();
+    is_pe = ("windows" in tl) or ("win32" in tl) or ("msvc" in tl) or ("mingw" in tl);
+    is_macho = ("darwin" in tl) or ("apple" in tl) or ("macos" in tl) or ("ios" in tl);
+    if is_pe or is_macho {
+        return "";
+    }
+    return aarch64_outline_atomics_ir();
+}
+
 def emit_shared_library(
     llvm_ir_str: str,
     manifest: any,
@@ -219,10 +233,6 @@ def emit_shared_library(
             "  ret i32 %r\n}\n"
         );
     }
-    import platform;
-    if is_elf and clib_paths and platform.machine() in ["aarch64", "arm64"] {
-        ir_str += aarch64_outline_atomics_ir();
-    }
     exports: list[str] = [];
     for _s in list(export_symbols) + extra_exports + ["__jac_shared_init"] {
         if _s and _s not in exports {
@@ -237,6 +247,10 @@ def emit_shared_library(
 
     llvm.initialize_native_asmparser();
 
+    triple = llvm.get_default_triple();
+    assert isinstance(triple, str);
+    ir_str += aarch64_floor_atomics_ir(triple, list(clib_paths or []));
+
     try {
         mod = llvm.parse_assembly(ir_str);
         mod.verify();
@@ -246,8 +260,6 @@ def emit_shared_library(
 
     target = llvm.Target.from_default_triple();
     assert isinstance(target, llvm.Target);
-    triple = llvm.get_default_triple();
-    assert isinstance(triple, str);
     target_machine = target.create_target_machine(
         opt=2, reloc="pic", codemodel="small"
     );

--- a/jac/tests/compiler/backends/native/test_aarch64_outline_atomics.jac
+++ b/jac/tests/compiler/backends/native/test_aarch64_outline_atomics.jac
@@ -9,6 +9,18 @@ library linked perfectly clean and then died at `dlopen` with
 
     libjac_unitree.so: undefined symbol: __aarch64_ldadd4_relax
 
+Executables link the same floor archives and pay the same debt. Once the
+launcher stopped being a Zig-linked stub and became `jac nacompile --strict
+launcher/launcher.jac` (#8468), nothing supplied compiler_rt for it any more,
+and the linux/arm64 `jac` binary linked clean and then refused to start with
+
+    jac: symbol lookup error: jac: undefined symbol: __aarch64_ldset8_acq_rel
+
+(#8727). So the emitter hangs off `_finalize_native_ir`, the one point every
+`nacompile` artifact passes through -- shared library and executable alike --
+and it is keyed on the TARGET triple, not on `platform.machine()`: the host
+that cross-compiles an aarch64 image is usually an x86_64 runner.
+
 Our own codegen is not the source and cannot be the fix: under the exact target
 machine `shared_emit` builds, LLVM lowers `atomicrmw` to inline `ldxr`/`stxr`
 and never calls a helper. The vendored objects are the callers, so the artifact
@@ -39,7 +51,13 @@ value, the stored new value, sub-word CAS's zero-extension of a caller's wide
 """
 
 import jaclang.compiler.backends.native.llvm.binding as llvm;
-import from jaclang.compiler.backends.native.shared_emit { aarch64_outline_atomics_ir }
+import from jaclang.compiler.backends.native.shared_emit {
+    aarch64_floor_atomics_ir,
+    aarch64_outline_atomics_ir
+}
+import from jaclang.cli.commands.nacompile { _finalize_native_ir }
+
+glob EXEC_STUB = 'define void @"jac_entry"() {\nentry:\n  ret void\n}\n';
 
 """Every symbol the LSE outline-atomics ABI defines, spelled out from its axes."""
 def _abi_family -> list[str] {
@@ -159,4 +177,128 @@ test "the asm block is well-formed IR on every host, not just aarch64" {
     for nm in _abi_family() {
         assert nm in text , f"{nm} did not survive into the parsed module";
     }
+}
+
+
+"""The IR `jac nacompile` hands to LLVM for one target, straight off the
+production finalization point. Every argument but the ones a test varies is
+the launcher's own shape: a plain executable, not shared, not Windows, not
+macOS."""
+def _finalized(
+    triple: str,
+    clib_paths: list[str],
+    shared: bool = False,
+    is_macos: bool = False,
+    static_musl: bool = False
+) -> str {
+    (out, _exports) = _finalize_native_ir(
+        llvm_ir_str=EXEC_STUB,
+        triple=triple,
+        clib_paths=clib_paths,
+        manifest=None,
+        shared=shared,
+        is_windows=False,
+        is_macos=is_macos,
+        static_musl=static_musl
+    );
+    return out;
+}
+
+
+test "the aarch64 executable path defines the whole family (issue #8727)" {
+    # This host is x86_64 in CI and on every dev box that is not an ARM Mac, so
+    # a pass here is also the proof that the decision follows the TARGET and not
+    # `platform.machine()` -- the bug that made the injection wrong under the
+    # cross-compiling release legs.
+    ir = _finalized("aarch64-unknown-linux-gnu", ["libz.so"]);
+    assert "__aarch64_ldset8_acq_rel" in ir , (
+        "the aarch64 executable path emitted no __aarch64_ldset8_acq_rel; a "
+        "floor object calling it leaves the binary unable to start at all "
+        "(`jac: symbol lookup error: jac: undefined symbol: "
+        "__aarch64_ldset8_acq_rel`)"
+    );
+    missing = sorted(
+        {
+            n
+            for n in _abi_family()
+            if n not in ir
+        }
+    );
+    assert not missing , (
+        f"{len(missing)} outline-atomics helper(s) missing from the aarch64 "
+        f"executable's IR: {missing[:6]}"
+    );
+}
+
+
+test "the static-musl executable path defines them too" {
+    ir = _finalized("aarch64-unknown-linux-musl", ["libz.so"], static_musl=True);
+    assert "__aarch64_ldset8_acq_rel" in ir , (
+        "a fully static aarch64 executable merges the same floor archive "
+        "members, so it needs the same callees"
+    );
+}
+
+
+test "the aarch64 shared-library path defines them too" {
+    ir = _finalized("aarch64-unknown-linux-gnu", ["libz.so"], shared=True);
+    assert "__aarch64_ldset8_acq_rel" in ir , (
+        "`jac nacompile --shared` links the floor archives as well; this is "
+        "the dlopen failure the family was first written for"
+    );
+}
+
+
+test "a non-aarch64 target carries none of them" {
+    ir = _finalized("x86_64-unknown-linux-gnu", ["libz.so"]);
+    assert "__aarch64_" not in ir , (
+        "the helpers are aarch64 machine code; an x86_64 artifact carrying "
+        "them would not assemble"
+    );
+}
+
+
+test "an artifact that links no floor archive carries none of them" {
+    ir = _finalized("aarch64-unknown-linux-gnu", []);
+    assert "__aarch64_" not in ir , (
+        "our own codegen never calls these -- with no vendored objects in the "
+        "link there is no caller, so nothing to define"
+    );
+}
+
+
+test "an aarch64 Mach-O artifact carries none of them" {
+    ir = _finalized("arm64-apple-darwin", ["libz.dylib"], is_macos=True);
+    assert "__aarch64_" not in ir , (
+        "`.hidden` and `%function` are ELF directives, and Apple's toolchain "
+        "supplies the helpers itself; emitting them here would fail to "
+        "assemble"
+    );
+}
+
+
+test "the finalized aarch64 executable IR still parses" {
+    llvm.initialize_all_targets();
+    llvm.initialize_all_asmprinters();
+    src = (
+        "target triple = \"aarch64-unknown-linux-gnu\"\n"
+        + _finalized("aarch64-unknown-linux-gnu", ["libz.so"])
+    );
+    mod = llvm.parse_assembly(src);
+    mod.verify();
+    text = str(mod);
+    for nm in _abi_family() {
+        assert nm in text , (f"{nm} did not survive into the parsed executable module");
+    }
+}
+
+
+test "the emitter itself is gated on the target, not the host" {
+    # `emit_shared_library` is the other consumer, so the gate is pinned on the
+    # shared helper directly as well as through the nacompile path above.
+    assert aarch64_floor_atomics_ir("aarch64-unknown-linux-gnu", ["libz.so"]) != "";
+    assert aarch64_floor_atomics_ir("aarch64-unknown-linux-gnu", []) == "";
+    assert aarch64_floor_atomics_ir("x86_64-unknown-linux-gnu", ["libz.so"]) == "";
+    assert aarch64_floor_atomics_ir("arm64-apple-darwin", ["libz.dylib"]) == "";
+    assert aarch64_floor_atomics_ir("aarch64-pc-windows-msvc", ["z.lib"]) == "";
 }

--- a/release_notes/unreleased/jaclang/8781.bugfix.md
+++ b/release_notes/unreleased/jaclang/8781.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: the linux/arm64 binary starts again**: Every native artifact that links the C floor archives now carries the aarch64 LSE outline-atomics helpers, executables included and not just shared libraries, and the decision is keyed on the target triple rather than the build host. `jac` on linux/arm64 no longer dies at load with `undefined symbol: __aarch64_ldset8_acq_rel`.


### PR DESCRIPTION
Fixes #8727.

The linux/arm64 `jac` binary links clean and then cannot start:

```
jac: symbol lookup error: jac: undefined symbol: __aarch64_ldset8_acq_rel
```

This is broader than the issue reads. It is not only the multi-arch docker
image: the nightly "Release jac dev binary (rolling main)" job has failed every
night since 2026-08-22 (last success 2026-08-21) at its "Smoke test (no system
Python)" step, with exactly this symbol, on the binary `zig build` itself
produced. `jac-dev-linux-aarch64` and `jac-dev-admin-dist.tar.gz` on the `dev`
release are frozen at 2026-08-21 while every other leg publishes daily, and
`jaseci/jaclang:dev` is frozen with them. That also closes the issue's open
caveat: a release-path arm64 binary does carry the same undefined symbol.

## What was wrong

`__aarch64_ldset8_acq_rel` is an LSE outline-atomics helper. The C floor
archives are built with `-moutline-atomics`, so their objects call
`__aarch64_{ldadd,ldclr,ldeor,ldset,swp,cas}<size>_<order>`. Those live only in
a static libgcc/compiler-rt; `libgcc_s` exports none of them.

The repo already had the answer, from #8307: `aarch64_outline_atomics_ir()` in
`shared_emit.jac` emits weak+hidden LL/SC definitions of the whole family as
`module asm`. It just had exactly one call site, inside `emit_shared_library`,
under this gate:

```
if is_elf and clib_paths and platform.machine() in ["aarch64", "arm64"] {
```

Two holes. Nothing on the **executable** path emitted the helpers at all. And
the gate read the **build host** rather than the target, so a cross-compiled
image got the wrong answer in either direction.

It stayed invisible until #8468 turned the launcher from a Zig-linked stub into
`jac nacompile --strict launcher/launcher.jac`, "linked by Jac's own ELF/Mach-O
linkers". Zig used to supply compiler_rt's copies; Jac's own ELF linker does
not. That commit landed 2026-08-21 21:33 and the first red nightly is
2026-08-22 06:47.

## The fix

`nacompile`'s shared-library and entry-point injection collapse into one
`_finalize_native_ir` -- the single point every artifact it produces passes
through, shared library and executable alike -- and the family hangs off that
through a new `aarch64_floor_atomics_ir(triple, clib_paths)` in `shared_emit`.
`emit_shared_library` calls the same helper instead of carrying its own copy of
the gate. One emitter, one decision, keyed on the target triple.

The conditions that were doing real work are kept: ELF only (not Mach-O, whose
toolchain supplies these itself, and where `.hidden` / `%function` would not
assemble; not PE), and only when floor archives are in the link, since our own
codegen never calls these -- `atomicrmw` lowers to inline `ldxr`/`stxr`. The
weak+hidden linkage and the `module asm` header are untouched.

## What the tests prove, and what they do not

`jac/tests/compiler/backends/native/test_aarch64_outline_atomics.jac` gains
eight tests that drive `_finalize_native_ir` directly, from an x86_64 host, and
pin:

* the plain ELF executable path defines `__aarch64_ldset8_acq_rel` and all 100
  members of the family for an `aarch64-unknown-linux-gnu` target;
* so do the static-musl executable path and the shared-library path;
* an x86_64 target, an aarch64 target with no floor archives, and an aarch64
  Mach-O target get none of them;
* the finalized aarch64 executable IR still parses and every helper survives
  into the module;
* the gate on the shared helper itself, for `emit_shared_library`.

Because the host running them is x86_64 and the target is aarch64, a pass is
also the proof that the decision follows the target and not
`platform.machine()`.

Before the fix, the first three of those fail on the real assertion, e.g.

```
AssertionError: the aarch64 executable path emitted no __aarch64_ldset8_acq_rel;
a floor object calling it leaves the binary unable to start at all
```

These pin the property at the emit layer. They do **not** prove the end result,
and neither this PR's checks nor any x86_64 box can: that needs a linux/arm64
binary that starts. The definitive confirmation is the next nightly
"Release jac dev binary (rolling main)" run getting past its "Smoke test (no
system Python)" step and publishing a fresh `jac-dev-linux-aarch64`.

## Second commit: `platforms` input on the experimental image

Ask #2 from the issue, kept in its own commit. `.github/workflows/experimental-image.yml`
hardcoded `linux/amd64,linux/arm64`, so a broken arch fails the build even for
consumers who only need the other one. It now takes a `platforms` choice input
defaulting to both; `resolve` derives the runner matrix from it, the image job
fetches only the arches asked for, and buildx gets the same list.

## Targeted test runs

`test_aarch64_outline_atomics.jac` 12 passed, `test_exec_link.jac` 9 passed,
`test_static_archive_link.jac` 7 passed. `test_shared_lib.jac` errors on
`ctypes.argtypes` (E1001, `Cannot assign list[type[c_int64]] to
Sequence[type[_SpecialForm]]`), which reproduces unchanged on the merge base
and is not touched by this PR.
