### PR TITLE
test(native): pin the asm parser on the nacompile path itself, not on a helper the test initializes (#8788 follow-up)

### DIFF
--- a/jac/tests/compiler/backends/native/test_aarch64_outline_atomics.jac
+++ b/jac/tests/compiler/backends/native/test_aarch64_outline_atomics.jac
@@ -54,6 +54,15 @@ and finds none registered. It is `report_fatal_error`, so the process aborts:
 The parse-level test that shipped with #8781 stopped exactly one step short of
 that, which is why the object-emission test below runs in a subprocess.
 
+There are two object-emission tests, and the difference between them is the
+whole point. One calls `init_object_codegen` itself and proves the emitter
+works: every helper assembles and reaches the symbol table, on any host. It
+does NOT prove that `jac nacompile` calls that initialization, so the
+executable path could drop it and that test would stay green -- which is the
+shape of the original miss, one level up. The other drives the real
+`jac nacompile` CLI and pins the property that actually broke the release:
+the executable compile path registers an asm parser for ITS target.
+
 Not pinned here at all, because it needs an aarch64 machine: the semantics. Each
 helper was run under qemu-aarch64 against a C harness checking the returned old
 value, the stored new value, sub-word CAS's zero-extension of a caller's wide
@@ -63,6 +72,7 @@ value, the stored new value, sub-word CAS's zero-extension of a caller's wide
 import os;
 import subprocess;
 import sys;
+import tempfile;
 import from pathlib { Path }
 import jaclang.compiler.backends.native.llvm.binding as llvm;
 import from jaclang.compiler.backends.native.shared_emit {
@@ -342,5 +352,72 @@ test "the aarch64 executable path assembles to a real object (#8788)" {
     assert "EMIT_OK" in res.stdout , (
         f"the object emitted, but not as an aarch64 ELF carrying every member "
         f"of the outline-atomics family.\nstdout: {res.stdout[-800:]}"
+    );
+}
+
+
+test "jac nacompile itself registers a parser for its target (#8788)" {
+    # The property that broke the aarch64 release build, driven through the real
+    # CLI rather than through a helper the test initializes for itself: revert
+    # nacompile.impl.jac's `init_object_codegen()` to the bare
+    # initialize_all_targets/asmprinters pair and this goes red, which is the
+    # control the previous test did not answer.
+    #
+    # The C floor import is what puts `module asm` in this module at all, so
+    # JAC_DUMP_IR is read back first: it holds the finalized module, written
+    # just BEFORE emission, and is therefore present in the aborting case too.
+    # Without that check a fixture that quietly lost its clib import would make
+    # this pass while proving nothing.
+    #
+    # No aarch64 toolchain is involved. The abort is at object emission, which
+    # is upstream of linking, so cross-compiling from any host reaches it.
+    work = tempfile.mkdtemp();
+    dump = os.path.join(work, "finalized.ll");
+    env = dict(os.environ);
+    env["JAC_DUMP_IR"] = dump;
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "jaclang",
+            "nacompile",
+            "--target",
+            "aarch64-unknown-linux-gnu",
+            os.path.join(FIXTURES, "static_archive_crc32.jac"),
+            "-o",
+            os.path.join(work, "crc32_aarch64")
+        ],
+        capture_output=True,
+        text=True,
+        timeout=900,
+        env=env
+    );
+    out = res.stdout + res.stderr;
+
+    assert os.path.isfile(dump) , (
+        f"nacompile never dumped its finalized module, so nothing here says "
+        f"whether the run carried module asm at all.\n{out[-800:]}"
+    );
+    with open(dump) as _f {
+        finalized = _f.read();
+    }
+    assert "__aarch64_ldset8_acq_rel" in finalized , (
+        "the fixture compiled without the outline-atomics helpers in its "
+        "module, so this run exercised nothing: the helpers ride on a C floor "
+        "import, and static_archive_crc32.jac must keep one"
+    );
+
+    assert "Inline asm not supported by this streamer" not in out , (
+        f"jac nacompile aborted assembling the outline-atomics `module asm` "
+        f"for an aarch64 target: the executable compile path registered no asm "
+        f"parser for the target it was emitting.\n{out[-800:]}"
+    );
+    assert res.returncode not in [134, -6] , (
+        f"jac nacompile died on SIGABRT ({res.returncode}) emitting for "
+        f"aarch64.\n{out[-800:]}"
+    );
+    assert "Object code emitted" in out , (
+        f"jac nacompile never got past object emission for an aarch64 target, "
+        f"which is where a missing asm parser kills it.\n{out[-800:]}"
     );
 }


