### PR TITLE
fix(client): pin zod below 4.5, whose @__PURE__ annotations Rollup rejects and every client build fails on

### DIFF
--- a/jac/jaclang/client/npm_provider.jac
+++ b/jac/jaclang/client/npm_provider.jac
@@ -17,7 +17,7 @@ glob CORE_RUNTIME_DEPS: dict[str, str] = {
      },
      OPTIONAL_RUNTIME_DEPS: dict[str, str] = {
          "@tanstack/react-form": "^1.33.0",
-         "zod": "^4.3.6"
+         "zod": "~4.4.3"
      },
      CORE_DEV_DEPS: dict[str, str] = {
          "vite": "^6.4.1",

--- a/release_notes/unreleased/jaclang/8933.bugfix.md
+++ b/release_notes/unreleased/jaclang/8933.bugfix.md
@@ -1,0 +1,1 @@
+- **Client builds no longer fail on zod 4.5**: the client dependency table pinned zod as `^4.3.6`, so a fresh install picked up 4.5.x, whose `@__PURE__` annotations Rollup rejects, and every `vite build` exited non-zero. `GET /static/client.js` on a served app and the admin console then answered 503. zod is pinned to `~4.4.3`, the last release that builds.


### PR DESCRIPTION
## What this changes

One line in `jac/jaclang/client/npm_provider.jac`: the client dependency table's `"zod": "^4.3.6"` becomes `"zod": "~4.4.3"`.

## Why

zod 4.5.0 through 4.5.4 shipped on 2026-08-28 and 29 and place `@__PURE__` comments where Rollup refuses them:

```
node_modules/zod/v4/core/util.js (330:0): A comment
"// Wrapped in a `@__PURE__` IIFE: esbuild never tree-shakes a top-level initializer ..."
in "node_modules/zod/v4/core/util.js" contains an annotation that Rollup cannot interpret due to the position of the comment.
```

With a caret, a fresh install resolves to 4.5.4 and `vite build` exits non-zero. Anything that builds a client bundle then answers 503: `GET /static/client.js` on a served app, and the admin console, whose `index.html` is built by `build_admin_client` on first request.

## How it was isolated

On a tree that reproduces CI's failure exactly (zod 4.5.4, rollup 4.63.1, vite 6.4.3), each variable was held in turn and the build re-run against the real `jac run --serve` path:

| zod | rollup | `GET /static/client.js` |
|---|---|---|
| 4.5.4 | 4.63.1 | 503, annotation error in `util.js` / `regexes.js` |
| 4.5.4 | 4.62.5 | 503, same annotation error |
| 4.4.3 | 4.63.1 | build proceeds past zod (fails later only because that fixture declares no client app) |

Rollup's version does not change the outcome; zod's does. `~4.4.3` keeps the last release that builds and excludes the next minor, since the breakage arrived with one.

## Why the suite did not catch it

The two tests covering these endpoints, `server/test_serve.jac` static bundle and `server/test_admin.jac` admin index, asserted `status in [200, 503, 500]` and `in [200, 503]`, so a failed build passed. #8927 tightens them to `== 200`, and that PR is red on CI for exactly this reason; it is the end-to-end confirmation of this fix once rebased onto it.

A developer box with an older zod already in bun's cache keeps resolving the caret to the cached version and never sees the failure, which is why this read as CI-only for a while.

## Validation

Rig per TESTING.md part 1: `zig build -Ddev` from this checkout with the native compiler kernel built in-tree. `jac fmt --check --lintfix` and `jac check` clean on the changed file. The table above is the behavioural evidence; the definitive run is CI's `test-scale (server)` on #8927 after it rebases onto this.

**Not run:** any suite that does not build a client bundle. This changes one dependency pin and no code.
