### PR TITLE
ci: the jac-kit action checks its download against a manifest sealed into the kit, and fetches again on a miss

### DIFF
--- a/.github/actions/jac-kit/action.yml
+++ b/.github/actions/jac-kit/action.yml
@@ -1,11 +1,12 @@
 name: Get jac kit
 description: >
   Download the kit artifact into the checkout (binary, typeshed stubs, vendored
-  musl/wasm runtimes land at their in-tree paths), put jac on PATH, and warm
-  its runtime cache. The kit is the binary built from this checkout
-  (build-kit); the job's JAC_NO_DEV_SOURCE decides whether it runs sealed
-  ("1") or through the [dev] reroute (""). upload-artifact strips the
-  executable bit; restore it.
+  musl/wasm runtimes land at their in-tree paths), check it against the
+  manifest build-kit sealed into it, put jac on PATH, and warm its runtime
+  cache. The kit is the binary built from this checkout (build-kit); the
+  job's JAC_NO_DEV_SOURCE decides whether it runs sealed ("1") or through
+  the [dev] reroute (""). upload-artifact strips the executable bit; restore
+  it.
 inputs:
   name:
     description: Kit artifact name
@@ -18,6 +19,38 @@ runs:
       with:
         name: ${{ inputs.name }}
         path: jac
+
+    # download-artifact can report success on a download it never finished:
+    # when the blob stream stalls mid-extraction the step exits 0 with the
+    # files extracted so far, the last of them cut short, and without its
+    # "download completed" line (main run 33816389635: four jobs spent 70s on
+    # a kit the other jobs fetched in 7s, then died on a jac binary with no
+    # payload trailer). Check every file against the manifest; on a miss,
+    # fetch once more and check again, so a stall costs a retry, not the job.
+    - name: Check the kit against its manifest
+      id: check
+      shell: bash
+      working-directory: jac
+      run: |
+        if bash "$GITHUB_ACTION_PATH/manifest.sh" check; then
+          echo "ok=1" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::kit download is incomplete; fetching it again"
+          echo "ok=0" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Fetch the kit again
+      if: steps.check.outputs.ok != '1'
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        path: jac
+
+    - name: Check the kit again
+      if: steps.check.outputs.ok != '1'
+      shell: bash
+      working-directory: jac
+      run: bash "$GITHUB_ACTION_PATH/manifest.sh" check
 
     - shell: bash
       run: |

--- a/.github/actions/jac-kit/manifest.sh
+++ b/.github/actions/jac-kit/manifest.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# The kit manifest. Run from jac/ on both sides of the artifact:
+#
+#   manifest.sh write <kit paths...>   (build-kit, right before the upload)
+#   manifest.sh check                  (the jac-kit action, after the download)
+#
+# `write` hashes every file under the kit paths into zig-out/kit.sha256 and
+# hashes that file into zig-out/kit.sha256.sha256, so a manifest cut short by
+# the same truncation it exists to catch cannot vouch for the files after it.
+# `check` verifies both, strictly: a short, unreadable, or improperly
+# formatted line fails the check instead of warning past it.
+set -euo pipefail
+
+if command -v sha256sum >/dev/null 2>&1; then
+  SUM=(sha256sum)
+else
+  SUM=(shasum -a 256)
+fi
+MANIFEST=zig-out/kit.sha256
+
+case "${1:-}" in
+  write)
+    shift
+    [ $# -gt 0 ] || { echo "manifest.sh write: no kit paths given" >&2; exit 2; }
+    find "$@" -type f -print0 | LC_ALL=C sort -z | xargs -0 "${SUM[@]}" > "$MANIFEST"
+    "${SUM[@]}" "$MANIFEST" > "$MANIFEST.sha256"
+    echo "kit manifest: $(wc -l < "$MANIFEST" | tr -d ' ') files"
+    ;;
+  check)
+    "${SUM[@]}" --strict --quiet -c "$MANIFEST.sha256"
+    "${SUM[@]}" --strict --quiet -c "$MANIFEST"
+    echo "kit verified: $(wc -l < "$MANIFEST" | tr -d ' ') files"
+    ;;
+  *)
+    echo "usage: manifest.sh write <kit paths...> | check" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/_macos-native.yml
+++ b/.github/workflows/_macos-native.yml
@@ -49,14 +49,17 @@ jobs:
           zig build fetch-typeshed --summary all
           zig build vendor-wasm-libc --summary all
 
-      - name: Verify the kit is complete
+      # Same shape as build-kit in ci.yml: assert each tree, then seal the
+      # manifest the jac-kit action checks its download against.
+      - name: Verify the kit is complete and write its manifest
         working-directory: jac
         run: |
           set -euo pipefail
