### PR TITLE
fix(cli): jac --version resolves the manifest by walk-up, so dev mode reports the tree it runs

### DIFF
--- a/jac/jaclang/cli/impl/manifest_route.impl.jac
+++ b/jac/jaclang/cli/impl/manifest_route.impl.jac
@@ -14,26 +14,33 @@ def _read_version_from_toml(toml_path: Path) -> (str | None) {
     return None;
 }
 
+# jac.toml resolves to the nearest ancestor (walk-up, nearest wins), so the
+# version must too: dev_source points at the dir containing jaclang/, while
+# the manifest usually lives at the repo root above it.
+def _nearest_toml_version(start: Path) -> (str | None) {
+    for candidate in [start] + list(start.parents) {
+        toml_path = candidate / 'jac.toml';
+        if toml_path.exists() {
+            return _read_version_from_toml(toml_path);
+        }
+    }
+    return None;
+}
+
 impl resolve_cli_version -> str {
     dev_source = os.environ.get('JAC_DEV_SOURCE');
     if dev_source {
-        toml_path = Path(dev_source) / 'jac.toml';
-        if toml_path.exists() {
-            ver = _read_version_from_toml(toml_path);
-            if ver {
-                return ver;
-            }
+        ver = _nearest_toml_version(Path(dev_source).resolve());
+        if ver {
+            return ver;
         }
     }
 
     jac_file = jaclang.__file__;
     if jac_file {
-        source_toml = Path(jac_file).parent.parent / 'jac.toml';
-        if source_toml.exists() {
-            ver = _read_version_from_toml(source_toml);
-            if ver {
-                return ver;
-            }
+        ver = _nearest_toml_version(Path(jac_file).resolve().parent.parent);
+        if ver {
+            return ver;
         }
     }
 

--- a/jac/tests/cli/test_version_resolution.jac
+++ b/jac/tests/cli/test_version_resolution.jac
@@ -1,0 +1,72 @@
+"""Version-resolution tests for `jac --version` (#8804).
+
+`resolve_cli_version` must honor the manifest walk-up contract documented in
+jac.toml: the nearest ANCESTOR jac.toml wins, no merging. The dev-mode probes
+start from the directory containing jaclang/ (JAC_DEV_SOURCE, or derived from
+jaclang.__file__), while the manifest usually lives at the repo root above it,
+so a probe that only checks the starting directory silently falls through to
+the launcher binary's baked-in dist metadata and misreports the version.
+"""
+
+import os;
+import tempfile;
+import from pathlib { Path }
+import from jaclang.cli.manifest_route { _nearest_toml_version, resolve_cli_version }
+
+
+def _make_tree(base: Path, rel: str, toml_at: str, version: (str | None)) -> Path {
+    start = base / rel;
+    start.mkdir(parents=True, exist_ok=True);
+    body = f'[project]\nname = "x"\nversion = "{version}"\n' if version else '[project]\nname = "x"\n';
+    (base / toml_at / 'jac.toml').write_text(body, encoding='utf-8');
+    return start;
+}
+
+
+test "version is read from a jac.toml in the starting directory" {
+    with tempfile.TemporaryDirectory() as td {
+        start = _make_tree(Path(td), 'jac', 'jac', '1.2.3');
+        assert _nearest_toml_version(start) == '1.2.3';
+    }
+}
+
+test "version walks up to the nearest ancestor jac.toml" {
+    with tempfile.TemporaryDirectory() as td {
+        start = _make_tree(Path(td), 'repo/jac', 'repo', '4.5.6');
+        assert _nearest_toml_version(start) == '4.5.6';
+    }
+}
+
+test "nearest jac.toml wins even without a version (no merging)" {
+    with tempfile.TemporaryDirectory() as td {
+        base = Path(td);
+        start = _make_tree(base, 'repo/jac', 'repo', '7.8.9');
+        (base / 'repo' / 'jac' / 'jac.toml').write_text('[dev]\n', encoding='utf-8');
+        assert _nearest_toml_version(start) is None;
+    }
+}
+
+test "no jac.toml on the walk-up path yields None" {
+    with tempfile.TemporaryDirectory() as td {
+        deep = Path(td) / 'a' / 'b';
+        deep.mkdir(parents=True);
+        assert _nearest_toml_version(deep) is None;
+    }
+}
+
+test "resolve_cli_version honors JAC_DEV_SOURCE pointing below the manifest" {
+    with tempfile.TemporaryDirectory() as td {
+        start = _make_tree(Path(td), 'repo/jac', 'repo', '9.9.9');
+        saved = os.environ.get('JAC_DEV_SOURCE');
+        os.environ['JAC_DEV_SOURCE'] = str(start);
+        try {
+            assert resolve_cli_version() == '9.9.9';
+        } finally {
+            if saved is None {
+                del os.environ['JAC_DEV_SOURCE'];
+            } else {
+                os.environ['JAC_DEV_SOURCE'] = saved;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #8804.

## Problem

In dev mode (`[dev] jaclang_source` set), `jac --version` reports the version baked into the installed launcher binary instead of the version of the source tree it actually runs. On a 0.37.1 checkout with a launcher built at 0.36.0:

```
$ jac --version
🛠  jac dev mode — using compiler source at /home/kuggix/jac/jac
jac 0.36.0  (Linux x86_64)
```

`resolve_cli_version()` probes `$JAC_DEV_SOURCE/jac.toml` and then `Path(jaclang.__file__).parent.parent / 'jac.toml'`. Since `jaclang_source = "jac"` points at the directory *containing* `jaclang/`, both probes resolve to `<repo>/jac/jac.toml`, which does not exist: the manifest lives one level up at the repo root. Both miss, and the resolver falls through to `pkg_version('jaclang')`, the dist metadata bundled inside the launcher from its last `zig build`. The stale version string appears nowhere in the tree, which makes the mismatch confusing to diagnose, and rebuilding only hides it until the next version bump.

## Fix

Replace the single-directory checks with a walk-up to the nearest ancestor `jac.toml`, matching the config resolution contract documented at the top of `jac.toml` (nearest ancestor wins, no merging). Nearest-wins is honored strictly: a nearer manifest without a `[project].version` does not fall through to a farther ancestor; the probe just yields nothing and resolution moves to the next probe. The `pkg_version('jaclang')` fallback is unchanged and still serves the non-dev binary path.

Both dev probes (`JAC_DEV_SOURCE` and the `jaclang.__file__` fallback) share the new helper since they start from the same place.

## Validation

Live, on this checkout:

- `jac --version` in dev mode now prints `jac 0.37.1` (the tree), banner unchanged.
- `JAC_NO_DEV_SOURCE=1 jac --version` outside the repo still prints the binary's own `0.36.0`, so the non-dev fallback is untouched.

New tests in `jac/tests/cli/test_version_resolution.jac`:

- version found in the starting directory
- walk-up to an ancestor manifest (the shape that was broken: `dev_source = <repo>/jac`, manifest at `<repo>`)
- nearest-wins with no merging: a nearer version-less `jac.toml` masks an ancestor that has one
- no manifest anywhere on the walk-up path yields nothing
- `resolve_cli_version` end to end with `JAC_DEV_SOURCE` pointing below the manifest

All 5 pass; full `jac test jac/tests/cli` is green apart from 2 known parallel-run `test_mcp` resource flakes that pass in isolation both with and without this change.
