### PR TITLE
test(runtimelib): pin the module identity of persisted built-in archetypes

### DIFF
--- a/jac/tests/runtimelib/test_layer3_coercion_alias.jac
+++ b/jac/tests/runtimelib/test_layer3_coercion_alias.jac
@@ -11,7 +11,7 @@ import logging;
 import from datetime { date, datetime, time }
 import from enum { Enum }
 import from uuid { UUID, uuid4 }
-import from jaclang.runtime.archetype { NodeAnchor, Root }
+import from jaclang.runtime.archetype { NodeAnchor, Root, GenericEdge }
 # archetype_alias is an ambient Jac builtin (no import). Serializer is
 # an explicit import because we directly test its internals here.
 import from jaclang.data.serializer { Serializer }
@@ -61,6 +61,45 @@ test "alias to same qualified name is a no-op (does not self-alias)" {
 test "_get_class returns None for truly unregistered class names" {
     resolved = Serializer._get_class("definitely.not", "Present");
     assert resolved is None;
+}
+
+
+# --- Persisted built-in identity manifest -----------------------------------
+#
+# jaclang's own built-in archetypes are pinned here on purpose. Their
+# fully-qualified name is part of the on-disk wire format (see
+# `Serializer._get_class` / `is_auto_registered_module`), so moving one of
+# these classes to a new module is a data migration, not just a refactor
+# (jaclang/issues/8747 is what happens when that migration is skipped).
+#
+# This intentionally lists only the *concrete* persisted archetypes -- the
+# base classes (NodeArchetype, EdgeArchetype, WalkerArchetype,
+# ObjectArchetype) are never instantiated as themselves, so no stored row
+# ever carries their name and moving them needs no alias.
+#
+# If this test starts failing because you moved one of these classes: don't
+# just update the entry below. First register the class's old fully-qualified
+# name as an alias in `data/serializer.jac`'s `_BUILTIN_MOVED_FROM`, so
+# existing databases keep resolving it -- then update this manifest to match.
+glob _PERSISTED_BUILTIN_IDENTITIES: dict[str, str] = {
+         'Root': 'jaclang.runtime.archetype',
+         'GenericEdge': 'jaclang.runtime.archetype'
+     };
+
+
+test "persisted built-ins keep their pinned module identity" {
+    live = {'Root': Root, 'GenericEdge': GenericEdge};
+    for (name, expected_module) in _PERSISTED_BUILTIN_IDENTITIES.items() {
+        cls = live[name];
+        actual = f"{getattr(cls, '__module__')}.{getattr(cls, '__name__')}";
+        expected = f"{expected_module}.{name}";
+        assert actual == expected , (
+            f"{name} moved from {expected} to {actual}. It is a persisted "
+            "built-in, so existing databases still carry the old module "
+            "name -- register it as an alias in data/serializer.jac's "
+            "_BUILTIN_MOVED_FROM before updating this manifest entry."
+        );
+    }
 }
 
 


### PR DESCRIPTION
## Summary

Follow-up to #8956 (fixes #8747). That PR aliased `Root`/`GenericEdge` to their pre-#8682 module path, but nothing stops the *next* package move from repeating the same silent failure: forgetting to add an alias produces no warning at review time, only a data-loss report from a user later. #8681 has more of these moves queued.

This adds a small guardrail instead of relying on someone remembering:

- `_PERSISTED_BUILTIN_IDENTITIES` pins the current fully-qualified name of every jaclang built-in that is actually persisted with a concrete `__type__` (today: `Root`, `GenericEdge`). Base archetypes (`NodeArchetype`, `EdgeArchetype`, `WalkerArchetype`, `ObjectArchetype`) are deliberately excluded — they're never instantiated as themselves, so no stored row ever carries their name.
- A test asserts each entry still resolves to that exact module/class. Moving one of these classes without touching this file fails the build; the assertion message points directly at `data/serializer.jac`'s `_BUILTIN_MOVED_FROM` (the mechanism `register_alias`/`schema_was` built for exactly this) instead of leaving the next contributor to rediscover #8747 from scratch.

Verified the guardrail actually fires, not just that it compiles: temporarily pointed the manifest at the wrong module and confirmed the exact intended failure message, then reverted before committing.

This intentionally does not attempt to fix the other gap identified during #8956's review — the destructive self-heal in `ExecutionContext._resolve_roots`, which can silently overwrite the system root anchor if it fails to materialize for *any* reason (not just this one). That's a materially different, riskier change to root-bootstrap semantics and belongs in its own issue/PR.

## Test plan

- [x] `JAC_TEST_JOBS=1 jac test jac/tests/runtimelib/test_layer3_coercion_alias.jac` — 22 passed.
- [x] Confirmed the new test fails with the intended message when the manifest is deliberately made stale (temporary local edit, reverted before commit).
- [x] `jac precommit` passes clean. No release-notes fragment needed (test-only change under `jac/tests/`).