### PR TITLE
DO NOT MERGE: run test-runtime x5 to catch the /cl/__error__ flake with the #8844 probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
 
   jac-check:
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    if: ${{ false }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       # Reroute lane: see the jac check step below.
@@ -404,7 +404,7 @@ jobs:
   contribution-checks:
     name: Contribution Checks
     needs: changes
-    if: ${{ github.event_name != 'push' || needs.changes.outputs.docs == 'true' }}
+    if: ${{ false }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
@@ -455,7 +455,7 @@ jobs:
   # box ever dies again.
   test-compiler:
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    if: ${{ false }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -502,8 +502,13 @@ jobs:
   # Everything except the compiler tests.
   test-runtime:
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    if: ${{ true }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        attempt: [1, 2, 3, 4, 5]
+    name: test-runtime (attempt ${{ matrix.attempt }})
     env:
       JAC_NO_DEV_SOURCE: "1"
     steps:
@@ -554,7 +559,7 @@ jobs:
   #   off.
   test-in-package-sealed:
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' || needs.changes.outputs.byllm == 'true' }}
+    if: ${{ false }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -606,7 +611,7 @@ jobs:
 
   test-client:
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    if: ${{ false }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -645,7 +650,7 @@ jobs:
   # Those findings are a follow-up on the test files, not on this lane.
   test-packages-and-docs:
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.byllm == 'true' || needs.changes.outputs.docs == 'true' }}
+    if: ${{ false }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: ""
@@ -677,7 +682,7 @@ jobs:
 
   test-scale:
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' }}
+    if: ${{ false }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: ""
@@ -742,11 +747,7 @@ jobs:
   # built from this checkout.
   test-scale-k8s:
     needs: [changes, build-kit]
-    if: >-
-      (github.event_name != 'pull_request' ||
-       needs.changes.outputs.core == 'true' ||
-       needs.changes.outputs.scale == 'true') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-k8s')
+    if: ${{ false }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -821,7 +822,7 @@ jobs:
   # kit, binaries run under qemu-user.
   test-native-aarch64:
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
+    if: ${{ false }}
     runs-on: ubuntu-latest
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -850,7 +851,7 @@ jobs:
   # with, and an end-to-end fused-runtime boot of a freshly compiled na host.
   test-launcher-jac:
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
+    if: ${{ false }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
@@ -876,7 +877,7 @@ jobs:
   # covered by `jac test` in the kit lanes below.
   test-bootstrap:
     needs: changes
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    if: ${{ false }}
     strategy:
       fail-fast: false
       matrix:
@@ -898,7 +899,7 @@ jobs:
 
   test-jac-pack-smoke:
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' || needs.changes.outputs.byllm == 'true' }}
+    if: ${{ false }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -1211,7 +1212,7 @@ jobs:
   # one does not (it exercises the published installer, not this checkout).
   installer-test:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && needs.changes.outputs.installer == 'true') }}
+    if: ${{ false }}
     uses: ./.github/workflows/_installer.yml
     with:
       shellcheck: true
@@ -1224,7 +1225,7 @@ jobs:
   # on ordinary compiler churn, which is what put a 44-68 min leg on the
   # critical path of every native PR to begin with.
   macos-native:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'macos')) }}
+    if: ${{ false }}
     uses: ./.github/workflows/_macos-native.yml
 
   # Aggregate gate: branch protection requires only this context. A NEW job
@@ -1232,7 +1233,7 @@ jobs:
   # the gate instead of skipping it (skipped required checks count as passing).
   everything-passed:
     name: Everything Passed
-    if: always()
+    if: ${{ false }}
     needs:
       - changes
       - build-kit

--- a/jac/tests/runtimelib/test_client_status_document.jac
+++ b/jac/tests/runtimelib/test_client_status_document.jac
@@ -20,6 +20,21 @@ import from jaclang.testing.testing { JacTestClient }
 
 glob FIXTURES = str(Path(__file__).parent / "fixtures");
 
+"""Records every message the logger accepts, before any handler sees it.
+
+A logger filter runs at emit time on the logger object itself, so an empty
+tap separates "nothing was ever emitted to this logger" from "a handler or
+its stream dropped the record" -- the two causes an empty buffer conflates.
+"""
+obj _EmitTap {
+    has seen: list[str] = [];
+
+    def filter(record: any) -> bool {
+        self.seen.append(record.getMessage());
+        return True;
+    }
+}
+
 def _as_any(v: any) -> any {
     return v;
 }
@@ -276,11 +291,14 @@ test "the /cl/__error__ endpoint logs a rendered diagnostic with a Jac location"
         buf = io.StringIO();
         sink = logging.StreamHandler(buf);
         logger = logging.getLogger("jaclang.client_errors");
+        tap = _EmitTap();
         logger.addHandler(sink);
         # The sink must see the record whatever level the root logger was left
         # at, so the level is pinned here and restored below.
         old_level = logger.level;
         logger.setLevel(logging.ERROR);
+        logger.addFilter(tap);
+        attached_to = id(logger);
         _error_rate_limiter._seen = {};
         _error_rate_limiter._count = 0;
         client = JacTestClient.from_file(
@@ -308,10 +326,16 @@ test "the /cl/__error__ endpoint logs a rendered diagnostic with a Jac location"
             );
             sink.flush();
             logged = buf.getvalue();
+            live = logging.getLogger("jaclang.client_errors");
             assert "error[E7003]" in logged , (
                 f"diagnostic never reached the sink; response={body}; "
-                f"logger disabled={logger.disabled} level={logger.level} "
-                f"handlers={logger.handlers} propagate={logger.propagate}; "
+                f"emitted={len(tap.seen)} records={tap.seen}; "
+                f"logger id at attach={attached_to} at assert={id(live)}; "
+                f"sink still attached={sink in live.handlers}; "
+                f"disabled={live.disabled} level={live.level} "
+                f"effective={live.getEffectiveLevel()} "
+                f"global_disable={logging.root.manager.disable}; "
+                f"handlers={live.handlers} propagate={live.propagate}; "
                 f"buffer={logged!r}"
             );
             assert "--> app.jac:2" in logged , logged;
@@ -320,6 +344,7 @@ test "the /cl/__error__ endpoint logs a rendered diagnostic with a Jac location"
             assert "  Stack: TypeError" in logged , logged;
             assert "at app (app.jac:2:" in logged , logged;
         } finally {
+            logger.removeFilter(tap);
             logger.removeHandler(sink);
             logger.setLevel(old_level);
             client.close();


### PR DESCRIPTION
Throwaway experiment on top of #8923. Every CI job except `changes`, `build-kit` and `test-runtime` is disabled, and `test-runtime` runs as a five-way matrix with `fail-fast: false`, so the flake in item 3 of #8844 gets five chances to fire with the emit-time probe from #8923 in place. Any attempt that fails will print whether the record was ever emitted to the logger, the logger identity at attach vs assert, and the process-wide `logging.disable` value.

Do not merge: the ci.yml change exists only to run one lane repeatedly. Close after reading the logs.