### PR TITLE
fix(release): the release builds the commit that was approved, or it refuses (#8793)

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -16,6 +16,18 @@ on:
         description: "Release tag to upload assets to: canonical v<version>, or `dev` for the rolling prerelease."
         required: true
         type: string
+      commit:
+        # A tag is a mutable ref, and checking one out is how a release ends up
+        # building a tree nobody approved: re-cutting a version whose tag
+        # already existed rebuilt whatever that tag still pointed at, five days
+        # stale (#8793). The release resolves the commit under review and names
+        # it here, so the artifact is pinned to an immutable object while `tag`
+        # stays what it always was -- the upload target. Empty (the release
+        # event, workflow_dispatch) keeps the tag checkout.
+        description: "Immutable commit SHA to build. Empty = check out `tag`."
+        required: false
+        default: ""
+        type: string
       channel:
         description: "release: cold + glibc-pinned; dev: cached + host-native."
         required: false
@@ -148,14 +160,32 @@ jobs:
       # (host-native) on the dev channel and macOS.
       DTARGET: ${{ inputs.channel != 'dev' && matrix.zig_target && format('-Dtarget={0}', matrix.zig_target) || '' }}
     steps:
-      # Check out the release tag (release channel) or the pushed commit (dev
+      # Check out the commit the release resolved (release channel, when the
+      # caller names one), else the release tag, else the pushed commit (dev
       # channel), so a recovery run after main advanced still builds the
       # release's own source. SHA-pinned: this job holds contents:write and
       # ships user-downloaded binaries, so a re-pointed tag on the action must
       # not reach it.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.channel == 'dev' && github.sha || inputs.tag || github.event.release.tag_name }}
+          ref: ${{ inputs.channel == 'dev' && github.sha || inputs.commit || inputs.tag || github.event.release.tag_name }}
+
+      # The provenance line the v0.37.0 post-mortem had to reconstruct from a
+      # cache key. It is also the assertion: if the checkout ever resolves
+      # something other than the commit the release named, this leg stops
+      # instead of shipping it.
+      - name: Record the commit being built
+        shell: bash
+        env:
+          WANT: ${{ inputs.commit }}
+        run: |
+          set -euo pipefail
+          HEAD_SHA="$(git rev-parse HEAD)"
+          echo "Building ${HEAD_SHA}"
+          if [ -n "$WANT" ] && [ "$HEAD_SHA" != "$WANT" ]; then
+            echo "::error::checkout resolved ${HEAD_SHA}, but this release is cutting ${WANT}"
+            exit 1
+          fi
 
       # Dev channel only: reuse the read-mostly caches main seeds. The release
       # channel builds cold on purpose (a cached payload could ship stale
@@ -549,7 +579,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.channel == 'dev' && github.sha || inputs.tag || github.event.release.tag_name }}
+          ref: ${{ inputs.channel == 'dev' && github.sha || inputs.commit || inputs.tag || github.event.release.tag_name }}
 
       - name: Read version (from jac.toml)
         id: ver
@@ -625,7 +655,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.channel == 'dev' && github.sha || inputs.tag || github.event.release.tag_name }}
+          ref: ${{ inputs.channel == 'dev' && github.sha || inputs.commit || inputs.tag || github.event.release.tag_name }}
 
       - name: Read version (from jac.toml)
         id: ver

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,10 +117,43 @@ jobs:
     outputs:
       version: ${{ steps.ver.outputs.version }}
       summary: ${{ steps.ver.outputs.summary }}
+      sha: ${{ steps.commit.outputs.sha }}
     steps:
