### PR TITLE
test(native): give the rc debug gate compile the same 900 s budget as its siblings

### DIFF
--- a/jac/tests/compiler/backends/native/test_native_rc_debug_gate.jac
+++ b/jac/tests/compiler/backends/native/test_native_rc_debug_gate.jac
@@ -49,7 +49,7 @@ def _compile_and_run(rc_debug_codegen: bool) -> tuple[str, str] {
             [sys.executable, "-m", "jaclang", "nacompile", src, "-o", out_bin],
             capture_output=True,
             text=True,
-            timeout=300,
+            timeout=900,
             env=env,
         );
         assert comp.returncode == 0 , (


### PR DESCRIPTION
## **Description**

`test-compiler (passes-native, chunk 1)` flips red on upstream main and on every PR whose run overlaps another: `test_native_rc_debug_gate.jac` caps its `nacompile` subprocess at 300 s while that compile takes about 330 s on an idle machine and longer on a loaded runner (`TimeoutExpired` after 300 s, `1516 passed, 1 error, 4 skipped`; seen on main at 4b3f1d16 and 463b15fa02 and on seven PRs on 2026-09-02). Twenty-four sibling native tests already give their compiles 900 s; this test now does too. The job keeps its own 15-minute budget.

Tests only, no fragment.