### PR TITLE
chore(examples): the jaclang.org site pins jac exactly, not by range

### DIFF
--- a/jac/examples/jaclang_org/jac.toml
+++ b/jac/examples/jaclang_org/jac.toml
@@ -2,7 +2,7 @@
 name = "jaclang_org"
 entry-point = "main.jac"
 kind = "web-app"
-jac-version = ">=0.37.3"
+jac-version = "==0.37.3"
 
 # Makes this site scaffoldable as a template: `jac create <name> --awesome`
 # dumps it (the payload bundles this tree as awesome_template beside the


### PR DESCRIPTION
Related to #8960. Not a fix: nothing in jac changes here.

## What this is

A one-line pin change in `jac/examples/jaclang_org/jac.toml`:

```diff
-jac-version = ">=0.37.3"
+jac-version = "==0.37.3"
```

The resolver defect is fixed in #8961 on `main` and #8962 on 0.34.18. This only
stops one example from taking the buggy path, so it is a workaround with a shelf
life, plus a configuration correction that stands on its own.

## Why it is needed now

A range resolves through the release listing, where the retired jaseci
meta-package tags are numerically larger than every jac tag, so a deployer picks
`2.3.28` and then aborts on a release that ships no `jac-2.3.28` binary. That is
how #8960 was reported: a user importing this site could not deploy it.

No 0.34.19 release is planned, so the deployers already in the field keep the
bug. An exact pin short-circuits in `_exact_of` before any listing happens, so
the site deploys on those deployers as well as on fixed ones.

## Why it is right regardless

This tree is also the `jac create <name> --awesome` template. A range pin means
every scaffolded project silently tracks whatever release is newest, which is not
what a reproducible template should do. An exact pin is the correct choice even
once every deployer carries #8961.

## Scope

`0.37.3` is the newest published release, so the pinned version does not change,
only how it is expressed. No release-note fragment, hence
`skip-release-notes-check`: this changes an example's configuration, not jac's
behaviour.
