### PR TITLE
fix(client): resolve workspace Vite dev paths and project config

### DIFF
--- a/jac/jaclang/client/impl/vite_bundler.impl.jac
+++ b/jac/jaclang/client/impl/vite_bundler.impl.jac
@@ -449,7 +449,11 @@ impl ViteBundler._generate_vite_config_content(
     }
 
     entry_dir = entry_relative.rpartition('/')[0];
-    if entry_relative.endswith('/build/main.js') {
+    if is_dev {
+        compiled_base = (self._client_app_dir() / 'compiled').relative_to(
+            build_dir
+        ).as_posix();
+    } elif entry_relative.endswith('/build/main.js') {
         compiled_base = entry_relative[:-13] + '/compiled';
     } elif entry_dir.rpartition('/')[2] == 'compiled' {
         compiled_base = entry_dir;
@@ -643,7 +647,7 @@ function jacCompiledReload() {
   return {
     name: "jac-compiled-reload",
     configureServer(server) {
-      const compiled = path.resolve(buildDir, "compiled");
+      const compiled = path.resolve(buildDir, __JAC_COMPILED_DIR__);
       try { server.watcher.add(compiled); } catch (e) {}
       let timer = null;
       const fire = (file) => {
@@ -671,6 +675,9 @@ function jacCompiledReload() {
 '''
                 if reload_enabled
                 else ""
+        );
+        mobile_compiled_block = mobile_compiled_block.replace(
+            '__JAC_COMPILED_DIR__', json.dumps(compiled_base)
         );
         config_content = f'''import {{ defineConfig }} from "vite";
 import path from "path";
@@ -1110,10 +1117,12 @@ impl ViteBundler.init(
     minify: bool = False,
     config_path: Optional[Path] = None
 ) {
-    self.project_dir = project_dir;
+    import from jaclang.project.config { find_project_root }
+    project_root = find_project_root(project_dir);
+    self.project_dir = project_root[0] if project_root else project_dir;
     self.minify = minify;
     self.config_path = config_path;
-    self.config_loader = JacClientConfig(project_dir);
+    self.config_loader = JacClientConfig(self.project_dir);
 
     self.output_dir = output_dir or (self._client_app_dir() / 'dist');
 
@@ -1353,6 +1362,9 @@ def _dev_head_scripts -> str {
 
 impl ViteBundler._ensure_dev_index_html(self: ViteBundler, build_dir: Path) -> None {
     index_html = build_dir / 'index.html';
+    entry_relative = (self._client_app_dir() / 'compiled' / '_entry.js').relative_to(
+        self._get_client_dir()
+    ).as_posix();
     index_content = '''<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -1392,7 +1404,7 @@ impl ViteBundler._ensure_dev_index_html(self: ViteBundler, build_dir: Path) -> N
         window.$RefreshReg$ = function() {};
         window.$RefreshSig$ = function() { return function(type) { return type; }; };
         window.__jac_refresh_installed__ = true;
-        return import("/compiled/_entry.js");
+        return import(__JAC_DEV_ENTRY__);
       }).then(function() {
         // entry loaded cleanly: clears the client slot in /__build_status
         try { import.meta.hot.send("jac:client-ready"); } catch(e) {}
@@ -1406,12 +1418,15 @@ impl ViteBundler._ensure_dev_index_html(self: ViteBundler, build_dir: Path) -> N
         });
       });
     } else {
-      import("/compiled/_entry.js").catch(function() {});
+      import(__JAC_DEV_ENTRY__).catch(function() {});
     }
     </script>
   </body>
 </html>
 ''';
+    index_content = index_content.replace(
+        '__JAC_DEV_ENTRY__', json.dumps('/' + entry_relative)
+    );
     if head_scripts := _dev_head_scripts() {
         index_content = index_content.replace('  </head>', f'{head_scripts}  </head>');
     }

--- a/jac/tests/client/test_web_target_dev.jac
+++ b/jac/tests/client/test_web_target_dev.jac
@@ -195,3 +195,120 @@ test "configured scripts reach the dev server index.html" {
         "title and meta tags"
     );
 }
+
+
+test "dev HTML and runtime aliases resolve in the selected workspace app" {
+    import re;
+    import tempfile;
+    import from jaclang.project.config { JacConfig, get_config, set_config }
+    import from jaclang.runtime.runtime { JacRuntime }
+    import from jaclang.client.vite_bundler { ViteBundler }
+
+    previous = get_config();
+    with tempfile.TemporaryDirectory() as tmp {
+        project = Path(tmp);
+        manifest = (
+            '[project]\nname = "dev-paths"\ndefault-app = "web"\n'
+            '[apps.web]\nkind = "web-app"\npath = "web"\n'
+            '[apps.desktop]\nkind = "desktop"\npath = "shell"\n'
+            '[apps.desktop.dependencies.npm]\nreact-native-web = "^0.19.13"\n'
+            '[client.pwa]\nenabled = true\n'
+            '[client.vite]\nplugins = ["tailwindcss()"]\n'
+            'lib_imports = ["import tailwindcss from \'@tailwindcss/vite\'"]\n'
+        );
+        (project / "jac.toml").write_text(manifest);
+        config = JacConfig.from_toml_str(manifest, project / "jac.toml");
+        try {
+            set_config(config);
+            for (app_name, app_path) in [("web", "web"), ("desktop", "shell")] {
+                target = project / app_path / "main.jac";
+                target.parent.mkdir();
+                with unittest.mock.patch.object(
+                    JacRuntime, "get_full_target_path", return_value=str(target)
+                ) {
+                    bundler = ViteBundler(target.parent);
+                    assert bundler.project_dir == project;
+                    build_dir = bundler._get_client_dir();
+                    compiled = build_dir / app_name / "compiled";
+                    compiled.mkdir(parents=True);
+                    for filename in [
+                        "_entry.js",
+                        "client_runtime.js",
+                        "client_mobui.js",
+                        "desktop_api.js",
+                        "wasm_host.js",
+                        "pwa_runtime.js"
+                    ] {
+                        (compiled / filename).write_text("export {};\n");
+                    }
+                    (compiled / "assets").mkdir();
+                    # Fullstack dev passes a build entry; client-only targets
+                    # pass Jac source. Both must resolve the compiled app.
+                    for entry_file in [build_dir / "build" / "main.js", target] {
+                        config_path = bundler.create_vite_config(
+                            entry_file,
+                            is_dev=True,
+                            for_desktop_dev=app_name == "desktop"
+                        );
+                        bundler._ensure_dev_index_html(build_dir);
+                        page = (build_dir / "index.html").read_text();
+                        imports = re.findall(r'import\("(/[^\"]*_entry.js)"\)', page);
+                        assert imports == [f"/{app_name}/compiled/_entry.js"] * 2;
+                        assert all(
+                            (build_dir / url.lstrip("/")).is_file() for url in imports
+                        );
+                        generated = config_path.read_text();
+                        assert '"react-native": "react-native-web"' in generated;
+                        assert "import tailwindcss from '@tailwindcss/vite'"
+                            in generated;
+                        assert "tailwindcss()" in generated;
+                        for filename in [
+                            "client_runtime.js",
+                            "client_mobui.js",
+                            "desktop_api.js",
+                            "wasm_host.js",
+                            "pwa_runtime.js",
+                            "assets"
+                        ] {
+                            assert f'path.resolve(buildDir, "{app_name}/compiled/{filename}")'
+                                in generated;
+                        }
+                        if app_name == "desktop" {
+                            assert 'const compiled = path.resolve(buildDir, "desktop/compiled")'
+                                in generated;
+                        }
+                    }
+                }
+            }
+        } finally {
+            set_config(previous);
+        }
+    }
+}
+
+
+test "single app dev keeps the unscoped compiled entry and aliases" {
+    import tempfile;
+    import from jaclang.project.config { JacConfig, get_config, set_config }
+    import from jaclang.client.vite_bundler { ViteBundler }
+
+    previous = get_config();
+    with tempfile.TemporaryDirectory() as tmp {
+        project = Path(tmp);
+        manifest = '[project]\nname = "single"\nkind = "web-app"\n';
+        (project / "jac.toml").write_text(manifest);
+        try {
+            set_config(JacConfig.from_toml_str(manifest, project / "jac.toml"));
+            bundler = ViteBundler(project);
+            build_dir = bundler._get_client_dir();
+            config_path = bundler.create_vite_config(project / "main.jac", is_dev=True);
+            bundler._ensure_dev_index_html(build_dir);
+            page = (build_dir / "index.html").read_text();
+            assert page.count('import("/compiled/_entry.js")') == 2;
+            assert 'path.resolve(buildDir, "compiled/client_runtime.js")'
+                in config_path.read_text();
+        } finally {
+            set_config(previous);
+        }
+    }
+}


### PR DESCRIPTION
## **Description**

Running `jac run` in a workspace such as the generated jaclang.org demo starts the servers but leaves the browser blank: the dev HTML imports `/compiled/_entry.js` even though the selected app is compiled under `web/compiled/`. Vite also loads configuration from the app subdirectory instead of the workspace root, dropping configured plugins and the `react-native-web` alias.

Resolve the project root when constructing the bundler, and use the selected app's compiled directory for the HTML entry, runtime and asset aliases, and desktop reload watcher. Regression tests cover workspace apps launched from subdirectories, both dev entry conventions, configured dependencies/plugins, and the existing single-app layout.

Validation:

- 33 tests passed across `test_web_target_dev`, `test_desktop_dev`, `test_client_bundle`, and `test_dev_restspec_parity`.
- `jac check jac/jaclang/client/vite_bundler.jac` passed (warnings remain).
- Formatting and `git diff --check` passed.
- Reproduced and verified with `jac browse`: the styled demo homepage and Socialize login page load without browser errors or a Vite error overlay.