-          for p in zig-out/bin/jac jaclang/vendor/typeshed/stdlib \
-                   .pbs-build/wasm32/libc; do
+          kit=(zig-out/bin/jac jaclang/vendor/typeshed/stdlib .pbs-build/wasm32/libc)
+          for p in "${kit[@]}"; do
             [ -e "$p" ] || { echo "::error::kit is missing $p"; exit 1; }
           done
+          bash "$GITHUB_WORKSPACE/.github/actions/jac-kit/manifest.sh" write "${kit[@]}"
 
       - name: Upload the kit
         uses: actions/upload-artifact@v4
@@ -64,6 +67,8 @@ jobs:
           name: jac-kit-macos
           path: |
             jac/zig-out/bin/jac
+            jac/zig-out/kit.sha256
+            jac/zig-out/kit.sha256.sha256
             jac/jaclang/vendor/typeshed/stdlib
             jac/.pbs-build/wasm32/libc
           include-hidden-files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,17 +167,22 @@ jobs:
           env -i HOME="$WORK" PATH=/usr/bin:/bin JAC_TEST_JOBS=0 JAC_NO_DEV_SOURCE=1 "$BIN" test "$WORK/test_smoke.jac"
 
       # if-no-files-found only fires when NO path matches, so a single missing
-      # tree ships a quietly incomplete kit to every consumer. Assert each one.
-      - name: Verify the kit is complete
+      # tree ships a quietly incomplete kit to every consumer. Assert each one,
+      # then seal a manifest of every kit file into the kit: the jac-kit
+      # action checks its download against it, because download-artifact can
+      # hand over a truncated kit and still report success.
+      - name: Verify the kit is complete and write its manifest
         working-directory: jac
         run: |
           set -euo pipefail
-          for p in zig-out/bin/jac jaclang/vendor/typeshed/stdlib \
-                   .pbs-build/linux-x86_64/musl/lib \
-                   .pbs-build/linux-aarch64/musl/lib \
-                   .pbs-build/wasm32/libc; do
+          kit=(zig-out/bin/jac jaclang/vendor/typeshed/stdlib
+               .pbs-build/linux-x86_64/musl/lib
+               .pbs-build/linux-aarch64/musl/lib
+               .pbs-build/wasm32/libc)
+          for p in "${kit[@]}"; do
             [ -e "$p" ] || { echo "::error::kit is missing $p"; exit 1; }
           done
+          bash "$GITHUB_WORKSPACE/.github/actions/jac-kit/manifest.sh" write "${kit[@]}"
 
       - name: Upload the kit
         uses: actions/upload-artifact@v4
@@ -185,6 +190,8 @@ jobs:
           name: jac-kit
           path: |
             jac/zig-out/bin/jac
+            jac/zig-out/kit.sha256
+            jac/zig-out/kit.sha256.sha256
             jac/jaclang/vendor/typeshed/stdlib
             jac/.pbs-build/linux-x86_64/musl/lib
             jac/.pbs-build/linux-aarch64/musl/lib


### PR DESCRIPTION
## What failed on main

The CI run for 8081ec800 ([run 33816389635](https://github.com/jaseci-labs/jaseci/actions/runs/33816389635)) failed in test-jac-pack-smoke and test-scale (microservices, data, server). All four died in the jac-kit action's warm-up step with:

```
jac (launcher): no runtime payload trailer (this is not a bundled jac binary)
```

The kit itself was whole: the same artifact (ID 9917157116) ran in every other lane of that run, and build-kit had already smoked the binary with its 110 MiB payload. In the four failing jobs `actions/download-artifact@v4` took about 70s instead of about 7s, never printed its "SHA256 digest of downloaded artifact" / "Artifact download completed successfully" lines, and still ended with outcome=success. The blob stream stalled mid-extraction, the step exited 0, and the jobs ran a jac binary cut short of its payload trailer.

(The Release run that failed at the same commit was a re-dispatch of an already-tagged v0.37.3 and passed on the next dispatch; nothing to fix there.)

## The fix

- build-kit (ci.yml) and build-kit-macos (_macos-native.yml) seal a manifest into the kit: `zig-out/kit.sha256` hashes every kit file, and `zig-out/kit.sha256.sha256` hashes the manifest, so a manifest cut short by the same truncation cannot vouch for the files after it.
- The jac-kit action checks its download against the manifest right after `download-artifact`, strictly (a short, missing, or malformed line fails). On a miss it warns, fetches the artifact once more, and checks again, so a stalled download costs a retry instead of the job.
- `.github/actions/jac-kit/manifest.sh` holds both sides (`write` / `check`). It uses `sha256sum` where present and `shasum -a 256` otherwise, so the macOS lane's kit gets the same treatment.

## Verified

- manifest.sh exercised locally against a fake kit tree: a clean check passes; a truncated binary, a missing file, a manifest cut at a line boundary, a missing manifest, and a missing manifest-of-manifest each fail with exit 1; writing with one hash tool and checking with the other agrees.
- The three YAML files parse; shellcheck is clean on the script; actionlint reports nothing new in the changed ranges.