### PR DESCRIPTION
Test-only fast-follow to #8788 (merged as 283700ce2). The fix there is correct
and stands; its regression test did not actually guard the regression.

## The gap

`fixtures/emit_aarch64_atomics_obj.jac` calls `init_object_codegen()` itself at
the top of its `with entry` block, then finalizes and emits. So it proves two
real things -- that the shim's all-targets parser works, and that every helper
reaches the symbol table -- and nothing about whether `jac nacompile` performs
that initialization.

Reverting only `jac/jaclang/cli/commands/impl/nacompile.impl.jac` to the bare
`initialize_all_targets()` / `initialize_all_asmprinters()` pair, which is
exactly the state that aborted the aarch64 release build, left the file green:

```
jac test jac/tests/compiler/backends/native/test_aarch64_outline_atomics.jac
13 passed
```

That is the same failure mode as the miss before it, one level up. #8781
asserted on IR text when the bug was at assembly; #8788 asserted on a helper
when the bug was in the path that calls it. The property that broke the release
is "the executable compile path registers an asm parser for its target", and
nothing pinned it.

## The test

Drive the real CLI: `jac nacompile --target aarch64-unknown-linux-gnu` over
`static_archive_crc32.jac`, whose `import from lzma` is what puts `module asm`
in the module at all. No aarch64 toolchain is involved -- the abort is at object
emission, upstream of linking -- and no aarch64 C floor is needed either; this
was developed on an x86_64 box with no `.pbs-build/linux-aarch64` present.

Three assertions keep it from passing for the wrong reason:

1. `JAC_DUMP_IR` is read back FIRST and must contain
   `__aarch64_ldset8_acq_rel`. That dump is written just before emission, so it
   is present in the aborting case too. A fixture that quietly lost its C floor
   import therefore fails here loudly instead of passing vacuously, and because
   the guard holds in both states it never masks the real assertion.
2. `Inline asm not supported by this streamer` and SIGABRT are ruled out by
   name, so a run that fails some other way is not read as success.
3. `Object code emitted` must appear -- the line printed only once
   `emit_object` returns. A link failure after emission still prints it, so an
   unrelated link problem cannot turn this red; an emission abort never does.

Subprocess isolation is kept, since `report_fatal_error` aborts the process and
would take the file's other thirteen tests with it.

## Verified both ways, on this base

| | as committed | `nacompile.impl.jac` init reverted |
|---|---|---|
| exit code | 0 | 134 (SIGABRT) |
| dump carries the helpers | yes | yes (precondition held) |
| `Object code emitted` | yes | no |
| abort signature | absent | present |
| file result | **14 passed** | **13 passed, 1 failed** |

```
FAILED ...::jac nacompile itself registers a parser for its target (#8788)
E   AssertionError: jac nacompile aborted assembling the outline-atomics `module asm`
    for an aarch64 target: the executable compile path registered no asm parser for
    the target it was emitting.
```

The self-initializing object-emission test from #8788 is kept as it is: checking
that every helper assembles and reaches the symbol table on any host is worth
having on its own. This is an addition, not a replacement.

No release-note fragment: the only changed file is under `jac/tests/`, which
`scripts/check-release-notes.sh` excludes from the package-change scan.
