### PR TITLE
ci: #8828 flake probe baseline on unfixed main (validation only, do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,6 +392,50 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit 0
 
+  # TEMPORARY (#8828 validation): five extra check-only copies of jac-check to
+  # amplify the intermittent phantom-type-error flake. Each probe is an
+  # independent full-tree `jac check` on a fresh runner, so one CI run gives
+  # six samples of the lane instead of one. DELETE THIS JOB before merge.
+  jac-check-probe:
+    needs: [changes, build-kit]
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        probe: [1, 2, 3, 4, 5]
+    env:
+      JAC_NO_DEV_SOURCE: ""
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: ./.github/actions/jac-kit
+
+      - name: Install plugin deps so jac check resolves scale/byllm imports
+        run: |
+          jac install \
+            "python-dotenv>=1.2.1,<2.0.0" \
+            "prometheus-client>=0.21.0,<1.0.0" \
+            "opentelemetry-sdk>=1.27.0,<2.0.0" \
+            "opentelemetry-exporter-otlp-proto-http>=1.27.0,<2.0.0" \
+            "apscheduler>=3.11.2,<4.0.0" "kubernetes>=34.1.0,<35.0.0" \
+            "docker>=7.1.0,<8.0.0" "boto3>=1.40.0,<2.0.0" \
+            "google-cloud-firestore>=2.21.0,<3.0.0" "google-cloud-storage>=2.19.0,<3.0.0" \
+            "firebase-admin>=6.0.0,<8.0.0" "requests>=2.32.0,<3.0.0" \
+            --global
+          jac install \
+            "litellm>=1.70.0,<=1.82.6" "pillow>=12.0.0,<13.0.0" \
+            "httpx>=0.27.0" "loguru>=0.7.2,<0.8.0" \
+            --global
+
+      - name: Run jac check (probe ${{ matrix.probe }})
+        run: |
+          set -euo pipefail
+          IGNORE_ARGS="tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ')"
+          jac check . --ignore $IGNORE_ARGS --nowarn
+
   # Pure PR-metadata policy: no kit, no jac. Docs code blocks are validated
   # by the suite (tests/cli/test_docs_code_blocks.jac) in the test lanes.
   contribution-checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,15 @@ jobs:
         with:
           submodules: true
 
+      - name: Restore JIR analysis cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/.cache/jac/jir
+          key: jac-check-jir-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-${{ github.sha }}
+          restore-keys: |
+            jac-check-jir-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-
+            jac-check-jir-${{ runner.os }}-
+
       - uses: ./.github/actions/jac-kit
 
       - name: Install plugin deps so jac check resolves scale/byllm imports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,12 +397,14 @@ jobs:
   # independent full-tree `jac check` on a fresh runner, so one CI run gives
   # six samples of the lane instead of one. DELETE THIS JOB before merge.
   jac-check-probe:
-    needs: [changes, build-kit]
+    # needs jac-check so its saved JIR cache (keyed on this run's sha) is an
+    # exact-match warm restore here: one cold world-compile per run, not six.
+    needs: [changes, build-kit, jac-check]
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 3
       matrix:
         probe: [1, 2, 3, 4, 5]
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         probe: [1, 2, 3, 4, 5]
     env:


### PR DESCRIPTION
**Validation only, do not merge.**

Control for #8873: unfixed main plus only the temporary probe commit (5 extra check-only copies of the jac-check lane per run, fail-fast off). This PR measures the base rate of the #8828 phantom-type-error flake; #8873 runs the same probes on top of the fix.

Reading the experiment: red probes here with all-green probes on #8873 across the same number of reruns is the red-to-green proof for the fix. If probes here stay green after several reruns, the amplification is inconclusive and the probes should add retirement pressure (JAC_CHECK_RECYCLE=1) before concluding anything.

Close without merging once the comparison is done.
