### PR TITLE
test(runtimelib): the /cl/__error__ flake reports whether the record was ever emitted (#8844)

### DIFF
--- a/jac/tests/runtimelib/test_client_status_document.jac
+++ b/jac/tests/runtimelib/test_client_status_document.jac
@@ -20,6 +20,21 @@ import from jaclang.testing.testing { JacTestClient }
 
 glob FIXTURES = str(Path(__file__).parent / "fixtures");
 
+"""Records every message the logger accepts, before any handler sees it.
+
+A logger filter runs at emit time on the logger object itself, so an empty
+tap separates "nothing was ever emitted to this logger" from "a handler or
+its stream dropped the record" -- the two causes an empty buffer conflates.
+"""
+obj _EmitTap {
+    has seen: list[str] = [];
+
+    def filter(record: any) -> bool {
+        self.seen.append(record.getMessage());
+        return True;
+    }
+}
+
 def _as_any(v: any) -> any {
     return v;
 }
@@ -276,11 +291,14 @@ test "the /cl/__error__ endpoint logs a rendered diagnostic with a Jac location"
         buf = io.StringIO();
         sink = logging.StreamHandler(buf);
         logger = logging.getLogger("jaclang.client_errors");
+        tap = _EmitTap();
         logger.addHandler(sink);
         # The sink must see the record whatever level the root logger was left
         # at, so the level is pinned here and restored below.
         old_level = logger.level;
         logger.setLevel(logging.ERROR);
+        logger.addFilter(tap);
+        attached_to = id(logger);
         _error_rate_limiter._seen = {};
         _error_rate_limiter._count = 0;
         client = JacTestClient.from_file(
@@ -308,10 +326,16 @@ test "the /cl/__error__ endpoint logs a rendered diagnostic with a Jac location"
             );
             sink.flush();
             logged = buf.getvalue();
+            live = logging.getLogger("jaclang.client_errors");
             assert "error[E7003]" in logged , (
                 f"diagnostic never reached the sink; response={body}; "
-                f"logger disabled={logger.disabled} level={logger.level} "
-                f"handlers={logger.handlers} propagate={logger.propagate}; "
+                f"emitted={len(tap.seen)} records={tap.seen}; "
+                f"logger id at attach={attached_to} at assert={id(live)}; "
+                f"sink still attached={sink in live.handlers}; "
+                f"disabled={live.disabled} level={live.level} "
+                f"effective={live.getEffectiveLevel()} "
+                f"global_disable={logging.root.manager.disable}; "
+                f"handlers={live.handlers} propagate={live.propagate}; "
                 f"buffer={logged!r}"
             );
             assert "--> app.jac:2" in logged , logged;
@@ -320,6 +344,7 @@ test "the /cl/__error__ endpoint logs a rendered diagnostic with a Jac location"
             assert "  Stack: TypeError" in logged , logged;
             assert "at app (app.jac:2:" in logged , logged;
         } finally {
+            logger.removeFilter(tap);
             logger.removeHandler(sink);
             logger.setLevel(old_level);
             client.close();


### PR DESCRIPTION
## What this changes

Item 3 of #8844, `tests/runtimelib/test_client_status_document.jac :: the /cl/__error__ endpoint logs a rendered diagnostic`, fails on CI at roughly the rate that issue records. It hit twice today on an unrelated scale-tests PR (#8916), runs 33746796930 and 33761954030.

This does not fix it. It makes the next failure say which of two things happened, because the current report cannot tell them apart.

The assertion reads an empty buffer and prints the logger's state **at assert time**. That is equally consistent with:

1. nothing was ever emitted to that logger object, or
2. a record was emitted and a handler, or its stream, dropped it.

A logger *filter* runs at emit time on the logger itself, before any handler. So an empty tap proves (1) and a non-empty tap with an empty buffer proves (2). The failure message also gains the logger's identity at attach and at assert, whether the sink is still attached, the effective level, and `logging.root.manager.disable`, the process-wide switch that suppresses records while leaving `logger.disabled` False and which nothing was checking.

No production code changes, no new assertion, no change to what passes. Only the failure message of the existing assertion, plus the filter that feeds it.

## What the last two CI failures already rule out

Both hypotheses named in #8844 are excluded by evidence, which is why this probe looks elsewhere:

```
AssertionError: diagnostic never reached the sink; response={'ok': True};
logger disabled=False level=0 handlers=[<StreamHandler (NOTSET)>] propagate=True; buffer=''
```

- **Not the throttle.** The response carries no `throttled` key, and the endpoint returns that shape early (`jaclang/server/impl/server.impl.jac:2242`). Execution reached `log_client_error`.
- **Not a disabled or muted logger.** `disabled=False`, `level=0`, `propagate=True`, sink still attached at assert time.
- **Not an early return before the log call.** `log_client_error` logs unconditionally at `jaclang/client/impl/client_diagnostics.impl.jac:486`.
- **Not an unflushed buffer.** The buffer is read after an explicit `sink.flush()`.

So the record was emitted and the handler was attached, yet the buffer is empty. The gap is between emit and receipt, which is exactly what the tap splits.

If the tap comes back empty and the two logger ids differ, this stops being a logging bug and joins items 1 and 2 of #8844, the one-name-two-instances family.

## Two adjacent things worth a look, not touched here

- There is a second client-error path with its own throttle and its own console output at `jaclang/scale/server/impl/serve.core.impl.jac:457`. If a fixture ever boots the scale server rather than the core one, the assertion watches the wrong sink.
- `tests/runtimelib/test_client_error_reporting.jac` attaches to the same `jaclang.client_errors` logger and does not reset `_error_rate_limiter`. Those two files sharing a worker process is a plausible interaction; `test-runtime` runs at `JAC_TEST_JOBS=auto`, so which files share a worker varies per run, which fits a CI-only intermittent failure that no local reproduction has caught.

## Validation

Rig per TESTING.md part 1: `zig build -Ddev` from this checkout, capability deps re-pinned. `jac --version` prints the dev banner naming the checkout.

- `jac fmt --check --lintfix` and `jac check` clean on the changed file.
- `jac test --jobs 0 jac/tests/runtimelib/test_client_status_document.jac`: **11 passed**, unchanged.

**Not run:** the rest of `tests/runtimelib`. This change touches one test file and no production code, so it cannot reach them. The flake itself did not reproduce locally, which is consistent with every attempt recorded on #8844; CI is where the new message will be read.
