### PR TITLE
test(compiler): a warm client build over a real layout is served from the cache, and the legacy HMR path reads the artifact

### DIFF
--- a/jac/jaclang/server/impl/hmr.impl.jac
+++ b/jac/jaclang/server/impl/hmr.impl.jac
@@ -599,7 +599,7 @@ impl HotReloader._recompile_client_code(
         program.drop_module_alerts(source_key);
 
         mark = len(program.errors_had);
-        mod = program.compile(source_key);
+        artifact = program.get_client_artifact(source_key);
 
         new_errors = program.errors_had[mark:];
         if new_errors {
@@ -615,9 +615,7 @@ impl HotReloader._recompile_client_code(
             }
             return;
         }
-
-        js_code = mod.gen.js or '';
-        if not js_code {
+        if artifact is None {
             if force {
                 console.warning(f"No client JS generated for {file_path}");
             }
@@ -625,10 +623,10 @@ impl HotReloader._recompile_client_code(
         }
 
         import from jaclang.client.client_surface { prepend_active_runtime_globals }
-        js_code = prepend_active_runtime_globals(js_code);
+        js_code = prepend_active_runtime_globals(artifact.js);
 
-        manifest = mod.gen.client_manifest if mod else None;
-        if manifest and manifest.imports {
+        manifest = artifact.manifest;
+        if manifest.imports {
             for (import_key, import_path) in manifest.imports.items() {
                 if import_key.startswith('@jac/') {
                     continue;

--- a/jac/tests/client/test_client_build_warm_start.jac
+++ b/jac/tests/client/test_client_build_warm_start.jac
@@ -1,0 +1,163 @@
+"""A warm client build over a real project layout compiles nothing.
+
+The unit tests for the client artifact cache drive one module through
+`get_client_artifact`. The site that motivated the cache has pages, shared
+components in subdirectories, and an entry that imports them, and its warm
+build still recompiled everything: the cache root followed the ambient project
+config, which is unset during parts of a `jac run`, so entries were written
+under the project and looked for beside each module. This test builds such a
+project through the client compiler once, then requires a warm build, a warm
+build with the ambient config pinned away, and the build after an HMR edit to
+enter the compiler only for what actually changed, leaving no cache directory
+beside any module.
+"""
+
+import os;
+import tempfile;
+import time;
+import from pathlib { Path }
+import from jaclang.compiler.driver.pass_driver { compile_progress }
+import from jaclang.project.config {
+    get_config,
+    pin_project_scope,
+    project_scope_is_pinned,
+    set_config
+}
+import from jaclang.runtime.runtime { JacRuntime as Jac }
+
+
+glob _BUTTON: str = (
+         'def:pub Button(label: str) -> any {\n    return <button>{label}</button>;\n}\n'
+     );
+
+
+"""A web-app with an entry, a shared component tree, and two routed pages."""
+def _project -> Path {
+    proj = Path(os.path.realpath(tempfile.mkdtemp(prefix="jac_warm_build_")));
+    (proj / "jac.toml").write_text('[project]\nname = "warmsite"\nkind = "web-app"\n');
+    (proj / "package.json").write_text('{"name":"warmsite","version":"0.0.0"}');
+    (proj / "shared" / "ui").mkdir(parents=True);
+    (proj / "pages").mkdir();
+    (proj / "shared" / "ui" / "button.jac").write_text(_BUTTON);
+    (proj / "shared" / "Navbar.jac").write_text(
+        'import from .ui.button { Button }\n\n'
+        'def:pub Navbar() -> any {\n    return <nav><Button label="home" /></nav>;\n}\n'
+    );
+    (proj / "pages" / "index.jac").write_text(
+        'import from ..shared.Navbar { Navbar }\n\n'
+        'def:pub page -> JsxPage {\n    return <div><Navbar /></div>;\n}\n'
+    );
+    (proj / "pages" / "about.jac").write_text(
+        'def:pub page -> JsxPage {\n    return <p>about</p>;\n}\n'
+    );
+    (proj / "main.jac").write_text(
+        'import from .shared.Navbar { Navbar }\n\n'
+        'def:pub app() -> any {\n    return <main><Navbar /></main>;\n}\n'
+    );
+    return proj;
+}
+
+
+"""The project's client compiler, writing under `out`."""
+def _compiler(proj: Path) -> any {
+    import from jaclang.client.vite_client_bundle { ViteClientBundleBuilder }
+    builder = ViteClientBundleBuilder(vite_package_json=proj / "package.json");
+    compiler = builder._get_compiler();
+    compiler.jac_client_compiler.compiled_dir = proj / "out";
+    return compiler;
+}
+
+
+"""Run the client build; return the modules that entered the compiler."""
+def _build(proj: Path) -> list[str] {
+    seen: list[str] = [];
+    with compile_progress.listen(seen.append) {
+        _compiler(proj).jac_client_compiler.compile(None, proj / "main.jac");
+    }
+    return [os.path.basename(p) for p in seen];
+}
+
+
+"""Rewrite `path`, stamped clearly later than any cache file."""
+def _edit(path: Path, text: str) {
+    path.write_text(text);
+    later = time.time() + 5.0;
+    os.utime(str(path), (later, later));
+}
+
+
+"""Cache directories that landed beside a module instead of under the project."""
+def _stray_caches(proj: Path) -> list[str] {
+    return [
+        str(p.relative_to(proj))
+        for p in proj.rglob(".jac")
+        if p.is_dir() and p.parent != proj
+    ];
+}
+
+
+test "a warm client build over a real layout is served from the cache" {
+    import from jaclang.server.hmr { HotReloader }
+    import from jaclang.server.watcher { JacFileWatcher }
+    proj = _project();
+
+    cold = _build(proj);
+    for name in ["main.jac", "Navbar.jac", "button.jac", "index.jac", "about.jac"] {
+        assert name in cold , f"the cold build must compile {name}, saw {cold}";
+    }
+    warm = _build(proj);
+    assert warm == [] , f"the warm build must be served from the cache, compiled {warm}";
+
+    pinned = project_scope_is_pinned();
+    saved = get_config();
+    try {
+        pin_project_scope(None);
+        unconfigured = _build(proj);
+    } finally {
+        if pinned {
+            pin_project_scope(saved);
+        } else {
+            set_config(None);
+            get_config(force_discover=True);
+        }
+    }
+    assert unconfigured == [] , (
+        f"with no ambient config the warm build must still find its cache, "
+        f"compiled {unconfigured}"
+    );
+    assert _stray_caches(proj) == [] , (
+        f"cache entries must live under the project, found {_stray_caches(proj)}"
+    );
+
+    button = proj / "shared" / "ui" / "button.jac";
+    _edit(button, _BUTTON.replace("{label}", "clicked {label}"));
+    reloader = HotReloader(
+        base_path=str(proj),
+        module_name="main",
+        watcher=JacFileWatcher(watch_paths=[str(proj)]),
+        client_compiler=_compiler(proj)
+    );
+    reloader._running = True;
+    edited: list[str] = [];
+    with compile_progress.listen(edited.append) {
+        reloader._recompile_client_unified(str(button));
+    }
+    assert any(p.endswith("button.jac") for p in edited) , (
+        f"an HMR edit must recompile the edited module, saw {edited}"
+    );
+    assert "clicked" in (proj / "out" / "shared" / "ui" / "button.js").read_text() , (
+        "the HMR output must carry the edit"
+    );
+
+    Jac.get_program().hub.reset();
+    after = _build(proj);
+    assert "Navbar.jac" in after , (
+        f"the module that imports the edited one must recompile, saw {after}"
+    );
+    for name in ["main.jac", "index.jac", "about.jac"] {
+        assert name not in after , (
+            f"{name} imports nothing that changed and must be served, saw {after}"
+        );
+    }
+    assert _build(proj) == [] , "the build after that must be fully served again";
+}

--- a/jac/tests/compiler/test_module_cache_root.jac
+++ b/jac/tests/compiler/test_module_cache_root.jac
@@ -11,8 +11,19 @@ looked for later beside the file, and recompiled. The root now follows the
 import os;
 import tempfile;
 import from pathlib { Path }
-import from jaclang.compiler.driver.jir { get_module_cache_path }
-import from jaclang.project.config { get_config, project_scope_is_pinned, set_config }
+import jaclang.compiler.driver.compile_options as compile_options;
+import jaclang.compiler.placement.placement_pins as placement_pins;
+import from jaclang.compiler.driver.jir {
+    get_module_cache_path,
+    module_env_fingerprint
+}
+import from jaclang.project.config {
+    get_config,
+    get_config_for_path,
+    pin_project_scope,
+    project_scope_is_pinned,
+    set_config
+}
 
 
 test "a module's cache path follows the jac.toml above it, not the ambient config" {
@@ -45,4 +56,49 @@ test "a module's cache path follows the jac.toml above it, not the ambient confi
         "the cache path must not depend on the ambient config: "
         f"{without_ambient} vs {with_ambient}"
     );
+}
+
+
+test "a module's env key is the same inside and outside the config probe guards" {
+    # The analysis identity used to come from an ambient CompileOptions whose
+    # re-entrancy guard answers "no config" while another one is being built, so
+    # a module first keyed inside another compile was keyed one way on read and
+    # another on write, and recompiled on every run.
+    base = Path(os.path.realpath(tempfile.mkdtemp(prefix="jac_key_purity_")));
+    (base / "jac.toml").write_text(
+        '[project]\nname = "keyed"\n\n[gc]\ndefault = "none"\n'
+    );
+    mod = base / "util.jac";
+    mod.write_text("def two -> int {\n    return 2;\n}\n");
+    import jaclang;
+    internal = str(
+        Path(str(jaclang.__file__)).parent / "compiler" / "symbol_utils.jac"
+    );
+    pinned = project_scope_is_pinned();
+    saved = get_config();
+    try {
+        pin_project_scope(get_config_for_path(base));
+        for path in [str(mod), internal] {
+            plain = module_env_fingerprint(path);
+            compile_options._config_probe["active"] = True;
+            placement_pins._kind_probe["active"] = True;
+            try {
+                guarded = module_env_fingerprint(path);
+            } finally {
+                compile_options._config_probe["active"] = False;
+                placement_pins._kind_probe["active"] = False;
+            }
+            assert plain == guarded , (
+                f"the env key of {os.path.basename(path)} must not depend on the "
+                "config probe guards"
+            );
+        }
+    } finally {
+        if pinned {
+            pin_project_scope(saved);
+        } else {
+            set_config(None);
+            get_config(force_discover=True);
+        }
+    }
 }

--- a/release_notes/unreleased/jaclang/8958.bugfix.md
+++ b/release_notes/unreleased/jaclang/8958.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: HMR without a client compiler reads the client artifact**: The legacy hot-reload fallback recompiled an edited module with its own compile call and read the generated JS off the module; it now goes through the same cached client artifact as the initial build and the unified reload path, so every module that turns into client JS does so through one path.


### PR DESCRIPTION
## What this changes

Follow-up to #8945. That PR's unit tests drove one module through `get_client_artifact` and passed while a real site still recompiled everything on a warm start; the two cache defects it went on to fix were only found by measuring the site. This adds tests that pin the class of failure rather than the instances, and closes the one client-JS path that still bypassed the artifact.

### Tests

- `tests/client/test_client_build_warm_start.jac`: a project with an entry, a shared component tree in subdirectories, and two routed pages is built through the client compiler once. The warm build, the warm build with the ambient project config pinned away, and the build after an HMR edit to a leaf component must enter the compiler only for what changed (the edited module, then the module that imports it), and no cache directory may appear beside any module. About five seconds with a warm compiler. Against the pre-#8945-fix cache code it fails with the site's exact symptom (`shared/.jac`, `pages/.jac`, `shared/ui/.jac`).
- `tests/compiler/test_module_cache_root.jac`: a module's env key must be the same inside and outside the config probe guards, under a project whose gc setting differs from the default, which is the configuration that made the key flip. Also verified to fail against the pre-fix code.

### HMR

The unified HMR path already went through `compile_dependencies_recursively`, so an edit refreshes the artifact cache. The legacy fallback (no client compiler) ran its own `program.compile` and read `mod.gen.js`; it now reads the client artifact, so every module that turns into client JS does so through one path. The HMR suites pass.
