### PR TITLE
test(compiler): a work-envelope gate on the cold precompile path

### DIFF
--- a/jac/tests/compiler/fixtures/precompile_gate/base/util.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/base/util.jac
@@ -1,0 +1,16 @@
+obj Pair {
+    has a: int = 0,
+        b: int = 0;
+
+    def total -> int {
+        return self.a + self.b;
+    }
+}
+
+def twice(x: int) -> int {
+    return x * 2;
+}
+
+def label(p: Pair) -> str {
+    return f"{p.a}+{p.b}";
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/core/alpha.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/core/alpha.jac
@@ -1,0 +1,30 @@
+import from base.util { Pair, twice, label }
+import from core.beta { BetaBox }
+
+obj AlphaBox {
+    has n: int = 0;
+
+    def pair -> Pair {
+        return Pair(a=self.n, b=twice(self.n));
+    }
+
+    def name -> str {
+        return label(self.pair());
+    }
+
+    def peer_beta -> BetaBox {
+        return BetaBox(n=self.n + 1);
+    }
+}
+
+def make_alpha(n: int) -> AlphaBox {
+    return AlphaBox(n=n);
+}
+
+def:pub total_alpha(n: int) -> int {
+    return make_alpha(n).pair().total();
+}
+
+def:pub name_alpha(n: int) -> str {
+    return make_alpha(n).name();
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/core/beta.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/core/beta.jac
@@ -1,0 +1,30 @@
+import from base.util { Pair, twice, label }
+import from core.gamma { GammaBox }
+
+obj BetaBox {
+    has n: int = 1;
+
+    def pair -> Pair {
+        return Pair(a=self.n, b=twice(self.n));
+    }
+
+    def name -> str {
+        return label(self.pair());
+    }
+
+    def peer_gamma -> GammaBox {
+        return GammaBox(n=self.n + 1);
+    }
+}
+
+def make_beta(n: int) -> BetaBox {
+    return BetaBox(n=n);
+}
+
+def:pub total_beta(n: int) -> int {
+    return make_beta(n).pair().total();
+}
+
+def:pub name_beta(n: int) -> str {
+    return make_beta(n).name();
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/core/delta.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/core/delta.jac
@@ -1,0 +1,25 @@
+import from base.util { Pair, twice, label }
+
+obj DeltaBox {
+    has n: int = 3;
+
+    def pair -> Pair {
+        return Pair(a=self.n, b=twice(self.n));
+    }
+
+    def name -> str {
+        return label(self.pair());
+    }
+}
+
+def make_delta(n: int) -> DeltaBox {
+    return DeltaBox(n=n);
+}
+
+def:pub total_delta(n: int) -> int {
+    return make_delta(n).pair().total();
+}
+
+def:pub name_delta(n: int) -> str {
+    return make_delta(n).name();
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/core/gamma.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/core/gamma.jac
@@ -1,0 +1,30 @@
+import from base.util { Pair, twice, label }
+import from core.delta { DeltaBox }
+
+obj GammaBox {
+    has n: int = 2;
+
+    def pair -> Pair {
+        return Pair(a=self.n, b=twice(self.n));
+    }
+
+    def name -> str {
+        return label(self.pair());
+    }
+
+    def peer_delta -> DeltaBox {
+        return DeltaBox(n=self.n + 1);
+    }
+}
+
+def make_gamma(n: int) -> GammaBox {
+    return GammaBox(n=n);
+}
+
+def:pub total_gamma(n: int) -> int {
+    return make_gamma(n).pair().total();
+}
+
+def:pub name_gamma(n: int) -> str {
+    return make_gamma(n).name();
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/feat/f0.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/feat/f0.jac
@@ -1,0 +1,28 @@
+import from "@jac/runtime" { jacIsLoggedIn }
+import from core.alpha { total_alpha, name_alpha }
+import from core.beta { total_beta, name_beta }
+import from core.gamma { total_gamma, name_gamma }
+
+def run_f0 -> int {
+    r = 0;
+    r += total_alpha(0);
+    r += total_beta(0);
+    r += total_gamma(0);
+    return r;
+}
+
+def label_f0 -> str {
+    return name_alpha(0) + " " + name_beta(0) + " " + name_gamma(0);
+}
+
+def gate_f0 -> bool {
+    return jacIsLoggedIn() and run_f0() > 0;
+}
+
+obj Feature0 {
+    has labels: list[str] = [];
+
+    def count -> int {
+        return len(self.labels);
+    }
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/feat/f1.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/feat/f1.jac
@@ -1,0 +1,28 @@
+import from "@jac/runtime" { jacIsLoggedIn }
+import from core.beta { total_beta, name_beta }
+import from core.gamma { total_gamma, name_gamma }
+import from core.delta { total_delta, name_delta }
+
+def run_f1 -> int {
+    r = 0;
+    r += total_beta(1);
+    r += total_gamma(1);
+    r += total_delta(1);
+    return r;
+}
+
+def label_f1 -> str {
+    return name_beta(1) + " " + name_gamma(1) + " " + name_delta(1);
+}
+
+def gate_f1 -> bool {
+    return jacIsLoggedIn() and run_f1() > 0;
+}
+
+obj Feature1 {
+    has labels: list[str] = [];
+
+    def count -> int {
+        return len(self.labels);
+    }
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/feat/f2.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/feat/f2.jac
@@ -1,0 +1,28 @@
+import from "@jac/runtime" { jacIsLoggedIn }
+import from core.gamma { total_gamma, name_gamma }
+import from core.delta { total_delta, name_delta }
+import from core.alpha { total_alpha, name_alpha }
+
+def run_f2 -> int {
+    r = 0;
+    r += total_gamma(2);
+    r += total_delta(2);
+    r += total_alpha(2);
+    return r;
+}
+
+def label_f2 -> str {
+    return name_gamma(2) + " " + name_delta(2) + " " + name_alpha(2);
+}
+
+def gate_f2 -> bool {
+    return jacIsLoggedIn() and run_f2() > 0;
+}
+
+obj Feature2 {
+    has labels: list[str] = [];
+
+    def count -> int {
+        return len(self.labels);
+    }
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/feat/f3.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/feat/f3.jac
@@ -1,0 +1,28 @@
+import from "@jac/runtime" { jacIsLoggedIn }
+import from core.delta { total_delta, name_delta }
+import from core.alpha { total_alpha, name_alpha }
+import from core.beta { total_beta, name_beta }
+
+def run_f3 -> int {
+    r = 0;
+    r += total_delta(3);
+    r += total_alpha(3);
+    r += total_beta(3);
+    return r;
+}
+
+def label_f3 -> str {
+    return name_delta(3) + " " + name_alpha(3) + " " + name_beta(3);
+}
+
+def gate_f3 -> bool {
+    return jacIsLoggedIn() and run_f3() > 0;
+}
+
+obj Feature3 {
+    has labels: list[str] = [];
+
+    def count -> int {
+        return len(self.labels);
+    }
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/feat/f4.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/feat/f4.jac
@@ -1,0 +1,28 @@
+import from "@jac/runtime" { jacIsLoggedIn }
+import from core.alpha { total_alpha, name_alpha }
+import from core.beta { total_beta, name_beta }
+import from core.gamma { total_gamma, name_gamma }
+
+def run_f4 -> int {
+    r = 0;
+    r += total_alpha(4);
+    r += total_beta(4);
+    r += total_gamma(4);
+    return r;
+}
+
+def label_f4 -> str {
+    return name_alpha(4) + " " + name_beta(4) + " " + name_gamma(4);
+}
+
+def gate_f4 -> bool {
+    return jacIsLoggedIn() and run_f4() > 0;
+}
+
+obj Feature4 {
+    has labels: list[str] = [];
+
+    def count -> int {
+        return len(self.labels);
+    }
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/feat/f5.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/feat/f5.jac
@@ -1,0 +1,28 @@
+import from "@jac/runtime" { jacIsLoggedIn }
+import from core.beta { total_beta, name_beta }
+import from core.gamma { total_gamma, name_gamma }
+import from core.delta { total_delta, name_delta }
+
+def run_f5 -> int {
+    r = 0;
+    r += total_beta(5);
+    r += total_gamma(5);
+    r += total_delta(5);
+    return r;
+}
+
+def label_f5 -> str {
+    return name_beta(5) + " " + name_gamma(5) + " " + name_delta(5);
+}
+
+def gate_f5 -> bool {
+    return jacIsLoggedIn() and run_f5() > 0;
+}
+
+obj Feature5 {
+    has labels: list[str] = [];
+
+    def count -> int {
+        return len(self.labels);
+    }
+}

--- a/jac/tests/compiler/fixtures/precompile_gate/jac.toml
+++ b/jac/tests/compiler/fixtures/precompile_gate/jac.toml
@@ -1,0 +1,5 @@
+[project]
+name = "precompile-gate"
+
+[build]
+default_codespace = "server"

--- a/jac/tests/compiler/fixtures/precompile_gate/main.jac
+++ b/jac/tests/compiler/fixtures/precompile_gate/main.jac
@@ -1,0 +1,28 @@
+import from "@jac/runtime" { jacIsLoggedIn }
+import from feat.f0 { run_f0, gate_f0, Feature0 }
+import from feat.f1 { run_f1, gate_f1, Feature1 }
+import from feat.f2 { run_f2, gate_f2, Feature2 }
+import from feat.f3 { run_f3, gate_f3, Feature3 }
+import from feat.f4 { run_f4, gate_f4, Feature4 }
+import from feat.f5 { run_f5, gate_f5, Feature5 }
+
+def ready -> bool {
+    return jacIsLoggedIn()
+        and gate_f0()
+        and gate_f1()
+        and gate_f2()
+        and gate_f3()
+        and gate_f4()
+        and gate_f5();
+}
+
+with entry {
+    total = 0;
+    total += run_f0();
+    total += run_f1();
+    total += run_f2();
+    total += run_f3();
+    total += run_f4();
+    total += run_f5();
+    print(total, ready());
+}

--- a/jac/tests/compiler/test_compile_timing.jac
+++ b/jac/tests/compiler/test_compile_timing.jac
@@ -464,3 +464,130 @@ test "the chess AOT binary stays inside its recorded run envelope" {
         );
     }
 }
+
+"""The cold precompile path: how much of the work the cache takes back.
+
+`precompile_gate` is a twelve-module tree under fixtures: a server base module, four
+cross-importing server core modules, six client features (they import the
+client runtime) that call the core's public endpoints, and a client main. The client side
+is the point: a client unit's boundary analysis takes the full analysis of
+its server closure, and that is the work the cache takes back on the cold
+path (a server-only tree just builds its dependencies' symbol tables, which
+are cheap either way). Each unit is its own compile closure, so without the
+cache every unit re-analyzes its closure from source; with it, the
+interfaces and boundary facts persisted by earlier units serve the later
+ones in the same cold run. The gate is on work, not
+seconds: pass runs are deterministic for a given tree and compiler, so the
+ceilings below are hard asserts with room, and the warm run must take the
+re-wrap fast path for every unit. Wall times are published, never asserted.
+The fixture's server default is pinned for the measurement: the project
+config resolves from the working directory, so the fixture's own jac.toml is
+never consulted from under the test runner.
+"""
+glob PRECOMPILE_GATE: str = os.path.join(
+         TESTS_DIR, "compiler", "fixtures", "precompile_gate"
+     ),
+     GATE_COLD_MAX_RUNS: int = 560,
+     GATE_COLD_MAX_RATIO: float = 0.6;
+
+def _precompile_units(pkg: str, rebuild: bool) -> tuple[int, dict, float] {
+    import from jaclang.dist.precompile_bytecode {
+        precompile_unit,
+        find_jac_files,
+        _unit_program
+    }
+    import from jaclang.compiler.driver.jir { get_module_cache_path }
+    import from jaclang.compiler.frontend.codeinfo {
+        set_effective_default_codespace,
+        get_effective_default_codespace_override
+    }
+    files = find_jac_files(pkg);
+    for f in files {
+        cp = get_module_cache_path(f);
+        if cp.exists() {
+            cp.unlink();
+        }
+    }
+    shutil.rmtree(os.path.join(pkg, "_precompiled"), ignore_errors=True);
+    if rebuild {
+        os.environ["JAC_REBUILD"] = "1";
+    }
+    prior_default = get_effective_default_codespace_override();
+    set_effective_default_codespace("server");
+    started = time.perf_counter();
+    try {
+        for f in files {
+            assert precompile_unit(f, pkg, False, collect=False) is not None , f"{f} did not precompile";
+        }
+    } finally {
+        set_effective_default_codespace(prior_default);
+        if rebuild {
+            os.environ.pop("JAC_REBUILD", None);
+        }
+    }
+    wall = time.perf_counter() - started;
+    prog: any = _unit_program[0] if _unit_program else None;
+    runs = sum(prog.analysis.pass_runs.values()) if prog is not None else 0;
+    events = dict(prog.analysis.cache_events) if prog is not None else {};
+    if prog is not None {
+        prog.analysis.pass_runs.clear();
+        prog.analysis.pass_time.clear();
+        prog.analysis.cache_events.clear();
+    }
+    return (runs, events, wall, );
+}
+
+test "the cold precompile path stays inside its work envelope" {
+    import from jaclang.dist.precompile_bytecode {
+        precompile_unit,
+        find_jac_files,
+        _unit_program
+    }
+    import from jaclang.compiler.frontend.codeinfo {
+        set_effective_default_codespace,
+        get_effective_default_codespace_override
+    }
+    with tempfile.TemporaryDirectory() as tmp {
+        pkg = os.path.join(tmp, "precompile_gate");
+        shutil.copytree(
+            PRECOMPILE_GATE, pkg, ignore=shutil.ignore_patterns(".jac", "_precompiled")
+        );
+        (no_cache, _, wall_none) = _precompile_units(pkg, rebuild=True);
+        (cold, events, wall_cold) = _precompile_units(pkg, rebuild=False);
+        shutil.rmtree(os.path.join(pkg, "_precompiled"), ignore_errors=True);
+        prior_default = get_effective_default_codespace_override();
+        set_effective_default_codespace("server");
+        started = time.perf_counter();
+        try {
+            for f in find_jac_files(pkg) {
+                assert precompile_unit(f, pkg, False, collect=False) is not None;
+            }
+        } finally {
+            set_effective_default_codespace(prior_default);
+        }
+        wall_warm = time.perf_counter() - started;
+        prog: any = _unit_program[0] if _unit_program else None;
+        warm_runs = sum(prog.analysis.pass_runs.values()) if prog is not None else 0;
+        publish(
+            "precompile-gate",
+            f"precompile gate x12 units: no-cache {no_cache} runs {wall_none:.2f}s, "
+            f"cold {cold} runs {wall_cold:.2f}s (hydrated {events.get(
+                'dep_hydrate', 0
+            )}, boundary facts served {events.get('boundary_facts', 0)}), "
+            f"warm {warm_runs} runs {wall_warm:.2f}s"
+        );
+        assert cold <= GATE_COLD_MAX_RUNS , (
+            f"cold precompile did {cold} pass runs; the ceiling is {GATE_COLD_MAX_RUNS} "
+            "(recorded 472 against 1213 without the cache): closure work the cache used to take back is being redone"
+        );
+        assert cold <= GATE_COLD_MAX_RATIO * no_cache , (
+            f"cold precompile with the cache did {cold} pass runs against {no_cache} without it "
+            f"(ratio {cold / max(no_cache, 1):.2f}, ceiling {GATE_COLD_MAX_RATIO})"
+        );
+        assert events.get("dep_hydrate", 0) >= 1 , f"the cold run hydrated nothing (events: {events})";
+        assert events.get("boundary_facts", 0) >= 1 , (
+            f"the cold run served no boundary facts from the cache (events: {events})"
+        );
+        assert warm_runs == 0 , f"the warm precompile ran {warm_runs} passes instead of re-wrapping";
+    }
+}


### PR DESCRIPTION
## What

A CI gate on the *cold* precompile path: how much of a unit's dependency work the analysis cache takes back within one cold run. It lives in `tests/compiler/test_compile_timing.jac` beside the chess AOT gate, so it runs in the `test-compiler (toplevel)` lane on every PR with no workflow change, and reports through the same durable timing file.

## Why cold, and why counters

Every precompile unit is its own compile closure; without the cache each re-ingests its dependency closure from source, and with it the interfaces persisted by earlier units serve the later ones in the same run. That intra-run reuse is what regressed after #8839 merged (1927 to 2183 pass runs on littleX, fixed in #8894), and it is deterministic: pass runs depend on the tree and the compiler, not the machine. So the gate asserts on work (pass runs, hydrations, the warm re-wrap path) with headroom, and only publishes wall times.

## Fixture

`fixtures/precompile_gate`: a server base module, four cross-importing server core modules, six client feature modules (they import the client runtime) that call the core's public endpoints (`def:pub`), and a client main. The client side is the point. A client unit's boundary analysis takes the full analysis of its server closure, and that closure analysis is exactly what the cache takes back on the cold path: on littleX without the cache the analysis pipeline runs 200 times for 39 units, with it 60. A server-only tree only builds its dependencies' symbol tables, which are cheap with or without the cache (444 against 436 pass runs), so it cannot gate anything.

The fixture's server default is pinned inside the test: the project config resolves from the working directory, so the fixture's own jac.toml is never consulted from under the test runner, and under this repo's native default the marker-less modules would become native units whose tree dependencies the cache cannot serve.

## Recorded

| | pass runs | wall |
|---|---|---|
| no cache (`JAC_REBUILD`) | 987 | 6.5s |
| cold, cache on | 679 (42 hydrations) | 1.3s |
| warm (units removed, module cache kept) | 0 | 0.01s |

Gate: cold <= 760 pass runs, cold <= 0.85 x no-cache, at least one hydration, warm == 0.
