### PR TITLE
test(scale): one resolver for the pod binary the bundle tests ship (#8897 phase 0a.3)

### DIFF
--- a/jac/jaclang/scale/tests/deploy/test_client_build_fail_fast.jac
+++ b/jac/jaclang/scale/tests/deploy/test_client_build_fail_fast.jac
@@ -28,6 +28,7 @@ import from jaclang.scale.deploy.target.kubernetes.kubernetes_config {
 import from jaclang.scale.deploy.target.kubernetes.manifest_builder { ManifestBuilder }
 import from jaclang.scale.injector.bundle { release_binary_env }
 import from jaclang.scale.runtime.context.util { jac_executable }
+import from jaclang.scale.tests.support { pod_binary }
 
 # No jac release carries this version, so it can never collide with the jac
 # running the suite.
@@ -307,7 +308,7 @@ test "a genuine compile error fails on the first attempt with no retry" {
 test "a pinned app builds its client on the pinned release, not the deploying jac" {
     # The checkout's own binary is published as the pinned release, the same way
     # the seal tests reuse it as the pod binary.
-    jac_bin = Path(str(__file__)).parents[4] / "zig-out" / "bin" / "jac";
+    jac_bin = pod_binary();
     if not jac_bin.is_file() {
         return;
     }

--- a/jac/jaclang/scale/tests/microservices/test_app_precompile.jac
+++ b/jac/jaclang/scale/tests/microservices/test_app_precompile.jac
@@ -6,6 +6,7 @@ import sys;
 import tarfile;
 import tempfile;
 import from pathlib { Path }
+import from jaclang.scale.tests.support { pod_binary }
 import from jaclang.scale.injector.bundle {
     DEFAULT_SEAL_TIMEOUT_S,
     _stage_app,
@@ -264,7 +265,7 @@ test "a real pod binary seals the app into a .jab (source + _precompiled + manif
     # The checkout's own binary stands in for the downloaded pod binary; the
     # mechanism (stage -> precompile_bytecode.jac --seal -> pack _precompiled/**)
     # is identical for release binaries.
-    jac_bin = Path(__file__).parents[4] / "zig-out" / "bin" / "jac";
+    jac_bin = pod_binary();
     if not jac_bin.is_file() {
         return;
     }

--- a/jac/jaclang/scale/tests/microservices/test_bundle_jacignore.jac
+++ b/jac/jaclang/scale/tests/microservices/test_bundle_jacignore.jac
@@ -2,6 +2,7 @@ import io;
 import tarfile;
 import tempfile;
 import from pathlib { Path }
+import from jaclang.scale.tests.support { pod_binary }
 import from jaclang.scale.injector.bundle {
     _stage_app,
     add_source_members,
@@ -15,7 +16,7 @@ import from jaclang.scale.injector.bundle {
 }
 
 
-glob _JAC_BIN: Path = Path(__file__).parents[4] / "zig-out" / "bin" / "jac",
+glob _JAC_BIN: Path = pod_binary(),
      _PARKED: str = "# parked for the deploy\ndocsite/\nevaluation/\n";
 
 

--- a/jac/jaclang/scale/tests/microservices/test_bundle_services.jac
+++ b/jac/jaclang/scale/tests/microservices/test_bundle_services.jac
@@ -4,6 +4,7 @@ import shutil;
 import tarfile;
 import tempfile;
 import from pathlib { Path }
+import from jaclang.scale.tests.support { pod_binary }
 import from jaclang.scale.injector.bundle {
     assert_entry_module_ships,
     bundle_source_files,
@@ -14,7 +15,7 @@ import from jaclang.scale.injector.bundle {
 }
 
 
-glob _JAC_BIN: Path = Path(__file__).parents[4] / "zig-out" / "bin" / "jac",
+glob _JAC_BIN: Path = pod_binary(),
      _ROOT: Path = Path(tempfile.mkdtemp(prefix="jac-bundle-services-")),
      _ROUTED_TOML: str = (
          "[project]\nname = \"mini\"\n\n[scale.microservices.routes]\n"

--- a/jac/jaclang/scale/tests/microservices/test_fat_bundle.jac
+++ b/jac/jaclang/scale/tests/microservices/test_fat_bundle.jac
@@ -3,6 +3,7 @@ import tarfile;
 import tempfile;
 import json;
 import from pathlib { Path }
+import from jaclang.scale.tests.support { pod_binary }
 import from jaclang.scale.injector.bundle {
     content_address,
     fat_bundle_enabled,
@@ -23,7 +24,7 @@ def _app(toml: str) -> str {
 def _pod_binary -> bytes | None {
     # The checkout's own binary stands in for the downloaded pod binary, same
     # as test_app_precompile; skip when the toolchain has not been built.
-    jac_bin = Path(__file__).parents[4] / "zig-out" / "bin" / "jac";
+    jac_bin = pod_binary();
     if not jac_bin.is_file() {
         return None;
     }

--- a/jac/jaclang/scale/tests/microservices/test_pvc_injector.jac
+++ b/jac/jaclang/scale/tests/microservices/test_pvc_injector.jac
@@ -5,6 +5,7 @@ import tempfile;
 import tomllib;
 import from pathlib { Path }
 import from jaclang.scale.injector.bundle { sanitized_jac_toml, pack_jab }
+import from jaclang.scale.tests.support { pod_binary }
 import from jaclang.scale.injector.pvc_injector {
     PvcInjector,
     build_bundle_pvc,
@@ -17,7 +18,7 @@ import from jaclang.scale.injector.pvc_injector {
 }
 
 
-glob _JAC_BIN: Path = Path(__file__).parents[4] / "zig-out" / "bin" / "jac";
+glob _JAC_BIN: Path = pod_binary();
 
 
 def _make_project(project: str, toml: str) {

--- a/jac/jaclang/scale/tests/microservices/test_seed_determinism.jac
+++ b/jac/jaclang/scale/tests/microservices/test_seed_determinism.jac
@@ -3,6 +3,7 @@ import tempfile;
 import from pathlib { Path }
 import from jaclang.scale.injector.bundle { pack_jab, content_address }
 import from jaclang.scale.injector.binary { pack_binary_bytes }
+import from jaclang.scale.tests.support { pod_binary }
 import from jaclang.compiler.driver.jir {
     FLAG_PRECOMPILED,
     compiler_source_digest,
@@ -16,7 +17,7 @@ import from jaclang.compiler.driver.jir {
 }
 
 
-glob _JAC_BIN: Path = Path(__file__).parents[4] / "zig-out" / "bin" / "jac";
+glob _JAC_BIN: Path = pod_binary();
 
 
 test "identical content packs to identical bytes (content-address stable)" {

--- a/jac/jaclang/scale/tests/support.jac
+++ b/jac/jaclang/scale/tests/support.jac
@@ -30,6 +30,11 @@ def get_free_port -> int {
     return port;
 }
 
+"""The jac binary `zig build` writes, resolved from this file's depth in tests/."""
+def pod_binary -> Path {
+    return Path(__file__).parents[3] / "zig-out" / "bin" / "jac";
+}
+
 """Delete SQLite, legacy shelf, and client-build leftovers under fixtures_dir."""
 def cleanup_db_files(fixtures_dir: Path) {
     for pattern in [


### PR DESCRIPTION
## What this changes

Part of #8896, third PR of #8897 (phase 0, step 0a), after #8902 and #8908.

Seven files each spelled the same path by hand to find the jac binary the bundle tests ship into pods:

```jac
Path(__file__).parents[4] / "zig-out" / "bin" / "jac"
```

Four carried it as a `_JAC_BIN` glob (`microservices/test_pvc_injector.jac:20`, `test_bundle_jacignore.jac:18`, `test_bundle_services.jac:17`, `test_seed_determinism.jac:19`), three inline (`microservices/test_fat_bundle.jac:26`, `test_app_precompile.jac:267`, `deploy/test_client_build_fail_fast.jac:310`). They now call `support.pod_binary()`.

**The index is not copyable, which is the one thing worth reading in this diff.** `support.jac` sits in `tests/` while every caller sits in `tests/<group>/`, so the shared helper needs `parents[3]` to name the same `jac/` build root the callers named with `parents[4]`. Copying the expression verbatim resolves to the repo root instead, and because the result is only ever passed to `is_file()`, that failure would look like a missing binary rather than a wrong path. The helper says so at the definition.

**Behaviour is unchanged.** Every caller keeps its own `is_file()` guard, including the six that currently `return` early when the binary is absent. Making those fail loud is 0d's job, where TESTING.md's rule about tests that cannot fail gets enforced.

## Validation

Rig per TESTING.md part 1: `zig build -Ddev` from this checkout with the capability deps re-pinned, plus the native compiler kernel built into the tree (see the note below). The marker test passes: a planted type error in a scale test file is reported by the checker, so the binary is serving this checkout.

Every suite that owns one of the seven copies, one file per process (`jac test --jobs 0`):

| Suite | Result |
|---|---|
| `microservices/test_bundle_services.jac` | 24 passed |
| `microservices/test_app_precompile.jac` | 15 passed |
| `microservices/test_pvc_injector.jac` | 10 passed |
| `microservices/test_bundle_jacignore.jac` | 10 passed |
| `deploy/test_client_build_fail_fast.jac` | 9 passed |
| `microservices/test_seed_determinism.jac` | 8 passed |
| `microservices/test_fat_bundle.jac` | 6 passed |

82 tests, all green. `jac fmt --check --lintfix` and `jac check` are clean on all eight changed files.

**Not run:** nothing under `server/`, `data/` or `misc/`, which contain no copy of this expression, and no cluster leg. This change cannot reach them.

## Two corrections to #8897's plan

**The `_as_any` slice was attempted here and pulled back out.** The plan proposed replacing the twelve identical `_as_any` copies with the stdlib `cast(any, x)`, on the grounds that `cast` is already used this way in-tree (`test_deploy_k8s.jac:497`). That is wrong: a function declared to return `any` erases the type, and `cast(any, x)` does not. Converting all twelve produced errors in three files, of the shape

```
error[E1030]: Type "MockAppleSSO" has no attribute "verify_and_process"
error[E1002]: Cannot return <Unknown>, expected MockUserInfo
```

so the conversion was reverted and the definitions restored. `_as_any` can still be consolidated into `support.jac` as one shared helper; it just cannot be deleted in favour of the stdlib. Worth deciding against the fact that eight of its twelve holders are mock files, so phase 3 removes most of its call sites anyway.

**The "three JAC_EXECUTABLE client-build harness copies" in the plan are not a hoistable duplicate.** `_builder` and `_project` in `deploy/test_client_build_{deps,stage,fail_fast}.jac` differ by app name, namespace, and parameters (`dry_run`, `client`). They collapse when those three files merge into one, which is phase 1's section 2, not a shared-harness move.

## A rig note, unrelated to this change

`zig build -Ddev`, the loop CONTRIBUTING documents, currently produces a binary that refuses every command on main:

```
OSError: This jac build is missing its native compiler kernel ('libjac_compiler.so' + .layout.json under jaclang/compiler/)
```

Since #8825 the native parse kernel is mandatory, but the payload assembler returns early in linked-source mode (`jac/jaclang/dist/payload/impl/assemble.impl.jac:138`) before the block that builds the kernel and copies it into the tree, while the LLVM shim is still placed there. The guard at `jac/jaclang/compiler/native_compiler.jac:474` keys off exactly that shim to decide the tree is a full kit, so the two disagree about what a dev tree is. Reproducing what a release build does by hand unblocks it:

```bash
JAC_COMPILER_LIB=off JAC_NO_DEV_SOURCE=1 JAC_STUBCAT_BUILDING=1 \
JAC_LLVM_SHIM=jac/jaclang/compiler/backends/native/llvm/libjacllvm.so \
jac nacompile --shared jaclang/compiler/jc_unit.jac -o jaclang/compiler/libjac_compiler.so
```

Filed separately if it is not already known; noted here because it is what this PR's validation had to work around.
