### PR TITLE
ci: the jac-check cache is the rerouted compiler's whole cache, not jac/jir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,14 +240,21 @@ jobs:
       # whole-repo sweep collapses to diagnostics replay. Restored before
       # jac-kit (which pins XDG_CACHE_HOME to this path) so the kit's own
       # warm-up precompile re-wraps cached JIRs instead of compiling.
+      #
+      # The path is the whole jac cache, not jac/jir: this lane runs the
+      # reroute (the checkout's compiler), and a rerouted compiler keeps
+      # every JIR it writes -- its own precompiled modules and the sweep's
+      # analysis entries -- under jac/rt/<generation>/. Caching jac/jir alone
+      # saved ~7 MB and restored nothing. There is no digest-agnostic
+      # fallback key: a generation directory from another compiler digest
+      # is dead weight to restore.
       - name: Restore JIR analysis cache
         uses: actions/cache/restore@v4
         with:
-          path: ${{ runner.temp }}/.cache/jac/jir
-          key: jac-check-jir-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-${{ github.sha }}
+          path: ${{ runner.temp }}/.cache/jac
+          key: jac-check-cache-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-${{ github.sha }}
           restore-keys: |
-            jac-check-jir-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-
-            jac-check-jir-${{ runner.os }}-
+            jac-check-cache-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-
 
       - uses: ./.github/actions/jac-kit
 
@@ -371,8 +378,8 @@ jobs:
         if: always()
         uses: actions/cache/save@v4
         with:
-          path: ${{ runner.temp }}/.cache/jac/jir
-          key: jac-check-jir-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-${{ github.sha }}
+          path: ${{ runner.temp }}/.cache/jac
+          key: jac-check-cache-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-${{ github.sha }}
 
       - name: Error-code breakdown (label "type-error-report")
         if: contains(github.event.pull_request.labels.*.name, 'type-error-report')


### PR DESCRIPTION
## What

The jac-check cache steps that landed with #8839 pointed at `jac/jir` under the runner's XDG cache root. The lane runs the reroute (the checkout's own compiler), and a rerouted compiler keeps every JIR it writes, its own precompiled modules and the whole-repo sweep's analysis entries alike, under `jac/rt/<generation>/`. The saved cache was ~7 MB and restored nothing.

Evidence, [the jac-check job on main after the cache landed](https://github.com/jaseci-labs/jac/actions/runs/33699066293/job/100476912750): `Cache hit for restore-key ... Cache Size: ~7 MB`, then `Jac setup complete (215 modules compiled and cached)` taking 5m25s and an 8m21s cold sweep. Locally, under an explicit `XDG_CACHE_HOME`, a single rerouted `jac check` writes 712 JIRs (313 MB) under `jac/rt/<generation>/` and no `jac/jir` at all.

## Change

- Restore and save `${{ runner.temp }}/.cache/jac` (the whole jac cache).
- Key namespace renamed to `jac-check-cache-` so the empty `jac-check-jir-` entries never match.
- The digest-agnostic fallback key is removed: a generation directory built by another compiler digest cannot be used, so restoring it is dead weight.

With a hit, both the kit warm-up precompile (re-wrap instead of compiling) and the sweep (diagnostics replay) should collapse; measured locally the sweep goes from 7m13s cold to under two seconds warm.