+      # Every later job anchors on this sha, so it has to be the commit that
+      # was actually approved -- and on the PR path the obvious answer is the
+      # wrong one. GITHUB_SHA there is the base branch resolved when the RUN
+      # was created, not the commit this PR produced: any merge landing in
+      # between silently retargets the release onto someone else's work. The
+      # pull_request payload's merge_commit_sha is this PR's own landed commit
+      # (the merge, squash or rebase commit on main, since we only run on
+      # merged == true), and it cannot drift. On workflow_dispatch there is no
+      # PR and GITHUB_SHA is the dispatched ref's commit, which is exactly the
+      # tree being released.
+      - name: Resolve the commit being released
+        id: commit
+        env:
+          EVENT: ${{ github.event_name }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "pull_request" ]; then
+            SHA="$MERGE_COMMIT_SHA"
+          else
+            SHA="$GITHUB_SHA"
+          fi
+          if ! printf '%s' "$SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::Could not resolve the commit being released (event=${EVENT}, got '${SHA}'); refusing to tag or build an unidentified tree."
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Releasing commit: $SHA"
+
+      # Pinned to the resolved commit, not to whatever the trigger's ref points
+      # at now: the version below has to be the one that commit declares.
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ steps.commit.outputs.sha }}
           persist-credentials: false
 
       # The root jac.toml is the source of truth for the jaclang version.
