### PR TITLE
backport(scale): a range pin resolves to a jac release, not a jaseci tag

### DIFF
--- a/jac/jaclang/scale/injector/binary.jac
+++ b/jac/jaclang/scale/injector/binary.jac
@@ -179,8 +179,20 @@ def _list_release_versions(repo: str) -> list[str] {
     out: list[str] = [];
     for rel in arr {
         tag = str(rel.get("tag_name", ""));
-        if tag.startswith("v") and not rel.get("prerelease", False) {
-            out.append(tag[1:]);
+        if (
+            not tag.startswith("v")
+            or rel.get("prerelease", False)
+            or rel.get("draft", False)
+        ) {
+            continue;
+        }
+        version = tag[1:];
+        prefix = f"jac-{version}-";
+        for asset in rel.get("assets", []) {
+            if str(asset.get("name", "")).startswith(prefix) {
+                out.append(version);
+                break;
+            }
         }
     }
     return out;

--- a/jac/jaclang/scale/tests/test_version_pin.jac
+++ b/jac/jaclang/scale/tests/test_version_pin.jac
@@ -77,6 +77,31 @@ test "a range picks the newest published release that satisfies it" {
 }
 
 
+test "only a release whose tag names its own binary is a candidate" {
+    # jac#8960: the retired jaseci meta-package tags are numerically larger
+    # than every jac tag, so an open-ended range resolved to 2.3.28 and the
+    # deploy aborted on a release shipping no jac-2.3.28 binary. v2.3.27 is the
+    # trap: it ships a real jac binary, but of a version its tag does not name.
+    releases = json.dumps(
+        [
+            {"tag_name": "v0.37.3", "assets": [{"name": "jac-0.37.3-linux-x86_64"}]},
+            {"tag_name": "v2.3.28", "assets": [{"name": "jaseci-2.3.28.tar.gz"}]},
+            {"tag_name": "v2.3.27", "assets": [{"name": "jac-0.16.6-linux-x86_64"}]},
+            {"tag_name": "v0.38.0", "draft": True, "assets": []}
+        ]
+    ).encode(
+        "utf-8"
+    );
+    with unittest.mock.patch.object(
+        binary_mod, "_http_get_bytes", return_value=releases
+    ) {
+        assert binary_mod._list_release_versions(REPO) == ["0.37.3"];
+        assert _resolve_target_version(REPO, ">=0.37.3") == "0.37.3";
+        assert _resolve_target_version(REPO, ">=0.34") == "0.37.3";
+    }
+}
+
+
 test "a malformed spec resolves to '' (no target)" {
     with unittest.mock.patch.object(
         binary_mod, "_list_release_versions", return_value=["0.34.3"]


### PR DESCRIPTION
Backport of #8961 to the 0.34 line. Fixes #8960 here.

The resolver is byte-identical between `v0.34.17`, `v0.37.3` and `main`, and 0.34
is what the jachammer deployer runs, which is where this was reported.

## The bug

`_list_release_versions` accepted every non-prerelease tag starting with `v`, so
the retired jaseci meta-package releases (`v2.3.2` through `v2.3.28`) stayed in
the candidate set. They are numerically larger than every jac tag, and
`_resolve_target_version` returns the numeric maximum, so any open-ended range
picked `2.3.28`:

```
jac-version = ">=0.37.3"   ->  2.3.28
jac-version = ">=0.34"     ->  2.3.28
```

The deploy then aborted on a release shipping no `jac-2.3.28` binary. Only `==`
and `~=` escaped it.

On this line the failure is worse than a bad error message: the deployer asks the
resolver, gets `2.3.28`, and the generation guard from #8777 refuses with "this
deployer is jac 0.34.17 and cannot deploy an app pinned to 2.3.28", so a project
actually pinned `>=0.37.3` is told it is pinned to a version it never named.

## The fix

A tag is a candidate only when it carries `jac-<tag version>-<platform>`, the
asset contract `download_release_binary` already relies on. Draft releases are
skipped for the same reason.

Filtering on "carries a `jac-*` asset" is not enough: `v2.3.27` ships a real
`jac-0.16.6-linux-x86_64` under a tag naming the meta-package version. A date
cutoff does not separate the lines either, the first self-named release is
`v0.30.0` on 2026-06-22 and the legacy line runs to 2026-06-25.

## Test

```
26 passed
```

Mutation checked on this branch. With the filter reverted:

```
1 failed, 25 passed
```

No release-note fragment: this branch has no `release_notes` tree.
