### PR TITLE
ci: nightly sweep closes stale unlabeled issues and PRs from members and collaborators

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,112 @@
+name: Close Stale
+
+# Nightly sweep over open issues and PRs that satisfy all three of:
+#   1. no label at all (labeling an item is how you pin it open),
+#   2. opened by someone with access to this repo (an org member or a
+#      collaborator); external contributors' items are never touched,
+#   3. no activity of any kind for DAYS days (GitHub's updated_at, which
+#      moves on comments, edits, labels, reviews, and pushes).
+# Each match gets one comment and is closed (issues as "not planned").
+# Runs are capped so they stay under GitHub's ~500 comments/hour secondary
+# limit; whatever the cap leaves waits for the next night. A manual
+# dispatch defaults to a dry run that only lists the matches.
+
+on:
+  schedule:
+    - cron: '23 4 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Only list what would be closed'
+        type: boolean
+        default: true
+      days:
+        description: 'Days without activity before an item is closed'
+        type: string
+        default: '10'
+      max_ops:
+        description: 'Maximum items to close in one run'
+        type: string
+        default: '150'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: close-stale
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Close stale unlabeled internal issues and PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run == true }}
+          DAYS: ${{ inputs.days || '10' }}
+          MAX_OPS: ${{ inputs.max_ops || '150' }}
+        run: |
+          set -euo pipefail
+          cutoff=$(date -u -d "$DAYS days ago" +%Y-%m-%dT%H:%M:%S+00:00)
+          msg="Closing: no activity in ${DAYS}+ days. Reopen if still relevant."
+
+          # Everyone with access: org members (via teams or the org's base
+          # permission) plus outside collaborators. A failed lookup leaves
+          # the list empty, which can only narrow the sweep, never widen it.
+          gh api "repos/$REPO/collaborators?affiliation=all&per_page=100" --paginate \
+            --jq '.[].login' | sort -u > collaborators.txt || true
+
+          # Server-side filter, oldest first so a capped run drains in order.
+          gh api -X GET search/issues --paginate \
+            -f q="repo:$REPO is:open no:label updated:<$cutoff" \
+            -f per_page=100 -f sort=updated -f order=asc \
+            --jq '.items[] | [.number, (if .pull_request then "pr" else "issue" end), .user.login, .author_association, .updated_at] | @tsv' \
+            > candidates.tsv
+
+          # Internal = on the access list, or GitHub itself reports the
+          # author as an owner, member, or collaborator of this repo.
+          awk -F'\t' -v cols=collaborators.txt '
+            BEGIN { while ((getline l < cols) > 0) c[l] = 1 }
+            ($3 in c) || $4 == "OWNER" || $4 == "MEMBER" || $4 == "COLLABORATOR" { print }
+          ' candidates.tsv > eligible.tsv
+
+          echo "cutoff=$cutoff collaborators=$(wc -l < collaborators.txt) candidates=$(wc -l < candidates.tsv) eligible=$(wc -l < eligible.tsv) cap=$MAX_OPS dry_run=$DRY_RUN"
+
+          taken=0
+          closed=0
+          failed=0
+          while IFS=$'\t' read -r num kind login assoc updated; do
+            if [ "$taken" -ge "$MAX_OPS" ]; then
+              echo "cap of $MAX_OPS reached; the rest waits for the next run"
+              break
+            fi
+            taken=$((taken + 1))
+            echo "$kind #$num by $login ($assoc), last activity $updated"
+            [ "$DRY_RUN" = true ] && continue
+            ok=0
+            for attempt in 1 2 3 4 5; do
+              if [ "$kind" = pr ]; then
+                gh pr close "$num" -R "$REPO" --comment "$msg" && { ok=1; break; }
+              else
+                gh issue close "$num" -R "$REPO" --reason "not planned" --comment "$msg" && { ok=1; break; }
+              fi
+              # "was submitted too quickly" is the comment-rate limit; back off.
+              echo "  attempt $attempt failed, backing off"
+              sleep $((120 * attempt))
+            done
+            if [ "$ok" = 1 ]; then
+              closed=$((closed + 1))
+            else
+              failed=$((failed + 1))
+              echo "  FAILED $kind #$num"
+            fi
+            sleep 8
+          done < eligible.tsv
+
+          echo "taken=$taken closed=$closed failed=$failed"
+          if [ "$failed" -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
## What

A nightly workflow, `.github/workflows/close-stale.yml`, closes open issues and PRs that meet all three conditions:

1. **No label at all.** Any label pins an item open.
2. **Opened by a member or collaborator.** Items from external contributors are never touched.
3. **No activity for 10 days**, by GitHub's `updated_at` (comments, edits, labels, reviews, pushes all count).

Each match gets one comment (`Closing: no activity in 10+ days. Reopen if still relevant.`) and is closed; issues close as "not planned".

## Why not `actions/stale`

It has no author filter. Its only positive filters are labels, milestones, and assignees, so "members and collaborators only" can't be expressed. This is a ~60-line script step using `gh` instead.

## How internal is decided

The search API returns each item's `author_association`. Separately, the step fetches `repos/{repo}/collaborators?affiliation=all`, which lists org members with access plus outside collaborators (45 people today). An author is internal if they're on that list **or** GitHub reports them as `OWNER`/`MEMBER`/`COLLABORATOR`. If the collaborator lookup fails the list is empty, which can only shrink the sweep, never widen it.

## Rate limiting

A bulk close on 2026-09-03 tripped GitHub's secondary limit (~500 comment creations per rolling hour) at item 497. This run caps at 150 closes, waits 8s between them, and backs off 2/4/6/8/10 minutes on failure. Anything past the cap waits for the next night. Oldest items go first.

## Operating it

- `workflow_dispatch` defaults to **dry run**: it lists what would be closed and touches nothing. Inputs: `dry_run`, `days` (default 10), `max_ops` (default 150).
- Schedule: 04:23 UTC daily. `concurrency` prevents overlapping runs.
- Closes appear as `github-actions[bot]`.

## Validation

The step body was executed locally against this repo in dry-run mode (it's plain bash + `gh`, so it runs unchanged outside Actions):

```
cutoff=2026-08-25T11:17:11+00:00 collaborators=45 candidates=7 eligible=7 cap=150 dry_run=true
pr #8674 by SandeepaHWP (COLLABORATOR), last activity 2026-08-25T02:09:07Z
issue #8687 by akindu-k (COLLABORATOR), last activity 2026-08-25T04:43:02Z
issue #8688 by akindu-k (COLLABORATOR), last activity 2026-08-25T08:49:35Z
issue #8694 by Developer-Linus (COLLABORATOR), last activity 2026-08-25T09:08:46Z
issue #8696 by kugesan1105 (MEMBER), last activity 2026-08-25T09:09:29Z
issue #8697 by kugesan1105 (MEMBER), last activity 2026-08-25T09:09:37Z
issue #8698 by kugesan1105 (MEMBER), last activity 2026-08-25T09:09:42Z
taken=7 closed=0 failed=0
```

Also checked: the cap path (`max_ops=3` stops after 3 and says so), a 400-day cutoff yields zero candidates, and synthetic `CONTRIBUTOR` / `FIRST_TIME_CONTRIBUTOR` / `NONE` / bot rows are filtered out both with and without the collaborator list. YAML parses; no `${{ }}` inside the script body (all inputs arrive as env vars).

No release-note fragment: workflow-only change.

