### PR TITLE
test(scale): the mock list ratchets down, and a scale PR is asked how it was validated (#8897 phase 0e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,6 +443,14 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: bash scripts/check-release-notes.sh
+      # TESTING.md section 4: a scale change says what it ran and what it did
+      # not. A warning until #8896 phase 5 flips it to a failure.
+      - name: Check Scale Validation Section
+        if: github.event_name == 'pull_request'
+        env:
+          CI: "true"
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: bash scripts/check-scale-validation.sh
 
   # Compiler suite, one chunk per runner; chunking parallelizes the suite.
   # The native-backend chunk and the na/sv equivalence pins are chunks here.

--- a/jac/jaclang/scale/tests/TESTING.md
+++ b/jac/jaclang/scale/tests/TESTING.md
@@ -112,6 +112,10 @@ No `unittest.mock`, no monkeypatched collaborators, no fake gateway objects. A
 mock encodes the behaviour you assumed the collaborator has, which is the
 assumption the bug lives in.
 
+The remaining files that import `unittest.mock` are listed in
+`misc/test_mock_ratchet.jac`; a file not on that list that starts importing it
+fails the suite, and the list only shrinks.
+
 When a boundary must be stubbed, stub it with something real:
 
 - an in-process HTTP server instead of a fake transport,

--- a/jac/jaclang/scale/tests/misc/test_mock_ratchet.jac
+++ b/jac/jaclang/scale/tests/misc/test_mock_ratchet.jac
@@ -1,0 +1,93 @@
+"""The mock ratchet: the files that still import unittest.mock, and no more of them.
+
+TESTING.md 2.2 forbids mocks in the scale suites. Removing the existing ones
+is phase 3 of #8896; until then this list is the debt, exact in both
+directions. A file not listed here that starts importing `unittest.mock` or
+`MagicMock` fails the suite: write the test against a real collaborator, or
+argue the entry into this list in review. A listed file that stops importing
+them also fails, so the list is edited down and never quietly stale.
+"""
+
+import from pathlib { Path }
+
+glob TESTS_ROOT: Path = Path(__file__).parents[1],
+     SELF: str = str(Path(__file__).relative_to(TESTS_ROOT)),
+     ALLOWED: set[str] = {
+         "data/test_auth_cutover.jac",
+         "data/test_firebase_env.jac",
+         "data/test_gcs_storage.jac",
+         "data/test_identity_fail_loud.jac",
+         "data/test_s3_storage.jac",
+         "deploy/http_activation_test_support.jac",
+         "deploy/test_cluster_provider.jac",
+         "deploy/test_database_intent.jac",
+         "deploy/test_deploy_banner.jac",
+         "deploy/test_deploy_k8s.jac",
+         "deploy/test_deployer.jac",
+         "deploy/test_destroy_reclaim.jac",
+         "deploy/test_dry_run_purity.jac",
+         "deploy/test_factories.jac",
+         "deploy/test_http_activation_config.jac",
+         "deploy/test_http_activation_microservices.jac",
+         "deploy/test_ingress_deployer.jac",
+         "deploy/test_ingress_tls_preservation.jac",
+         "deploy/test_k8s_utils.jac",
+         "deploy/test_memory_trigger_guard.jac",
+         "deploy/test_pod_env.jac",
+         "deploy/test_superseded_deployment_reap.jac",
+         "deploy/test_version_pin.jac",
+         "microservices/test_binary_injector.jac",
+         "microservices/test_drain.jac",
+         "microservices/test_fleet_rollout.jac",
+         "microservices/test_plan.jac",
+         "microservices/test_stop_signal_scope.jac",
+         "misc/test_k8s_ops.jac",
+         "misc/test_metrics.jac",
+         "misc/test_optional_deps.jac",
+         "misc/test_prometheus_client.jac",
+         "misc/test_shared_store_failure.jac",
+         "server/test_firebase_auth_sso.jac",
+         "server/test_sso.jac"
+     };
+
+
+def _imports_mock(path: Path) -> bool {
+    text = path.read_text(encoding="utf-8");
+    return "unittest.mock" in text or "MagicMock" in text;
+}
+
+
+def _mock_importers -> set[str] {
+    found: set[str] = set();
+    for path in sorted(TESTS_ROOT.rglob("*.jac")) {
+        rel = str(path.relative_to(TESTS_ROOT));
+        if rel == SELF or rel.startswith("fixtures/") {
+            continue;
+        }
+        if _imports_mock(path) {
+            found.add(rel);
+        }
+    }
+    return found;
+}
+
+
+test "no scale test file outside the allowlist imports unittest.mock" {
+    new_importers = sorted(_mock_importers() - ALLOWED);
+    assert not new_importers , (
+        "these files import unittest.mock or MagicMock and are not on the "
+        f"allowlist in {SELF}: {new_importers}. TESTING.md 2.2: stub a boundary "
+        "with something real (an in-process server, a temporary Postgres, a "
+        "local cluster, a fixture app), not a mock. If this file genuinely "
+        "must mock, add it to ALLOWED in review with the reason in the PR."
+    );
+}
+
+
+test "every allowlisted file still imports unittest.mock, so the list shrinks with the debt" {
+    stale = sorted(ALLOWED - _mock_importers());
+    assert not stale , (
+        f"these ALLOWED entries no longer import unittest.mock: {stale}. "
+        f"Remove them from the list in {SELF}; the ratchet only turns one way."
+    );
+}

--- a/scripts/check-scale-validation.sh
+++ b/scripts/check-scale-validation.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# A PR that touches jac/jaclang/scale/** must say how it was validated.
+#
+# TESTING.md section 4 asks for three things in the PR body: the suites run,
+# by file, with counts; what was exercised by hand and where; and what was
+# NOT run, stated plainly. This check looks for a "Validation" heading and a
+# "not run" statement. Seeded as a warning; #8896 phase 5 makes it fail.
+#
+# Env: PR_BODY (the pull request description). Changed files come from the
+# same diff logic as check-release-notes.sh.
+set -euo pipefail
+
+if [ -n "${PRE_COMMIT_FROM_REF:-}" ] && [ -n "${PRE_COMMIT_TO_REF:-}" ]; then
+    CHANGED_FILES=$(git diff --name-only "$PRE_COMMIT_FROM_REF"..."$PRE_COMMIT_TO_REF" 2>/dev/null || true)
+elif [ "${CI:-}" = "true" ]; then
+    MERGE_BASE=$(git merge-base origin/main HEAD 2>/dev/null || echo "")
+    if [ -z "$MERGE_BASE" ]; then
+        git fetch --depth=200 origin main >/dev/null 2>&1 || true
+        MERGE_BASE=$(git merge-base origin/main HEAD 2>/dev/null || echo "")
+    fi
+    CHANGED_FILES=$(git diff --name-only "$MERGE_BASE"...HEAD 2>/dev/null || true)
+else
+    CHANGED_FILES=$(git diff --cached --name-only 2>/dev/null || true)
+fi
+
+SCALE_TOUCHED=$(printf '%s\n' "$CHANGED_FILES" | grep -E '^jac/jaclang/scale/' || true)
+if [ -z "$SCALE_TOUCHED" ]; then
+    echo "No jac/jaclang/scale changes; validation section not required."
+    exit 0
+fi
+
+BODY="${PR_BODY:-}"
+if [ -z "$BODY" ]; then
+    echo "::warning::No PR body available to check for a validation section."
+    exit 0
+fi
+
+MISSING=()
+if ! printf '%s\n' "$BODY" | grep -qiE '^#+[[:space:]]*validation'; then
+    MISSING+=("a '## Validation' heading (suites run by file with counts, and what was exercised by hand)")
+fi
+if ! printf '%s\n' "$BODY" | grep -qiE 'not run|did not run|was not run|nothing else (was )?run'; then
+    MISSING+=("a plain statement of what was NOT run")
+fi
+
+if [ ${#MISSING[@]} -eq 0 ]; then
+    echo "Validation section present for a scale change."
+    exit 0
+fi
+
+echo "::warning::This PR changes jac/jaclang/scale but its description is missing:"
+for m in "${MISSING[@]}"; do
+    echo "::warning::  - $m"
+done
+echo "::warning::See jac/jaclang/scale/tests/TESTING.md section 4. This becomes a failure in #8896 phase 5."
+exit 0


### PR DESCRIPTION
## What this changes

Part of #8896, phase 0e of #8897, the last phase 0 slice. Two ratchets, so the debt phase 0 measured cannot grow while phases 1 to 3 pay it down.

### The mock ratchet: `misc/test_mock_ratchet.jac`

TESTING.md §2.2 bans `unittest.mock` in the scale suites, and 35 files import it today. Removing them is phase 3. Until then this test holds the list of those 35 files and is exact in both directions, in the shape of `jac/tests/compiler/test_backend_purity.jac`'s debt table:

- a file **not** on the list that imports `unittest.mock` or `MagicMock` fails the `misc` group, naming the file and pointing at §2.2's real stand-ins;
- a listed file that **stops** importing it also fails, naming the stale entry, so the list is edited down and never quietly outlives the debt.

It scans `scale/tests/**/*.jac` excluding `fixtures/` and itself. The list is the measured state of `main` at this branch's base; two files joined it since the audit (`deploy/test_destroy_reclaim.jac` from #8699, `microservices/test_stop_signal_scope.jac`), which is exactly the regrowth the ratchet exists to make visible.

### The validation-section check: `scripts/check-scale-validation.sh`

TESTING.md §4 asks a scale PR to name the suites it ran with counts, what it exercised by hand, and what it did **not** run. Of 15 scale PR bodies sampled in the audit, two stated what was not run. The new `contribution-checks` step runs on every pull request; when the diff touches `jac/jaclang/scale/`, it looks for a `Validation` heading and a "not run" statement in the body. Changed files come from the same merge-base logic `check-release-notes.sh` uses.

**Seeded as a warning, deliberately.** It prints `::warning::` lines naming what is missing and exits 0. #8897 says phase 5 flips it to a failure once the rules are written into TESTING.md and the PR template; flipping it before that would fail contributors on a rule they have not been shown.

TESTING.md §2.2 gains two sentences pointing at the ratchet.

## Validation

Rig per TESTING.md part 1: `zig build -Ddev` from this checkout, capability deps re-pinned, native compiler kernel built in-tree. `jac fmt --check --lintfix` and `jac check` clean on the new test; `ci.yml` parses with the new step in place; the script passes `bash -n`.

**The ratchet was proven in both directions, not assumed:**

| Case | Result |
|---|---|
| baseline, 35 listed files | 2 passed |
| a throwaway `misc/test_zz_probe_mock.jac` importing `MagicMock` added | 1 failed: `not on the allowlist ... ['misc/test_zz_probe_mock.jac']` |
| a bogus entry `misc/test_zz_gone.jac` added to the list | 1 failed: `no longer import unittest.mock: ['misc/test_zz_gone.jac']` |

Both probes reverted; the committed file is the baseline.

**The script was exercised across its cases** with staged scale changes present:

| `PR_BODY` | Output | Exit |
|---|---|---|
| empty | `::warning::No PR body available` | 0 |
| no heading, no "not run" | two `::warning::` lines naming each missing part | 0 |
| `## Validation` + `Not run:` | `Validation section present` | 0 |
| same, `CI=true` | `Validation section present` | 0 |

**Not run:** every other scale suite; nothing here changes a test or a helper they use. The CI step itself is first exercised by this PR's own run.
