### PR TITLE
test(scale): rig requirements are declared, so a missing one stops passing green (#8897 phase 0b)

### DIFF
--- a/jac/jaclang/scale/tests/deploy/test_client_build_fail_fast.jac
+++ b/jac/jaclang/scale/tests/deploy/test_client_build_fail_fast.jac
@@ -28,7 +28,7 @@ import from jaclang.scale.deploy.target.kubernetes.kubernetes_config {
 import from jaclang.scale.deploy.target.kubernetes.manifest_builder { ManifestBuilder }
 import from jaclang.scale.injector.bundle { release_binary_env }
 import from jaclang.scale.runtime.context.util { jac_executable }
-import from jaclang.scale.tests.support { pod_binary }
+import from jaclang.scale.tests.support { require_pod_binary }
 
 # No jac release carries this version, so it can never collide with the jac
 # running the suite.
@@ -308,10 +308,7 @@ test "a genuine compile error fails on the first attempt with no retry" {
 test "a pinned app builds its client on the pinned release, not the deploying jac" {
     # The checkout's own binary is published as the pinned release, the same way
     # the seal tests reuse it as the pod binary.
-    jac_bin = pod_binary();
-    if not jac_bin.is_file() {
-        return;
-    }
+    jac_bin = require_pod_binary();
     tmp = tempfile.mkdtemp(prefix="client-pin-");
     project_dir = _web_app_project(tmp);
     _pin(project_dir, PINNED);

--- a/jac/jaclang/scale/tests/microservices/test_app_precompile.jac
+++ b/jac/jaclang/scale/tests/microservices/test_app_precompile.jac
@@ -6,7 +6,7 @@ import sys;
 import tarfile;
 import tempfile;
 import from pathlib { Path }
-import from jaclang.scale.tests.support { pod_binary }
+import from jaclang.scale.tests.support { require_pod_binary }
 import from jaclang.scale.injector.bundle {
     DEFAULT_SEAL_TIMEOUT_S,
     _stage_app,
@@ -265,10 +265,7 @@ test "a real pod binary seals the app into a .jab (source + _precompiled + manif
     # The checkout's own binary stands in for the downloaded pod binary; the
     # mechanism (stage -> precompile_bytecode.jac --seal -> pack _precompiled/**)
     # is identical for release binaries.
-    jac_bin = pod_binary();
-    if not jac_bin.is_file() {
-        return;
-    }
+    jac_bin = require_pod_binary();
     names = _names(pack_jab(_mini_app(), jac_bin.read_bytes()));
     assert "svc.jac" in names;
     # The sealed manifest sits at the tar root, which is what makes this a .jab.

--- a/jac/jaclang/scale/tests/microservices/test_bundle_jacignore.jac
+++ b/jac/jaclang/scale/tests/microservices/test_bundle_jacignore.jac
@@ -2,7 +2,7 @@ import io;
 import tarfile;
 import tempfile;
 import from pathlib { Path }
-import from jaclang.scale.tests.support { pod_binary }
+import from jaclang.scale.tests.support { pod_binary, require_pod_binary }
 import from jaclang.scale.injector.bundle {
     _stage_app,
     add_source_members,
@@ -128,9 +128,7 @@ test "parking the entry module fails the pack, not the fleet" {
 test "a sealed .jab carries no tree that .jacignore parks" {
     # Unfixed, this seal dies on evaluation/broken.jac, which is the crash the
     # in-pod boot compile hits.
-    if not _JAC_BIN.is_file() {
-        return;
-    }
+    require_pod_binary();
     raw = pack_jab(str(_app(_PARKED)), _JAC_BIN.read_bytes());
     with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tar {
         names = tar.getnames();

--- a/jac/jaclang/scale/tests/microservices/test_bundle_services.jac
+++ b/jac/jaclang/scale/tests/microservices/test_bundle_services.jac
@@ -4,7 +4,7 @@ import shutil;
 import tarfile;
 import tempfile;
 import from pathlib { Path }
-import from jaclang.scale.tests.support { pod_binary }
+import from jaclang.scale.tests.support { pod_binary, require_pod_binary }
 import from jaclang.scale.injector.bundle {
     assert_entry_module_ships,
     bundle_source_files,
@@ -311,9 +311,7 @@ test "the entry-module guard covers baseline exclusions, not just .jacignore" {
 
 
 test "a sealed .jab ships exactly the sources the resolution ran against" {
-    if not _JAC_BIN.is_file() {
-        return;
-    }
+    require_pod_binary();
     base = _app(
         _ROUTED_TOML, {"svc.jac": _PING, "lib/svc.jac": _PING, "main.jac": _PING}
     );

--- a/jac/jaclang/scale/tests/microservices/test_fat_bundle.jac
+++ b/jac/jaclang/scale/tests/microservices/test_fat_bundle.jac
@@ -3,7 +3,7 @@ import tarfile;
 import tempfile;
 import json;
 import from pathlib { Path }
-import from jaclang.scale.tests.support { pod_binary }
+import from jaclang.scale.tests.support { require_pod_binary }
 import from jaclang.scale.injector.bundle {
     content_address,
     fat_bundle_enabled,
@@ -21,14 +21,8 @@ def _app(toml: str) -> str {
 }
 
 
-def _pod_binary -> bytes | None {
-    # The checkout's own binary stands in for the downloaded pod binary, same
-    # as test_app_precompile; skip when the toolchain has not been built.
-    jac_bin = pod_binary();
-    if not jac_bin.is_file() {
-        return None;
-    }
-    return jac_bin.read_bytes();
+def _pod_binary -> bytes {
+    return require_pod_binary().read_bytes();
 }
 
 
@@ -75,9 +69,6 @@ test "fat bundles default ON; [scale] fat_bundle=false opts out" {
 
 test "fat_bundle=false ships no _vendor tree" {
     pod = _pod_binary();
-    if pod is None {
-        return;
-    }
     toml = "[project]\nname = \"mini\"\n\n[scale]\nfat_bundle = false\n";
     names = _names(pack_jab(_app(toml), pod));
     assert not any([n.startswith("_vendor") for n in names]) , names;
@@ -86,9 +77,6 @@ test "fat_bundle=false ships no _vendor tree" {
 
 test "default-on: a bare project ships a _vendor manifest for its closure" {
     pod = _pod_binary();
-    if pod is None {
-        return;
-    }
     names = _names(pack_jab(_app("[project]\nname = \"mini\"\n"), pod));
     assert "_vendor/VENDOR.json" in names , names;
 }
@@ -96,9 +84,6 @@ test "default-on: a bare project ships a _vendor manifest for its closure" {
 
 test "fat_bundle=true stages _vendor/wheels resolved by the seal binary" {
     pod = _pod_binary();
-    if pod is None {
-        return;
-    }
     toml = "[project]\nname = \"mini\"\n\n[scale]\nfat_bundle = true\n";
     raw = pack_jab(_app(toml), pod);
     names = _names(raw);
@@ -122,9 +107,6 @@ test "fat_bundle=true stages _vendor/wheels resolved by the seal binary" {
 
 test "the bundle digest is deterministic and moves when a wheel changes" {
     pod = _pod_binary();
-    if pod is None {
-        return;
-    }
     pinned = (
         "[project]\nname = \"mini\"\n\n[dependencies]\n"
         "python-dotenv = \"{}\"\n\n[scale]\nfat_bundle = true\n"

--- a/jac/jaclang/scale/tests/microservices/test_pvc_injector.jac
+++ b/jac/jaclang/scale/tests/microservices/test_pvc_injector.jac
@@ -5,7 +5,7 @@ import tempfile;
 import tomllib;
 import from pathlib { Path }
 import from jaclang.scale.injector.bundle { sanitized_jac_toml, pack_jab }
-import from jaclang.scale.tests.support { pod_binary }
+import from jaclang.scale.tests.support { pod_binary, require_pod_binary }
 import from jaclang.scale.injector.pvc_injector {
     PvcInjector,
     build_bundle_pvc,
@@ -39,9 +39,7 @@ def _sanitized_toml(project: str) -> dict {
 
 
 test "secrets are stripped and secret-bearing files excluded from the sealed .jab" {
-    if not _JAC_BIN.is_file() {
-        return;
-    }
+    require_pod_binary();
     with tempfile.TemporaryDirectory() as project {
         with open(os.path.join(project, "app.jac"), "w") as handle {
             handle.write("with entry { print(\"ok\"); }");

--- a/jac/jaclang/scale/tests/microservices/test_seed_determinism.jac
+++ b/jac/jaclang/scale/tests/microservices/test_seed_determinism.jac
@@ -3,7 +3,7 @@ import tempfile;
 import from pathlib { Path }
 import from jaclang.scale.injector.bundle { pack_jab, content_address }
 import from jaclang.scale.injector.binary { pack_binary_bytes }
-import from jaclang.scale.tests.support { pod_binary }
+import from jaclang.scale.tests.support { pod_binary, require_pod_binary }
 import from jaclang.compiler.driver.jir {
     FLAG_PRECOMPILED,
     compiler_source_digest,
@@ -25,9 +25,7 @@ test "identical content packs to identical bytes (content-address stable)" {
     # zeroed gzip header time and normalized member mtimes/owners.
     assert pack_binary_bytes(b"ELF") == pack_binary_bytes(b"ELF");
 
-    if not _JAC_BIN.is_file() {
-        return;
-    }
+    require_pod_binary();
     binary = _JAC_BIN.read_bytes();
     d = tempfile.mkdtemp();
     src = Path(d, "svc.jac");

--- a/jac/jaclang/scale/tests/server/test_scheduler_multipod.jac
+++ b/jac/jaclang/scale/tests/server/test_scheduler_multipod.jac
@@ -13,7 +13,7 @@ import time;
 import from tempfile { mkdtemp }
 import from jaclang.data.pgembed { PgRuntime }
 import from jaclang.data.store { PgStore }
-import from jaclang.scale._optdeps.apscheduler { HAS_APSCHEDULER }
+import from jaclang.testing.requires { require_module }
 import from jaclang.scale.scheduler.scheduler {
     JOBS_CHANGED_CHANNEL,
     JacScaleScheduler,
@@ -144,9 +144,7 @@ test "jobs-changed NOTIFY from one pod reaches the other pod's listener" {
 
 
 test "two live pods fire a due job exactly once and DELETE stops both" {
-    if not HAS_APSCHEDULER {
-        testskip('apscheduler not installed; covered in CI');
-    }
+    require_module("apscheduler");
     import datetime as _dt;
     import from apscheduler.schedulers.background { BackgroundScheduler }
     sa = _store();

--- a/jac/jaclang/scale/tests/support.jac
+++ b/jac/jaclang/scale/tests/support.jac
@@ -16,9 +16,11 @@ import shutil;
 import socket;
 import subprocess;
 import time;
+import unittest;
 import requests;
 import from pathlib { Path }
 import from typing { cast }
+import from jaclang.testing.test_runner { STRICT_ENV, strict_mode }
 
 """A port nothing is listening on."""
 def get_free_port -> int {
@@ -33,6 +35,25 @@ def get_free_port -> int {
 """The jac binary `zig build` writes, resolved from this file's depth in tests/."""
 def pod_binary -> Path {
     return Path(__file__).parents[3] / "zig-out" / "bin" / "jac";
+}
+
+"""The pod binary, or a named skip that JAC_TEST_STRICT turns into a failure.
+
+Mirrors `jaclang.testing.requires`, which cannot express a build artifact:
+this one is neither an importable module nor a tool on PATH.
+"""
+def require_pod_binary -> Path {
+    binary = pod_binary();
+    if not binary.is_file() {
+        detail = f"missing build artifact '{binary}' (run `zig build` to produce it)";
+        if strict_mode() {
+            raise AssertionError(
+                f"{detail}; {STRICT_ENV} is set, so this is a failure"
+            );
+        }
+        raise unittest.SkipTest(detail);
+    }
+    return binary;
 }
 
 """Delete SQLite, legacy shelf, and client-build leftovers under fixtures_dir."""
@@ -114,7 +135,7 @@ def register_user(base_url: str, username: str, password: str = "pass123") -> st
 `env` overlays the inherited environment, for fixtures that need a variable
 set for the server process (a PYTHONPATH entry, say). A server that exits
 before answering is reported immediately with its output rather than waited
-out. The 120s budget covers a cold compile cache, where the first boot must
+out. The 300s budget covers a cold compile cache, where the first boot must
 compile the app before it can serve /healthz.
 """
 def start_server(


### PR DESCRIPTION
## What this changes

Part of #8896, phase 0b of #8897, after #8902, #8908, #8911 and #8916.

Eight tests across seven files returned early when the pod binary was absent:

```jac
if not _JAC_BIN.is_file() {
    return;
}
```

A test that returns before its first assertion reports as a pass. `ci.yml:693` already described these as files that "silently self-skip". They now call `support.require_pod_binary()`, which names the missing artifact: a skip under a normal run, a failure under `JAC_TEST_STRICT=1`, which every scale lane sets (`ci.yml:723`).

`server/test_scheduler_multipod.jac`'s hand-rolled gate becomes the first-party one:

```jac
if not HAS_APSCHEDULER { testskip('apscheduler not installed; covered in CI'); }
```
```jac
require_module("apscheduler");
```

**It stays inside the single test that imports apscheduler.** The file has five tests and only one needs the dependency, so gating the module would have skipped the other four: the same silent coverage loss this phase exists to remove, wearing a nicer API.

**Why the helper is new rather than a call into `jaclang.testing.requires`.** That module covers importable modules, tools on PATH, and opt-in flags. The pod binary is none of the three: it is a build artifact at a known path. `require_pod_binary` mirrors that module's strict semantics rather than pretending the binary is a tool.

Two things the change uncovered and fixes in passing: `start_server`'s docstring still claimed the 120s budget it had before the 300s rewrite, and `testskip` lost its last user in the scheduler file.

## Validation

Rig per TESTING.md part 1: `zig build -Ddev` from this checkout, capability deps re-pinned, native compiler kernel built in-tree. `jac --version` prints the dev banner naming the checkout.

**The gate was proven, not assumed.** With `zig-out/bin/jac` moved aside, on `microservices/test_seed_determinism.jac`:

| | before this PR | after |
|---|---|---|
| normal run | 8 passed | 7 passed, **1 skipped** |
| `JAC_TEST_STRICT=1` | 8 passed | 7 passed, **1 failed** |

and the strict failure names its cause:

```
AssertionError: missing build artifact '/home/kuggix/jac/jac/zig-out/bin/jac'
(run `zig build` to produce it); JAC_TEST_STRICT is set, so this is a failure
```

Every affected suite, one file per process under `JAC_TEST_STRICT=1` the way CI runs them, with the binary present:

| Suite | Result |
|---|---|
| `microservices/test_bundle_services.jac` | 24 passed |
| `microservices/test_app_precompile.jac` | 15 passed |
| `microservices/test_pvc_injector.jac` | 10 passed |
| `microservices/test_bundle_jacignore.jac` | 10 passed |
| `deploy/test_client_build_fail_fast.jac` | 9 passed |
| `microservices/test_seed_determinism.jac` | 8 passed |
| `microservices/test_fat_bundle.jac` | 6 passed |
| `server/test_scheduler_multipod.jac` | 5 passed |

87 tests, all green. `jac fmt --check --lintfix` and `jac check` clean on all nine changed files.

**Not run:** the rest of `server/`, `data/`, `misc/` and `deploy/`, which carry none of these gates, and no cluster leg.

## What this deliberately leaves alone

The remaining `HAS_*` references in the scale suites are not rig gates and are out of scope here: `misc/test_optional_deps.jac` has them as its subject under test, and `misc/test_k8s_ops.jac` and `test_firebase_auth_sso.jac` patch them as mocks, which belongs to phase 3.
