### PR TITLE
fix(scale): give a discovered .sv.jac service the module it must run

### DIFF
--- a/jac/jaclang/scale/deploy/target/kubernetes/manifest_builder.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/manifest_builder.jac
@@ -419,11 +419,25 @@ obj ManifestBuilder {
     ) -> dict[str, dict[str, any]] {
         app_name = app_config.app_name or self.k8s_config.app_name;
 
-        import from jaclang.scale.runtime.discovery.discovery { resolve_routes }
+        import from jaclang.scale.runtime.discovery.discovery {
+            resolve_routes,
+            resolve_service_files
+        }
         ms_cfg = dict(self._ms_cfg());
         proj = self.project_dir or app_config.code_folder;
         routes: dict[str, str] = resolve_routes(proj, dict(ms_cfg.get("routes", {})));
         ms_cfg["routes"] = routes;
+        if routes {
+            services: dict[str, any] = dict(ms_cfg.get("services", {}));
+            for (svc_name, svc_module) in resolve_service_files(proj, routes).items() {
+                declared = dict(services.get(svc_name, {}));
+                if not declared.get("file") {
+                    declared["file"] = svc_module;
+                    services[svc_name] = declared;
+                }
+            }
+            ms_cfg["services"] = services;
+        }
         self.microservices_config = ms_cfg;
 
         if not routes {

--- a/jac/jaclang/scale/tests/fixtures/sv_module_service/jac.toml
+++ b/jac/jaclang/scale/tests/fixtures/sv_module_service/jac.toml
@@ -1,0 +1,4 @@
+[project]
+name = "svmod"
+entry-point = "main.jac"
+kind = "web-app"

--- a/jac/jaclang/scale/tests/fixtures/sv_module_service/main.jac
+++ b/jac/jaclang/scale/tests/fixtures/sv_module_service/main.jac
@@ -1,0 +1,5 @@
+sv import from .services.thing { list_items }
+
+def app -> str {
+    return str(list_items());
+}

--- a/jac/jaclang/scale/tests/fixtures/sv_module_service/services/thing.sv.jac
+++ b/jac/jaclang/scale/tests/fixtures/sv_module_service/services/thing.sv.jac
@@ -1,0 +1,7 @@
+node Item {
+    has label: str;
+}
+
+def :pub list_items -> list[str] {
+    return [i.label for i in [root --> (`?Item)]];
+}

--- a/jac/jaclang/scale/tests/test_pod_env.jac
+++ b/jac/jaclang/scale/tests/test_pod_env.jac
@@ -18,7 +18,8 @@ import from jaclang.scale.deploy.target.kubernetes.kubernetes_config {
 import from jaclang.scale.config.app_config { AppConfig }
 
 
-glob _K8S_E2E_FIXTURE: Path = Path(__file__).parent / "fixtures" / "k8s_e2e";
+glob _K8S_E2E_FIXTURE: Path = Path(__file__).parent / "fixtures" / "k8s_e2e",
+     _SV_MODULE_FIXTURE: Path = Path(__file__).parent / "fixtures" / "sv_module_service";
 
 
 test "generate_service_pod_specs auto-discovers services when no routes declared" {
@@ -51,6 +52,30 @@ test "build_env injects JAC_SV_ROUTES so pods get routes without a toml table" {
     pairs = {e["name"]: e["value"] for e in env};
     assert "JAC_SV_ROUTES" in pairs;
     assert json.loads(pairs["JAC_SV_ROUTES"]) == routes;
+}
+
+
+test "a discovered .sv.jac service is told which module to run" {
+    # jac#8693: generate_service_pod_specs merges discovered services in via
+    # resolve_routes but never calls the paired resolve_service_files, so a
+    # discovered service got a Deployment with no JAC_SV_FILE. The entrypoint
+    # then falls back to `find . -name "<svc>.jac"`, which cannot match the
+    # `<svc>.sv.jac` modules discovery exists to register, and every such pod
+    # crash-loops on "couldn't read 'thing.jac'".
+    cfg = KubernetesConfig(app_name="svmod", namespace="ns");
+    builder = ManifestBuilder(k8s_config=cfg, project_dir=str(_SV_MODULE_FIXTURE));
+    app_cfg = AppConfig(
+        code_folder=str(_SV_MODULE_FIXTURE), app_name="svmod", file_name="main.jac"
+    );
+
+    specs = builder.generate_service_pod_specs(app_cfg, "img");
+
+    assert "thing" in specs , sorted(specs.keys());
+    env = {e["name"]: e["value"] for e in specs["thing"]["containers"][0]["env"]};
+    assert env["JAC_SV_NAME"] == "thing" , env;
+    assert env.get("JAC_SV_FILE") == "services/thing.sv.jac" , (
+        f"discovered service got no module to run: {env.get('JAC_SV_FILE')!r}"
+    );
 }
 
 


### PR DESCRIPTION
Fixes #8693

## The bug

`ManifestBuilder.generate_service_pod_specs` merges auto-discovered `.sv.jac`
services into the fleet through `resolve_routes`, but never calls the paired
`resolve_service_files`. A discovered service therefore gets a route and a
Deployment with no `JAC_SV_FILE`, and the pod entrypoint falls back to

```sh
find . -name "${JAC_SV_NAME}.jac"
```

That can only match a module literally named `<svc>.jac`, while discovery
exists to register modules named `<svc>.sv.jac`. Every such service crash-loops
on `couldn't read '<svc>.jac'` and the deploy fails on fleet readiness.

The local microservice path already resolves the file map (`plugin.jac:84`,
`plugin.jac:397`). Only the Kubernetes deploy path skipped it.

## The fix

Call `resolve_service_files` next to the existing `resolve_routes` and fold the
result into `ms_cfg["services"][name]["file"]`, which is what the manifest
already reads to emit `JAC_SV_FILE`. An explicitly declared
`[scale.microservices.services.NAME] file` still wins, so this only fills in
what discovery left blank.

## Verification

`test_pod_env.jac` gets one test over a new fixture that is the issue's own
repro: a `services/thing.sv.jac` module with no `[scale.microservices]` config
at all. It builds a real `ManifestBuilder` and asserts the generated pod spec
carries the module.

```
22 passed
```

Mutation checked, so the test is not tautological. With the fix reverted:

```
E   AssertionError: discovered service got no module to run: None
1 failed, 21 passed
```

## Scope

The 0.34 line only. `main` already resolves the file map on this path
(`kubernetes_realizer.jac:78` calls `resolve_service_files` right after
`resolve_routes`), so there is nothing to port forward and this is not a
backport of anything.