@@ -175,6 +208,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          ref: ${{ needs.resolve.outputs.sha }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -184,11 +218,14 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       # Never move an existing tag: a published release's assets and notes
-      # describe the commit it was cut from.
+      # describe the commit it was cut from. So a version whose tag already
+      # names another commit is refused outright rather than quietly released
+      # from the old one (#8793). See scripts/release_tag_guard.sh.
       - name: Create and push tag
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
-        run: bash scripts/release_tag_guard.sh "$VERSION" "$GITHUB_SHA"
+          COMMIT: ${{ needs.resolve.outputs.sha }}
+        run: bash scripts/release_tag_guard.sh "$VERSION" "$COMMIT"
 
       # Draft: hidden from /releases/latest with no downloadable assets, so
       # install.sh can't resolve it until `publish` reveals it complete. NOT
@@ -234,6 +271,10 @@ jobs:
     uses: ./.github/workflows/build-binaries.yml
     with:
       tag: v${{ needs.resolve.outputs.version }}
+      # The tag is only the upload target. What gets BUILT is named by sha, so
+      # the artifacts provably correspond to the approved commit even if the
+      # tag is ever repointed or predates this release (#8793).
+      commit: ${{ needs.resolve.outputs.sha }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,16 +188,7 @@ jobs:
       - name: Create and push tag
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
-        run: |
-          set -euo pipefail
-          VTAG="v${VERSION}"
-          if git ls-remote --exit-code --tags origin "refs/tags/${VTAG}" >/dev/null 2>&1; then
-            echo "Tag ${VTAG} already exists; leaving it in place."
-          else
-            echo "Tagging ${VTAG} at ${GITHUB_SHA}"
-            git tag --annotate --message="jac ${VERSION}" "$VTAG" "$GITHUB_SHA"
-            git push origin "refs/tags/${VTAG}"
-          fi
+        run: bash scripts/release_tag_guard.sh "$VERSION" "$GITHUB_SHA"
 
       # Draft: hidden from /releases/latest with no downloadable assets, so
       # install.sh can't resolve it until `publish` reveals it complete. NOT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,10 +260,12 @@ After the release PR is merged, the **Release** workflow triggers automatically:
    - Go to **GitHub Actions** -> find the running **Release** workflow
    - Click the paused job, then **Review deployments**, select `release-approval`, and **Approve and deploy**
 2. The workflow then handles everything automatically:
-   - Tags `v<version>` at the merge commit and creates/updates the GitHub Release
+   - Tags `v<version>` at the release PR's merge commit, and builds that exact commit (the build is pinned to the sha, not to the tag), then creates/updates the GitHub Release
    - Builds the native `jac` binary per platform (Linux x86_64 + aarch64 at a pinned glibc 2.17 floor, macOS arm64), smoke-tests each on real hardware, verifies the Linux glibc floors, and attaches the binaries + checksums to the Release
 
-Every step is idempotent: re-running a partial release converges instead of erroring (existing tags are left in place, the release is updated in place, and asset uploads clobber).
+Every step is idempotent: re-running a partial release converges instead of erroring (a tag already on the release commit is left in place, the release is updated in place, and asset uploads clobber).
+
+A tag that points at a *different* commit is a refusal, not a re-run. The tag is never moved (a published release's assets and notes describe the commit it was cut from), and the release stops rather than quietly rebuilding the old tree. See the troubleshooting table below for the two ways out.
 
 ### Troubleshooting
 
@@ -274,3 +276,4 @@ Every step is idempotent: re-running a partial release converges instead of erro
 | Publish workflow didn't trigger | Ensure the PR branch started with `release/` |
 | Binaries missing from the release | Re-run **Build jac native binaries** via `workflow_dispatch` with the release tag (e.g. `v0.30.4`); it rebuilds and re-attaches idempotently. An empty tag builds artifacts only (a dry run that attaches nothing) |
 | Need to re-run after the release PR is merged | Manually trigger **Release** with `action: publish`; the version is re-read from the root `jac.toml` |
+| `Refusing to release vX.Y.Z: the tag already exists and points at a different commit` | The version was cut once already, from a commit that is not the one you are releasing now (a reverted release, say). Either bump the version and release that instead, or, **only if `vX.Y.Z` was never published** (its Release is still a draft with no assets), retire the stale tag and draft with `gh release delete vX.Y.Z --cleanup-tag --yes` and re-run. Never move a tag whose release was published: its assets and notes describe the old commit, and users who installed it keep that build |

--- a/jac/tests/release/test_release_tag_guard.jac
+++ b/jac/tests/release/test_release_tag_guard.jac
@@ -120,8 +120,9 @@ test "no existing tag: the guard creates it at the release commit" {
     fx = scaffold();
     try {
         res = run_guard(fx, fx["new"]);
-        assert res.returncode == 0 , "tagging a fresh version must succeed: " + res.stdout
-        + res.stderr;
+        assert res.returncode == 0 , "tagging a fresh version must succeed: "
+            + res.stdout
+            + res.stderr;
         assert remote_tag_commit(fx) == fx["new"] , "the pushed tag must resolve to the commit being released";
     } finally {
         shutil.rmtree(fx["base"], ignore_errors=True);
@@ -133,8 +134,9 @@ test "existing tag on the release commit: the re-run is idempotent" {
     try {
         tag_at(fx, fx["new"]);
         res = run_guard(fx, fx["new"]);
-        assert res.returncode == 0 , "a recovery re-run of the same commit must proceed: " + res.stdout
-        + res.stderr;
+        assert res.returncode == 0 , "a recovery re-run of the same commit must proceed: "
+            + res.stdout
+            + res.stderr;
         assert remote_tag_commit(fx) == fx["new"] , "the tag must still resolve to the release commit";
     } finally {
         shutil.rmtree(fx["base"], ignore_errors=True);
@@ -147,9 +149,12 @@ test "existing annotated tag on another commit: refuse, naming both commits" {
         tag_at(fx, fx["old"]);
         res = run_guard(fx, fx["new"]);
         out = res.stdout + res.stderr;
-        assert res.returncode != 0 , "a tag pointing at a different commit must fail the release instead of building the old tree; got: " + out;
-        assert (fx["old"] in out) , "the refusal must name the commit the tag already points at: " + out;
-        assert (fx["new"] in out) , "the refusal must name the commit being released: " + out;
+        assert res.returncode != 0 , "a tag pointing at a different commit must fail the release instead of building the old tree; got: "
+            + out;
+        assert (fx["old"] in out) , "the refusal must name the commit the tag already points at: "
+            + out;
+        assert (fx["new"] in out) , "the refusal must name the commit being released: "
+            + out;
         assert remote_tag_commit(fx) == fx["old"] , "a refusal must leave the existing tag exactly where it was";
     } finally {
         shutil.rmtree(fx["base"], ignore_errors=True);
@@ -163,7 +168,8 @@ test "existing lightweight tag on another commit: refuse as well" {
         res = run_guard(fx, fx["new"]);
         out = res.stdout + res.stderr;
         assert res.returncode != 0 , "an unannotated stale tag must refuse too: " + out;
-        assert (fx["old"] in out) , "the refusal must name the commit the tag already points at: " + out;
+        assert (fx["old"] in out) , "the refusal must name the commit the tag already points at: "
+            + out;
         assert remote_tag_commit(fx) == fx["old"] , "a refusal must leave the existing tag exactly where it was";
     } finally {
         shutil.rmtree(fx["base"], ignore_errors=True);

--- a/jac/tests/release/test_release_tag_guard.jac
+++ b/jac/tests/release/test_release_tag_guard.jac
@@ -1,0 +1,182 @@
+"""Tests for scripts/release_tag_guard.sh, the release pipeline's tag gate.
+
+The v0.37.0 re-run built a five-day-old tree because the gate treated "the tag
+already exists" as success without ever resolving what that tag pointed at.
+These pin the three outcomes it has to tell apart: no tag creates one, a tag on
+the same commit is an idempotent re-run, and a tag on a different commit is a
+refusal that names both commits and leaves the tag where it is.
+"""
+
+import os;
+import shutil;
+import subprocess;
+import tempfile;
+import from pathlib { Path }
+
+glob REPO_ROOT: Path = Path(__file__).resolve().parents[3],
+     GUARD: str = str(REPO_ROOT / "scripts" / "release_tag_guard.sh"),
+     VERSION: str = "0.37.0",
+     VTAG: str = "v0.37.0";
+
+"""A git environment isolated from the developer's own config and identity."""
+def git_env(home: str) -> dict[(str, str)] {
+    env = dict(os.environ);
+    env["HOME"] = home;
+    env["GIT_CONFIG_GLOBAL"] = os.path.join(home, "gitconfig-absent");
+    env["GIT_CONFIG_SYSTEM"] = os.path.join(home, "gitconfig-absent");
+    env["GIT_AUTHOR_NAME"] = "release test";
+    env["GIT_AUTHOR_EMAIL"] = "release-test@example.invalid";
+    env["GIT_COMMITTER_NAME"] = "release test";
+    env["GIT_COMMITTER_EMAIL"] = "release-test@example.invalid";
+    return env;
+}
+
+def git(args: list[str], cwd: str, home: str) -> any {
+    return subprocess.run(
+        ["git"] + args,
+        cwd=cwd,
+        env=git_env(home),
+        capture_output=True,
+        text=True,
+        check=True
+    );
+}
+
+"""A bare remote plus a work clone carrying two commits on main."""
+def scaffold -> dict[(str, str)] {
+    base = tempfile.mkdtemp(prefix="jac-release-tag-guard-");
+    remote = os.path.join(base, "remote.git");
+    work = os.path.join(base, "work");
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "-b", "main", remote],
+        check=True,
+        env=git_env(base)
+    );
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", work], check=True, env=git_env(base)
+    );
+    (Path(work) / "a.txt").write_text("first\n");
+    git(["add", "-A"], work, base);
+    git(["commit", "-qm", "first"], work, base);
+    old = git(["rev-parse", "HEAD"], work, base).stdout.strip();
+    (Path(work) / "a.txt").write_text("second\n");
+    git(["commit", "-qam", "second"], work, base);
+    new = git(["rev-parse", "HEAD"], work, base).stdout.strip();
+    git(["remote", "add", "origin", remote], work, base);
+    git(["push", "-q", "origin", "main"], work, base);
+    return {"base": base, "remote": remote, "work": work, "old": old, "new": new};
+}
+
+def run_guard(fx: dict[(str, str)], commit: str) -> any {
+    return subprocess.run(
+        ["bash", GUARD, VERSION, commit, "origin"],
+        cwd=fx["work"],
+        env=git_env(fx["base"]),
+        capture_output=True,
+        text=True
+    );
+}
+
+"""What the remote tag resolves to, peeling an annotated tag; "" when absent."""
+def remote_tag_commit(fx: dict[(str, str)]) -> str {
+    out = git(
+        [
+            "ls-remote",
+            "--tags",
+            "origin",
+            "refs/tags/" + VTAG,
+            "refs/tags/" + VTAG + "^{}"
+        ],
+        fx["work"],
+        fx["base"]
+    ).stdout;
+    plain = "";
+    peeled = "";
+    for line in out.splitlines() {
+        parts = line.split("\t");
+        if (len(parts) != 2) {
+            continue;
+        }
+        if parts[1].strip().endswith("^{}") {
+            peeled = parts[0].strip();
+        } elif (parts[1].strip() == "refs/tags/" + VTAG) {
+            plain = parts[0].strip();
+        }
+    }
+    return peeled or plain;
+}
+
+def tag_at(fx: dict[(str, str)], commit: str, annotated: bool = True) {
+    args = ["tag"];
+    if annotated {
+        args += ["-a", "-m", "jac " + VERSION];
+    }
+    args += [VTAG, commit];
+    git(args, fx["work"], fx["base"]);
+    git(["push", "-q", "origin", "refs/tags/" + VTAG], fx["work"], fx["base"]);
+}
+
+test "no existing tag: the guard creates it at the release commit" {
+    fx = scaffold();
+    try {
+        res = run_guard(fx, fx["new"]);
+        assert res.returncode == 0 , "tagging a fresh version must succeed: " + res.stdout
+        + res.stderr;
+        assert remote_tag_commit(fx) == fx["new"] , "the pushed tag must resolve to the commit being released";
+    } finally {
+        shutil.rmtree(fx["base"], ignore_errors=True);
+    }
+}
+
+test "existing tag on the release commit: the re-run is idempotent" {
+    fx = scaffold();
+    try {
+        tag_at(fx, fx["new"]);
+        res = run_guard(fx, fx["new"]);
+        assert res.returncode == 0 , "a recovery re-run of the same commit must proceed: " + res.stdout
+        + res.stderr;
+        assert remote_tag_commit(fx) == fx["new"] , "the tag must still resolve to the release commit";
+    } finally {
+        shutil.rmtree(fx["base"], ignore_errors=True);
+    }
+}
+
+test "existing annotated tag on another commit: refuse, naming both commits" {
+    fx = scaffold();
+    try {
+        tag_at(fx, fx["old"]);
+        res = run_guard(fx, fx["new"]);
+        out = res.stdout + res.stderr;
+        assert res.returncode != 0 , "a tag pointing at a different commit must fail the release instead of building the old tree; got: " + out;
+        assert (fx["old"] in out) , "the refusal must name the commit the tag already points at: " + out;
+        assert (fx["new"] in out) , "the refusal must name the commit being released: " + out;
+        assert remote_tag_commit(fx) == fx["old"] , "a refusal must leave the existing tag exactly where it was";
+    } finally {
+        shutil.rmtree(fx["base"], ignore_errors=True);
+    }
+}
+
+test "existing lightweight tag on another commit: refuse as well" {
+    fx = scaffold();
+    try {
+        tag_at(fx, fx["old"], annotated=False);
+        res = run_guard(fx, fx["new"]);
+        out = res.stdout + res.stderr;
+        assert res.returncode != 0 , "an unannotated stale tag must refuse too: " + out;
+        assert (fx["old"] in out) , "the refusal must name the commit the tag already points at: " + out;
+        assert remote_tag_commit(fx) == fx["old"] , "a refusal must leave the existing tag exactly where it was";
+    } finally {
+        shutil.rmtree(fx["base"], ignore_errors=True);
+    }
+}
+
+test "an unresolved release commit is refused before anything is tagged" {
+    fx = scaffold();
+    try {
+        res = run_guard(fx, "");
+        assert res.returncode != 0 , "an empty release commit must fail loudly";
+        assert remote_tag_commit(fx) == "" , "nothing may be tagged when the release commit is unknown";
+    } finally {
+        shutil.rmtree(fx["base"], ignore_errors=True);
+    }
+}

--- a/scripts/release_tag_guard.sh
+++ b/scripts/release_tag_guard.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Create the release tag for a version, or keep an existing one.
+#
+# Extracted verbatim from release.yml's tag-and-release "Create and push tag"
+# step so the decision has somewhere to be tested.
+#
+# Usage: release_tag_guard.sh <version> <commit-sha> [remote]
+
+set -euo pipefail
+
+VERSION="${1:-}"
+COMMIT="${2:-}"
+REMOTE="${3:-origin}"
+VTAG="v${VERSION}"
+
+if git ls-remote --exit-code --tags "$REMOTE" "refs/tags/${VTAG}" >/dev/null 2>&1; then
+    echo "Tag ${VTAG} already exists; leaving it in place."
+else
+    echo "Tagging ${VTAG} at ${COMMIT}"
+    git tag --annotate --message="jac ${VERSION}" "$VTAG" "$COMMIT"
+    git push "$REMOTE" "refs/tags/${VTAG}"
+fi

--- a/scripts/release_tag_guard.sh
+++ b/scripts/release_tag_guard.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
-# Create the release tag for a version, or keep an existing one.
-#
-# Extracted verbatim from release.yml's tag-and-release "Create and push tag"
-# step so the decision has somewhere to be tested.
+# The release tag names one commit, and it never comes to name another.
 #
 # Usage: release_tag_guard.sh <version> <commit-sha> [remote]
+#
+#   no tag yet          -> create the annotated tag at <commit-sha> and push it
+#   tag on <commit-sha> -> nothing to do; a recovery re-run converges
+#   tag on some other   -> refuse, naming both commits
+#
+# The refusal is the whole point. Before it existed, "the tag already exists"
+# was reported as success, and the build that followed checked out the tag --
+# so re-cutting a version rebuilt whatever that tag still pointed at. The
+# v0.37.0 re-run shipped a five-day-old tree that way and failed on a bug the
+# approved commit had already fixed (#8793). A build that succeeded would have
+# published binaries that did not correspond to the commit under review.
+#
+# Peeling matters: release tags are annotated, so `git ls-remote`'s first
+# column is the tag OBJECT, not the commit. Comparing that against a commit
+# never matches. The `^{}` entry is the commit, and asking for it explicitly
+# is what makes the comparison mean anything.
 
 set -euo pipefail
 
@@ -13,10 +26,85 @@ COMMIT="${2:-}"
 REMOTE="${3:-origin}"
 VTAG="v${VERSION}"
 
-if git ls-remote --exit-code --tags "$REMOTE" "refs/tags/${VTAG}" >/dev/null 2>&1; then
-    echo "Tag ${VTAG} already exists; leaving it in place."
-else
-    echo "Tagging ${VTAG} at ${COMMIT}"
-    git tag --annotate --message="jac ${VERSION}" "$VTAG" "$COMMIT"
-    git push "$REMOTE" "refs/tags/${VTAG}"
+fail() {
+    echo "::error::$1"
+    shift
+    [ "$#" -eq 0 ] || printf '%s\n' "$@"
+    exit 1
+}
+
+[ -n "$VERSION" ] || fail "release_tag_guard.sh: no version given."
+
+# A short or empty sha means the caller could not name the commit being
+# released (an unresolved merge_commit_sha, say). Tagging something anyway is
+# how a release ends up describing a tree nobody approved.
+if [[ ! "$COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+    fail "release_tag_guard.sh: '${COMMIT}' is not a full commit sha, so there is no commit to release." \
+        "The caller must pass the 40-character sha of the commit being released." \
+        "Nothing was tagged."
 fi
+
+if ! listing="$(git ls-remote --tags "$REMOTE" \
+    "refs/tags/${VTAG}" "refs/tags/${VTAG}^{}" 2>&1)"; then
+    fail "Could not query ${REMOTE} for ${VTAG}: ${listing}"
+fi
+
+plain=""
+peeled=""
+while IFS=$'\t' read -r sha ref; do
+    case "$ref" in
+        "refs/tags/${VTAG}^{}") peeled="$sha" ;;
+        "refs/tags/${VTAG}") plain="$sha" ;;
+    esac
+done <<<"$listing"
+
+# Annotated tags carry both entries; the peel is the commit. A lightweight tag
+# has only the plain entry, which already is the commit.
+existing="${peeled:-$plain}"
+
+if [ -z "$existing" ]; then
+    if ! git rev-parse --verify --quiet "${COMMIT}^{commit}" >/dev/null; then
+        git fetch --no-tags --quiet "$REMOTE" "$COMMIT" 2>/dev/null || true
+    fi
+    if ! git rev-parse --verify --quiet "${COMMIT}^{commit}" >/dev/null; then
+        fail "The commit being released (${COMMIT}) is not in this checkout and could not be fetched from ${REMOTE}." \
+            "Nothing was tagged."
+    fi
+    echo "Tagging ${VTAG} at ${COMMIT}"
+    # --force only ever retargets a LOCAL tag, and only on the branch where the
+    # remote has none: a stale tag left by an earlier fetch must not make the
+    # release die on "tag already exists". The push below is not forced, so
+    # nothing published can move.
+    git tag --annotate --force --message="jac ${VERSION}" "$VTAG" "$COMMIT"
+    git push "$REMOTE" "refs/tags/${VTAG}"
+    echo "Tagged ${VTAG} at ${COMMIT} and pushed it to ${REMOTE}."
+    exit 0
+fi
+
+if [ "$existing" = "$COMMIT" ]; then
+    echo "Tag ${VTAG} already points at ${COMMIT}; leaving it in place."
+    exit 0
+fi
+
+# Never move an existing tag: a published release's assets and notes describe
+# the commit it was cut from, and install.sh hands users exactly those assets.
+# So the tag stays, and the release stops here.
+fail "Refusing to release ${VTAG}: the tag already exists and points at a different commit." \
+    "" \
+    "  tag ${VTAG} resolves to: ${existing}" \
+    "  this release is cutting: ${COMMIT}" \
+    "" \
+    "The tag has NOT been moved. Building it anyway would ship a tree nobody" \
+    "approved under a version that claims otherwise." \
+    "" \
+    "Two ways forward:" \
+    "" \
+    "  1. Bump the version and release that instead. This is the answer" \
+    "     whenever ${VTAG} was ever published: its assets and notes describe" \
+    "     ${existing}, and users who already installed it keep that build." \
+    "" \
+    "  2. If ${VTAG} was never published (its GitHub Release is still a draft," \
+    "     with no assets attached), retire the stale tag and its draft, then" \
+    "     re-run this release:" \
+    "" \
+    "       gh release delete ${VTAG} --cleanup-tag --yes"


### PR DESCRIPTION
Closes #8793

The v0.37.0 re-run built a tree from 2026-08-26 and failed on #8729, a bug fixed five days earlier. `7913c7def` contained #8780, #8781, #8786 and #8788 with `behind_by=0`. Every fix was there. None of them were built.

```
tag v0.37.0 -> de803dae (annotated) -> 4c1659296   <- what got built
PR #8792 merge_commit_sha           -> 0b39a3c14   <- what was approved
```

`tag-and-release` logged `Tag v0.37.0 already exists; leaving it in place.` and succeeded. `build-binaries` logged `git checkout --progress --force refs/tags/v0.37.0`. The build printed `SHIM_KEY: a6301f84...`, byte-identical to the 2026-08-26 run, and that key hashes `jac/native/**` + `jac/build.zig` + `jac/bootstrap/pins.json`, both of which those fixes changed. An unchanged key is an unchanged tree.

The failure was loud only by luck. A stale tree that happened to build would have published binaries that do not correspond to the commit under review, under a tag claiming they do, and flipped it to latest.

## The failing test, first

The tag decision lived in an inline heredoc where nothing could reach it. The first commit extracts it verbatim to `scripts/release_tag_guard.sh` and pins its three outcomes in `jac/tests/release/test_release_tag_guard.jac`, driving the real script against a real bare remote with real annotated tags. Two of five went red on the extracted-as-is logic:

```
FAILED existing annotated tag on another commit: refuse, naming both commits
FAILED existing lightweight tag on another commit: refuse as well
E   AssertionError: a tag pointing at a different commit must fail the release
    instead of building the old tree; got: Tag v0.37.0 already exists; leaving
    it in place.
========================= 2 failed, 3 passed in 1.06s ==========================
```

The message in that assertion is the production one, verbatim. The second commit makes all five pass.

## A: the mismatch is a refusal, not a silent pass

`scripts/release_tag_guard.sh` resolves what an existing tag actually points at and compares it with the commit being released.

Peeling is the part that bit us. Release tags are annotated, so `git ls-remote --tags origin refs/tags/v0.37.0` returns the tag OBJECT (`de803dae`), and a naive comparison against a commit would never match, on every run, forever. The commit is the `^{}` entry, and it only appears if you ask for it:

```
$ git ls-remote --tags origin "refs/tags/v0.37.0"
10327ed1...	refs/tags/v0.37.0
$ git ls-remote --tags origin "refs/tags/v0.37.0" "refs/tags/v0.37.0^{}"
10327ed1...	refs/tags/v0.37.0
7ed29692...	refs/tags/v0.37.0^{}
```

Same commit proceeds, which keeps recovery re-runs idempotent and is the case that matters most in practice. A different commit refuses, naming both shas and both remedies (bump the version, or `gh release delete <tag> --cleanup-tag --yes` if the draft was never published). The existing invariant is untouched: an existing tag is never moved, because a published release's assets and notes describe the commit it was cut from. This converts a silent mismatch into a refusal; it adds no tag rewriting. A lightweight tag is handled too, and a release commit that is not a full 40-char sha is refused before anything is tagged.

## B: the build is pinned to a commit, not a ref

A refusal alone would have caught this instance. It would not have removed the indirection that let a mutable ref stand in for the approved tree, and `build-binaries.yml` would still resolve `refs/tags/v0.37.0` at checkout time no matter what the release meant. So both halves, and I would not ship A alone.

`build-binaries.yml` gains an optional `commit` input, and the three checkouts become:

```yaml
ref: ${{ inputs.channel == 'dev' && github.sha || inputs.commit || inputs.tag || github.event.release.tag_name }}
```

`release.yml` passes the resolved sha; `tag` stays exactly what it was, the upload target. The input is optional and declared on `workflow_call` only, so the `release: published` path (where `inputs` is empty) and `workflow_dispatch` (where `commit` is absent, hence null, hence falsy) both fall through to `inputs.tag`/`tag_name` unchanged, and the dev channel still short-circuits to `github.sha` before the new term is reached. `release-dev.yml` passes no `commit` and is unaffected.

Each build leg now logs the commit it built and fails if the checkout resolved anything other than what the release named. That is the provenance line the post-mortem had to reconstruct from a cache key.

## Which sha, per trigger

`resolve` now outputs the commit identity, which nothing in the pipeline had before, and picks it per trigger:

- **`pull_request`** (merged, head `release/*`): `github.event.pull_request.merge_commit_sha`. This is the commit the PR produced on main (the merge, squash or rebase commit; the job already gates on `merged == true`, so it is the landed one, not a test merge). `head.sha` is wrong because a squash or rebase merge means that commit never exists on main.
- **`workflow_dispatch`**: `github.sha`, the dispatched ref's own commit. There is no PR, and this is exactly the tree being released.

### The existing `$GITHUB_SHA` is already wrong, independently

Worth stating precisely, because the answer is not the one the general documentation implies. On a **merged** `pull_request` run, GitHub does not hand you the ephemeral `refs/pull/N/merge` commit. It resolves the base branch: the 2026-08-26 run's checkout logged `git checkout --progress --force -B main refs/remotes/origin/main`, and the tag step logged `Tagging v0.37.0 at 4c1659296...`, which is the squash commit on main and equals #8721's `merge_commit_sha`. So the tag has been landing on real, permanent commits.

It is still wrong. `$GITHUB_SHA` there names *whatever main's tip was when the run was created*, not *the commit this release PR produced*. Any merge landing between the release PR's merge and the release run's creation silently moves the tag onto unrelated work, and `resolve` would then read that other commit's `jac.toml`. Incidentally right, structurally wrong, and a race nobody would see until it fired. `merge_commit_sha` cannot drift.

`resolve` also checks out the resolved sha instead of the trigger's ref, so the version comes from the commit being released rather than from wherever the ref points now, and it refuses outright if the sha does not resolve to 40 hex characters rather than tagging an unidentified tree.

## Testing

```
jac test jac/tests/release/test_release_tag_guard.jac
5 passed
```

Five cases against a real bare remote and a real clone: no tag creates an annotated tag at the release commit; a tag on the release commit is an idempotent re-run; an annotated tag on another commit refuses, names both shas, and leaves the tag where it was; a lightweight tag on another commit refuses too; an unresolvable release commit refuses before anything is tagged. No test asserts that YAML contains a string.

Picked up automatically by ci.yml's `test-runtime` lane (`jac test tests/`).

## Docs

`CONTRIBUTING.md` asserted "existing tags are left in place" as the release's idempotency contract. That sentence is now false in the case that matters, so it moves with the behavior, and the troubleshooting table gains the refusal message and its two remedies.

## Out of scope

The `v0.37.0` tag and its release are untouched. Whether to bump to 0.37.1 or retire the stale tag is an operational call.

## Release note

None. `.github/workflows/**`, `scripts/**` and `jac/tests/**` are outside the `jac/jaclang/` -> fragment mapping, and `scripts/check-release-notes.sh` exits 0 on this diff; the change is CI-only with nothing to tell a user at release time.
