### PR TITLE
perf(compiler): speed up cold compilation and show live progress

### DIFF
--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -1328,16 +1328,33 @@ impl serve(
                 import from jaclang.compiler.driver.pass_driver { compile_progress }
                 compiler = server.introspector._bundle_builder._get_compiler();
                 compiled: list[str] = [];
+                active: list[str] = [];
+                completed: list[int] = [0];
                 started = time.perf_counter();
                 with console.status("Compiling client...") as status {
                     def _on_module(file_path: str) {
                         compiled.append(file_path);
-                        status.update(
-                            "Compiling client: "
-                                + _client_display_path(Path(file_path), base)
-                        );
+                        active.append(file_path);
                     }
-                    with compile_progress.listen(_on_module) {
+                    def _on_finished(file_path: str) {
+                        active.remove(file_path);
+                        completed[0] += 1;
+                    }
+                    def _progress_text -> str {
+                        current = list(active);
+                        detail = (
+                            f"Compiling client: {completed[0]} completed"
+                            f" · {len(current)} active · {time.perf_counter()
+                                - started:.1f}s"
+                        );
+                        if current {
+                            detail += " · "
+                                + _client_display_path(Path(current[-1]), base);
+                        }
+                        return detail;
+                    }
+                    status.update(_progress_text);
+                    with compile_progress.listen(_on_module, _on_finished) {
                         compiler.compile(server.introspector._module, Path(filename));
                     }
                 }

--- a/jac/jaclang/cli/console.jac
+++ b/jac/jaclang/cli/console.jac
@@ -17,7 +17,7 @@ obj Span {
 }
 
 obj _Spinner {
-    has text: str,
+    has text: any,
         stream: any,
         frames: list[str],
         style_prefix: str,
@@ -31,7 +31,7 @@ obj _Spinner {
         self._stop = Event();
     }
 
-    def update(text: str = '') {
+    def update(text: any = '') {
         self.text = text;
     }
 
@@ -46,7 +46,8 @@ obj _Spinner {
         idx = 0;
         while not self._stop.is_set() {
             frame = self.frames[idx % len(self.frames)];
-            text = self.text;
+            current = self.text;
+            text = str(current() if callable(current) else current);
             try {
                 width = os.get_terminal_size().columns;
             } except OSError {
@@ -84,7 +85,7 @@ obj _Spinner {
 }
 
 obj _NullStatus {
-    def update(text: str = '') -> None {
+    def update(text: any = '') -> None {
         return;
     }
 

--- a/jac/jaclang/compiler/driver/impl/compiler.impl.jac
+++ b/jac/jaclang/compiler/driver/impl/compiler.impl.jac
@@ -1220,190 +1220,196 @@ impl JacCompiler.compile(
         in_native_scope_path,
         scope_lowering_active
     }
-    compile_progress.notify(str(file_path));
-    _scope_armed = False;
-    if (
-        options.aot_mode
-        and options.default_codespace == 'native'
-        and self._reentrant_depth == 0
-        and in_native_scope_path(str(file_path))
-        and not scope_lowering_active()
-    ) {
-        activate_scope_lowering();
-        _scope_armed = True;
-    }
-    if self._reentrant_depth == 0 and not self.stub_catalog_disabled {
-        if not self.selfhost.is_selfhost(target_program) {
-            import from jaclang.compiler.types.stubcat.locate { StubCatalogUnavailable }
-            try {
-                self.ensure_stub_catalog();
-            } except StubCatalogUnavailable {}
+    with compile_progress.track(str(file_path)) {
+        _scope_armed = False;
+        if (
+            options.aot_mode
+            and options.default_codespace == 'native'
+            and self._reentrant_depth == 0
+            and in_native_scope_path(str(file_path))
+            and not scope_lowering_active()
+        ) {
+            activate_scope_lowering();
+            _scope_armed = True;
         }
-    }
-    import from pathlib { Path as _WrapPath }
-    import from jaclang.compiler.frontend.codeinfo {
-        get_effective_default_codespace_override,
-        set_effective_default_codespace
-    }
-    _prev_cs = get_effective_default_codespace_override();
-    _depth_prev = self._reentrant_depth;
-    self._reentrant_depth = _depth_prev + 1;
-    if _depth_prev == 0 {
-        self._closure_opts = options;
-    }
-    _gc_prev: (tuple | None) = None;
-    if _depth_prev == 0 and not os.environ.get('JAC_GC_NO_COMPILE_BOOST') {
-        import gc;
-        _gc_prev = gc.get_threshold();
-        if _gc_prev[0] >= COMPILE_GC_THRESHOLDS[0] {
-            _gc_prev = None;
-        } else {
-            gc.set_threshold(*COMPILE_GC_THRESHOLDS);
+        if self._reentrant_depth == 0 and not self.stub_catalog_disabled {
+            if not self.selfhost.is_selfhost(target_program) {
+                import from jaclang.compiler.types.stubcat.locate {
+                    StubCatalogUnavailable
+                }
+                try {
+                    self.ensure_stub_catalog();
+                } except StubCatalogUnavailable {}
+            }
         }
-    }
-    _outer_opts: (CompileOptions | None) = None;
-    _outer_prog: (JacProgram | None) = None;
-    _scratch_prog: (JacProgram | None) = None;
-
-    import from jaclang.compiler.driver.jir {
-        native_ir_cache_set_suspended,
-        native_ir_cache_suspended
-    }
-    _na_cache_prev = native_ir_cache_suspended();
-    if options.no_ir_cache {
-        native_ir_cache_set_suspended(True);
-    }
-    try {
-        if options.force_target_program {
-            _wrap_prog = target_program;
-        } else {
-            _wrap_prog = self.selfhost.resolve(file_path, target_program);
+        import from pathlib { Path as _WrapPath }
+        import from jaclang.compiler.frontend.codeinfo {
+            get_effective_default_codespace_override,
+            set_effective_default_codespace
         }
-
-        _scratch_prog = _wrap_prog;
-        _wrap_prog.scratch.compile_depth += 1;
-        if _depth_prev > 0 {
-            _outer_prog = _wrap_prog;
-            _outer_opts = _wrap_prog.options;
+        _prev_cs = get_effective_default_codespace_override();
+        _depth_prev = self._reentrant_depth;
+        self._reentrant_depth = _depth_prev + 1;
+        if _depth_prev == 0 {
+            self._closure_opts = options;
         }
-        _pre_errs = len(_wrap_prog.errors_had);
-        _pre_warns = len(_wrap_prog.warnings_had);
-        _mod: (uni.Module | None) = None;
-        _crash: (Exception | None) = None;
+        _gc_prev: (tuple | None) = None;
+        if _depth_prev == 0 and not os.environ.get('JAC_GC_NO_COMPILE_BOOST') {
+            import gc;
+            _gc_prev = gc.get_threshold();
+            if _gc_prev[0] >= COMPILE_GC_THRESHOLDS[0] {
+                _gc_prev = None;
+            } else {
+                gc.set_threshold(*COMPILE_GC_THRESHOLDS);
+            }
+        }
+        _outer_opts: (CompileOptions | None) = None;
+        _outer_prog: (JacProgram | None) = None;
+        _scratch_prog: (JacProgram | None) = None;
+        import from jaclang.compiler.driver.jir {
+            native_ir_cache_set_suspended,
+            native_ir_cache_suspended
+        }
+        _na_cache_prev = native_ir_cache_suspended();
+        if options.no_ir_cache {
+            native_ir_cache_set_suspended(True);
+        }
         try {
-            _mod = self._compile_once(
+            if options.force_target_program {
+                _wrap_prog = target_program;
+            } else {
+                _wrap_prog = self.selfhost.resolve(file_path, target_program);
+            }
+
+            _scratch_prog = _wrap_prog;
+            _wrap_prog.scratch.compile_depth += 1;
+            if _depth_prev > 0 {
+                _outer_prog = _wrap_prog;
+                _outer_opts = _wrap_prog.options;
+            }
+            _pre_errs = len(_wrap_prog.errors_had);
+            _pre_warns = len(_wrap_prog.warnings_had);
+            _mod: (uni.Module | None) = None;
+            _crash: (Exception | None) = None;
+            try {
+                _mod = self._compile_once(
+                    file_path=file_path,
+                    target_program=target_program,
+                    use_str=use_str,
+                    options=options
+                );
+            } except Exception as _e {
+                _crash = _e;
+            }
+            if _crash is not None {
+                _re_entered = import_error_re_enters(_crash, file_path);
+                if _re_entered is not None {
+                    raise CompilerSourceError(
+                        f"compiling {file_path} re-entered it: a pass imported "
+                        f"'{_re_entered}' while Python was still executing that "
+                        "module, so the name is not bound yet. A module a pass "
+                        "reaches at run time belongs in the schedule's dependency "
+                        "list (IR_SCHED_DEPS in jaclang.compiler.driver.schedules), "
+                        "which the loader pre-imports and which puts any compile "
+                        "nested in its import on the bootstrap tier."
+                    ) from _crash;
+                }
+            }
+            _resolved = os.path.realpath(file_path);
+            _probe = _mod if _mod is not None else _wrap_prog.mod.hub.get(_resolved);
+            _inferred_native = (
+                not options.aot_mode
+                and not options.force_codespace
+                and _probe is not None
+                and _probe.decided_codespace == 'native'
+            );
+            _failed = _crash is not None or len(_wrap_prog.errors_had) > _pre_errs;
+            if not (_inferred_native and _failed) {
+                if _crash is not None {
+                    raise _crash;
+                }
+                assert _mod is not None;
+                return _mod;
+            }
+
+            _is_ice = _crash is not None and len(_wrap_prog.errors_had) == _pre_errs;
+            if _is_ice and os.environ.get('JAC_NATIVE_ICE_RAISE') {
+                raise _crash;
+            }
+            _first_err = (
+                _wrap_prog.errors_had[_pre_errs].pretty_print().split('\n')[0]
+                    if len(_wrap_prog.errors_had) > _pre_errs
+                    else f"{type(_crash).__name__}: {_crash}"
+            );
+            _demote_alerts = _wrap_prog.errors_had[_pre_errs:];
+            _demote_code = (
+                _demote_alerts[0].code.code
+                    if (_demote_alerts and _demote_alerts[0].code is not None)
+                    else type(_crash).__name__
+            );
+            na_coverage_record(
+                _resolved, 'ice' if _is_ice else 'demoted', _demote_code, _first_err
+            );
+            import from jaclang.compiler.placement.placement_pins {
+                _mark_demoted_native
+            }
+            _mark_demoted_native(_resolved, _demote_code);
+            del _wrap_prog.errors_had[_pre_errs:];
+            del _wrap_prog.warnings_had[_pre_warns:];
+            try {
+                _wrap_prog.invalidate_module(_resolved);
+            } except Exception {}
+            try {
+                import from jaclang.compiler.placement.placement_solver {
+                    invalidate_importers_es
+                }
+                for _stale_mod in invalidate_importers_es(_wrap_prog, _resolved) {
+                    _drop_demoted_native_bindings(_stale_mod, _resolved);
+                }
+            } except Exception as _reset_exc {
+                import logging as _reset_log;
+                _reset_log.getLogger(__name__).warning(
+                    f"native demotion of {_resolved} could not reset its importers "
+                    f"({_reset_exc}); stale client bindings may persist until a rebuild."
+                );
+            }
+            try {
+                import from jaclang.cli.console { console as _note_console }
+                (_note_msg, _note_style) = na_demotion_note(
+                    file_path, _first_err, _is_ice
+                );
+                _note_console.print(_note_msg, style=_note_style, file=sys.stderr);
+            } except Exception {}
+            return self._compile_once(
                 file_path=file_path,
                 target_program=target_program,
                 use_str=use_str,
                 options=options
             );
-        } except Exception as _e {
-            _crash = _e;
-        }
-        if _crash is not None {
-            _re_entered = import_error_re_enters(_crash, file_path);
-            if _re_entered is not None {
-                raise CompilerSourceError(
-                    f"compiling {file_path} re-entered it: a pass imported "
-                    f"'{_re_entered}' while Python was still executing that "
-                    "module, so the name is not bound yet. A module a pass "
-                    "reaches at run time belongs in the schedule's dependency "
-                    "list (IR_SCHED_DEPS in jaclang.compiler.driver.schedules), "
-                    "which the loader pre-imports and which puts any compile "
-                    "nested in its import on the bootstrap tier."
-                ) from _crash;
+        } finally {
+            if _scope_armed {
+                deactivate_scope_lowering();
             }
-        }
-        _resolved = os.path.realpath(file_path);
-        _probe = _mod if _mod is not None else _wrap_prog.mod.hub.get(_resolved);
-        _inferred_native = (
-            not options.aot_mode
-            and not options.force_codespace
-            and _probe is not None
-            and _probe.decided_codespace == 'native'
-        );
-        _failed = _crash is not None or len(_wrap_prog.errors_had) > _pre_errs;
-        if not (_inferred_native and _failed) {
-            if _crash is not None {
-                raise _crash;
+            native_ir_cache_set_suspended(_na_cache_prev);
+            set_effective_default_codespace(_prev_cs);
+            self._reentrant_depth = _depth_prev;
+            if _depth_prev == 0 {
+                self._closure_opts = None;
             }
-            assert _mod is not None;
-            return _mod;
-        }
-
-        _is_ice = _crash is not None and len(_wrap_prog.errors_had) == _pre_errs;
-        if _is_ice and os.environ.get('JAC_NATIVE_ICE_RAISE') {
-            raise _crash;
-        }
-        _first_err = (
-            _wrap_prog.errors_had[_pre_errs].pretty_print().split('\n')[0]
-                if len(_wrap_prog.errors_had) > _pre_errs
-                else f"{type(_crash).__name__}: {_crash}"
-        );
-        _demote_alerts = _wrap_prog.errors_had[_pre_errs:];
-        _demote_code = (
-            _demote_alerts[0].code.code
-                if (_demote_alerts and _demote_alerts[0].code is not None)
-                else type(_crash).__name__
-        );
-        na_coverage_record(
-            _resolved, 'ice' if _is_ice else 'demoted', _demote_code, _first_err
-        );
-        import from jaclang.compiler.placement.placement_pins { _mark_demoted_native }
-        _mark_demoted_native(_resolved, _demote_code);
-        del _wrap_prog.errors_had[_pre_errs:];
-        del _wrap_prog.warnings_had[_pre_warns:];
-        try {
-            _wrap_prog.invalidate_module(_resolved);
-        } except Exception {}
-        try {
-            import from jaclang.compiler.placement.placement_solver {
-                invalidate_importers_es
+            if _outer_prog is not None and _outer_opts is not None {
+                _outer_prog.options = _outer_opts;
             }
-            for _stale_mod in invalidate_importers_es(_wrap_prog, _resolved) {
-                _drop_demoted_native_bindings(_stale_mod, _resolved);
+            if _scratch_prog is not None {
+                _scratch_prog.scratch.compile_depth -= 1;
+                if _scratch_prog.scratch.compile_depth <= 0 {
+                    _scratch_prog.scratch.compile_depth = 0;
+                    self._release_compile_scratch(_scratch_prog);
+                }
             }
-        } except Exception as _reset_exc {
-            import logging as _reset_log;
-            _reset_log.getLogger(__name__).warning(
-                f"native demotion of {_resolved} could not reset its importers "
-                f"({_reset_exc}); stale client bindings may persist until a rebuild."
-            );
-        }
-        try {
-            import from jaclang.cli.console { console as _note_console }
-            (_note_msg, _note_style) = na_demotion_note(file_path, _first_err, _is_ice);
-            _note_console.print(_note_msg, style=_note_style, file=sys.stderr);
-        } except Exception {}
-        return self._compile_once(
-            file_path=file_path,
-            target_program=target_program,
-            use_str=use_str,
-            options=options
-        );
-    } finally {
-        if _scope_armed {
-            deactivate_scope_lowering();
-        }
-        native_ir_cache_set_suspended(_na_cache_prev);
-        set_effective_default_codespace(_prev_cs);
-        self._reentrant_depth = _depth_prev;
-        if _depth_prev == 0 {
-            self._closure_opts = None;
-        }
-        if _outer_prog is not None and _outer_opts is not None {
-            _outer_prog.options = _outer_opts;
-        }
-        if _scratch_prog is not None {
-            _scratch_prog.scratch.compile_depth -= 1;
-            if _scratch_prog.scratch.compile_depth <= 0 {
-                _scratch_prog.scratch.compile_depth = 0;
-                self._release_compile_scratch(_scratch_prog);
+            if _gc_prev is not None {
+                import gc;
+                gc.set_threshold(*_gc_prev);
             }
-        }
-        if _gc_prev is not None {
-            import gc;
-            gc.set_threshold(*_gc_prev);
         }
     }
 }

--- a/jac/jaclang/compiler/driver/impl/compiler.impl.jac
+++ b/jac/jaclang/compiler/driver/impl/compiler.impl.jac
@@ -1668,9 +1668,11 @@ impl JacCompiler._compile_pipeline(
 
     if not options.symtab_ir_only and not had_blocking_errors {
         import from jaclang.compiler.placement.placement_solver {
-            solve_program_placement
+            solve_program_placement,
+            refresh_placement_module
         }
         try {
+            refresh_placement_module(mod_targ, actual_program);
             solve_program_placement(mod_targ, actual_program);
         } except Exception {}
     }

--- a/jac/jaclang/compiler/driver/impl/pass_driver.impl.jac
+++ b/jac/jaclang/compiler/driver/impl/pass_driver.impl.jac
@@ -89,6 +89,7 @@ impl _SetupProgress.is_active.getter -> bool {
 
 impl CompileProgress.postinit -> None {
     self._listeners = [];
+    self._finished_listeners = [];
 }
 
 impl CompileProgress.notify(file_path: str) -> None {
@@ -98,11 +99,34 @@ impl CompileProgress.notify(file_path: str) -> None {
 }
 
 @contextmanager
-impl CompileProgress.listen(callback: Callable[[str], None]) -> Iterator[None] {
+impl CompileProgress.track(file_path: str) -> Iterator[None] {
+    finished = list(self._finished_listeners);
+    self.notify(file_path);
+    try {
+        yield None;
+    } finally {
+        for callback in finished {
+            if callback in self._finished_listeners {
+                callback(file_path);
+            }
+        }
+    }
+}
+
+@contextmanager
+impl CompileProgress.listen(
+    callback: Callable[[str], None], on_finished: Callable[[str], None] | None = None
+) -> Iterator[None] {
     self._listeners.append(callback);
+    if on_finished is not None {
+        self._finished_listeners.append(on_finished);
+    }
     try {
         yield None;
     } finally {
         self._listeners.remove(callback);
+        if on_finished is not None {
+            self._finished_listeners.remove(on_finished);
+        }
     }
 }

--- a/jac/jaclang/compiler/driver/impl/program.impl.jac
+++ b/jac/jaclang/compiler/driver/impl/program.impl.jac
@@ -37,6 +37,10 @@ impl JacProgram.install_module(
     if displaced is None {
         return;
     }
+    work = self.analysis.placement_state.get('work');
+    if work is not None {
+        work.forget(displaced);
+    }
     te = self.type_evaluator;
     if te is not None {
         te.forget_module(resolved_path);
@@ -58,6 +62,10 @@ impl JacProgram.transitive_dependents(self: JacProgram, target_path: str) -> set
 }
 
 impl JacProgram.invalidate_module(self: JacProgram, resolved_path: str) -> None {
+    work = self.analysis.placement_state.get('work');
+    if work is not None {
+        work.forget_path(resolved_path);
+    }
     self.hub.evict(resolved_path);
     if resolved_path in self.analysis.placement_summaries {
         del self.analysis.placement_summaries[resolved_path];
@@ -250,6 +258,7 @@ impl JacProgram.get_type_evaluator(self: JacProgram) -> TypeEvaluator {
 }
 
 impl JacProgram.clear_type_system(self: JacProgram, clear_hub: bool = False) -> None {
+    self.analysis.placement_state.pop('work', None);
     self.type_evaluator = None;
     if clear_hub {
         self.mod.hub.clear();
@@ -338,6 +347,7 @@ impl JacProgram.release_compile_closure(
     self.diags.clear();
     self.scratch.clear();
     self.analysis.analyses_run.clear();
+    self.analysis.placement_state.pop('work', None);
     if self._iface is not None {
         self._iface.on_closure_release();
     }

--- a/jac/jaclang/compiler/driver/pass_driver.jac
+++ b/jac/jaclang/compiler/driver/pass_driver.jac
@@ -183,12 +183,19 @@ obj _SetupProgress {
 glob setup_progress = _SetupProgress();
 
 obj CompileProgress {
-    has _listeners: list[Callable[[str], None]] postinit;
+    has _listeners: list[Callable[[str], None]] postinit,
+        _finished_listeners: list[Callable[[str], None]] postinit;
 
     def postinit -> None;
     def notify(file_path: str) -> None;
     @contextmanager
-    def listen(callback: Callable[[str], None]) -> Iterator[None];
+    def track(file_path: str) -> Iterator[None];
+
+    @contextmanager
+    def listen(
+        callback: Callable[[str], None],
+        on_finished: Callable[[str], None] | None = None
+    ) -> Iterator[None];
 }
 
 glob compile_progress = CompileProgress();

--- a/jac/jaclang/compiler/placement/placement_solver.jac
+++ b/jac/jaclang/compiler/placement/placement_solver.jac
@@ -845,7 +845,7 @@ def _pull_boundary_import(imp: uni.Import, module: uni.Module, prog: any) -> int
     return new_stamps;
 }
 
-def solve_program_placement(entry_mod: uni.Module, prog: any) -> None {
+def solve_program_placement(entry_mod: uni.Module, prog: any) {
     work = placement_work(prog);
     work.track(entry_mod);
     hub = prog?.mod?.hub;

--- a/jac/jaclang/compiler/placement/placement_solver.jac
+++ b/jac/jaclang/compiler/placement/placement_solver.jac
@@ -4,6 +4,7 @@ import from jaclang.compiler.frontend.constant { CodeContext, Tokens as Tok }
 import from jaclang.compiler.frontend.diagnostics { DiagnosticInfo }
 import from jaclang.compiler.passes.transform { Transform }
 import type from jaclang.compiler.driver.program { JacProgram }
+import from jaclang.compiler.placement.placement_work { PlacementWork }
 import from jaclang.compiler.placement.placement {
     PLACEMENT_HOLD_EXEMPT_ROOTS,
     get_module_summary,
@@ -22,6 +23,20 @@ glob _na_scan_memo: dict[tuple, tuple] = {},
 
 def native_scan_memo_clear {
     _na_scan_memo.clear();
+}
+
+def placement_work(prog: any) -> PlacementWork {
+    state = placement_state(prog);
+    work = state.get('work');
+    if not isinstance(work, PlacementWork) {
+        work = PlacementWork();
+        state['work'] = work;
+    }
+    return work;
+}
+
+def refresh_placement_module(module: uni.Module, prog: any) {
+    placement_work(prog).refresh(module);
 }
 
 def _native_dep_scan(
@@ -340,12 +355,15 @@ def _import_source_module(elem: uni.Import, prog: any) -> (uni.Module | None) {
     if not isinstance(resolved, str) or not resolved.endswith('.jac') {
         return None;
     }
+    placement_work(prog).observe_path(resolved);
     return _materialize_module(os.path.abspath(resolved), prog);
 }
 
 def _closure_pullable(
     top: uni.UniNode, module: uni.Module, prog: any, seen: set[int]
 ) -> bool {
+    work = placement_work(prog);
+    work.observe(module);
     if id(top) in seen {
         return True;
     }
@@ -392,7 +410,7 @@ def _closure_pullable(
         return False;
     }
     elem_by_id: dict[int, uni.UniNode] = {id(stmt): stmt for stmt in module.body};
-    for ref_id in _ref_top_ids(module, top) {
+    for ref_id in work.refs(module).get(id(top), set()) {
         ref_elem = elem_by_id.get(ref_id);
         if ref_elem is None {
             continue;
@@ -529,7 +547,7 @@ def solve_module_placement(
         }
     }
 
-    _seed_from_summary(module, prog);
+    stamp_count[0] += _seed_from_summary(module, prog);
     pinned_idx: set[int] = set();
     for pes in get_module_summary(module, prog).elements {
         if pes.pinned {
@@ -563,6 +581,7 @@ def solve_module_placement(
     }
     has_seeds = bool(seed_ref_ids);
     if ((not client_tops and not native_tops and not has_seeds) or not inferable) {
+        _invalidate_stale_codegen();
         return stamp_count[0];
     }
 
@@ -571,10 +590,7 @@ def solve_module_placement(
     na_sources: set[int] = set();
     na_ref_ids: set[int] = set();
     uses_map: dict[int, set[int]] = {};
-    body_refs: dict[int, set[int]] = {};
-    for top in module.body {
-        body_refs[id(top)] = _ref_top_ids(module, top);
-    }
+    body_refs = placement_work(prog).refs(module);
 
     def _pullable_native(elem: uni.UniNode) -> bool {
         return not _is_sv_import(elem);
@@ -586,17 +602,17 @@ def solve_module_placement(
             cl_sources.add(id(elem));
             cl_seed_ids.add(id(elem));
         }
-        cl_ref_ids.update(_ref_top_ids(module, elem));
+        cl_ref_ids.update(body_refs[id(elem)]);
     }
     for elem in native_tops {
         if not _is_sv_import(elem) {
             na_sources.add(id(elem));
             na_seed_ids.add(id(elem));
         }
-        na_ref_ids.update(_ref_top_ids(module, elem));
+        na_ref_ids.update(body_refs[id(elem)]);
     }
     for elem in inferable {
-        uses_map[id(elem)] = _ref_top_ids(module, elem);
+        uses_map[id(elem)] = body_refs[id(elem)];
     }
     def _hard_closure(hc_seed_ids: set[int]) -> set[int] {
         result: set[int] = set(hc_seed_ids);
@@ -762,6 +778,7 @@ def _pull_into_target(
         target, prog, seed_ref_ids=seed_ids, dual=True, pull_dependents=False
     );
     if new_stamps {
+        placement_work(prog).changed(target);
         _warn_state_forks(target, prog);
         importer = os.path.basename(module.loc.mod_path or '');
         tidx_by_id: dict[int, int] = {};
@@ -784,6 +801,8 @@ def _pull_into_target(
 }
 
 def _pull_boundary_import(imp: uni.Import, module: uni.Module, prog: any) -> int {
+    work = placement_work(prog);
+    work.observe(module);
     if (
         _is_sv_import(imp)
         or imp.is_virtual_jac
@@ -798,6 +817,7 @@ def _pull_boundary_import(imp: uni.Import, module: uni.Module, prog: any) -> int
     if not isinstance(resolved, str) or not resolved.endswith('.jac') {
         return 0;
     }
+    work.observe_path(resolved);
     if _module_externally_pinned(resolved) {
         return 0;
     }
@@ -819,51 +839,24 @@ def _pull_boundary_import(imp: uni.Import, module: uni.Module, prog: any) -> int
     } except Exception {}
     new_stamps = 0;
     for target in targets {
+        work.observe(target);
         new_stamps += _pull_into_target(imp, target, module, prog);
     }
     return new_stamps;
 }
 
 def solve_program_placement(entry_mod: uni.Module, prog: any) -> None {
-    state = placement_state(prog);
-    if state.get('solving') {
-        return;
-    }
-    state['solving'] = True;
-    try {
-        rounds = 0;
-        changed = True;
-        while changed and rounds < 32 {
-            changed = False;
-            rounds += 1;
-            mods: list[uni.Module] = [entry_mod];
-            hub = prog?.mod?.hub;
-            if isinstance(hub, dict) {
-                for m in list(hub.values()) {
-                    if isinstance(m, uni.Module) and m is not entry_mod {
-                        mods.append(m);
-                    }
-                }
-            }
-            for m in mods {
-                if not isinstance(m, uni.Module) {
-                    continue;
-                }
-                for stmt in m.body {
-                    if (
-                        isinstance(stmt, uni.Import)
-                        and stmt.code_context == CodeContext.CLIENT
-                    ) {
-                        if _pull_boundary_import(stmt, m, prog) > 0 {
-                            changed = True;
-                        }
-                    }
-                }
+    work = placement_work(prog);
+    work.track(entry_mod);
+    hub = prog?.mod?.hub;
+    if isinstance(hub, dict) {
+        for module in list(hub.values()) {
+            if isinstance(module, uni.Module) {
+                work.track(module);
             }
         }
-    } finally {
-        state['solving'] = False;
     }
+    work.drain(prog);
 }
 
 def invalidate_importers_es(prog: any, mod_path: str) -> list[uni.Module] {
@@ -947,6 +940,7 @@ def demote_client_pulled_elements(
     del prog.warnings_had[warn_mark:];
     module.gen.js = '';
     module.gen.es_ast = None;
+    placement_work(prog).changed(module);
     invalidate_importers_es(prog, mod_path);
     try {
         import sys;
@@ -984,7 +978,10 @@ impl PlacementApplyPass.postinit -> None {
 
 impl PlacementApplyPass._run_impl(ir_in: uni.Module) -> uni.Module {
     import from jaclang.compiler.symbol_utils { report_serverless_kind_errors }
-    solve_module_placement(ir_in, self.prog);
+    refresh_placement_module(ir_in, self.prog);
+    if solve_module_placement(ir_in, self.prog) {
+        placement_work(self.prog).changed(ir_in);
+    }
     report_serverless_kind_errors(self, ir_in);
     return ir_in;
 }

--- a/jac/jaclang/compiler/placement/placement_work.jac
+++ b/jac/jaclang/compiler/placement/placement_work.jac
@@ -1,0 +1,182 @@
+"""Program-local placement dependencies, valid until a module's symbols change.
+
+An import is revisited only when a module it read changes. The queue also
+accepts modules materialized during a solve; reentrant solves share that queue.
+This is analysis state for a live compilation, separate from persisted JIR.
+"""
+
+import os;
+import jaclang.compiler.frontend.unitree as uni;
+
+
+obj PlacementWork {
+    has modules: dict[int, uni.Module] = {},
+        edges: dict[int, tuple[uni.Import, uni.Module]] = {},
+        owned: dict[int, list[int]] = {},
+        # Dictionaries act as ordered sets, preserving dependency discovery order.
+        readers: dict[int, dict[int, bool]] = {},
+        path_readers: dict[str, dict[int, bool]] = {},
+        reads: dict[int, set[int]] = {},
+        paths: dict[int, set[str]] = {},
+        references: dict[int, dict[int, set[int]]] = {},
+        pending: set[int] = set(),
+        queue: list[int] = [],
+        cursor: int = 0,
+        current: int | None = None,
+        solving: bool = False;
+
+    def enqueue(edge_id: int) {
+        if edge_id in self.edges and edge_id not in self.pending {
+            self.pending.add(edge_id);
+            self.queue.append(edge_id);
+        }
+    }
+
+    def track(module: uni.Module) {
+        if id(module) not in self.modules {
+            self.refresh(module);
+        }
+    }
+
+    def refresh(module: uni.Module) {
+        mid = id(module);
+        self.modules[mid] = module;
+        self.references.pop(mid, None);
+        old = self.owned.get(mid, []);
+        owned: list[int] = [];
+        for stmt in module.body {
+            if isinstance(stmt, uni.Import) {
+                eid = id(stmt);
+                owned.append(eid);
+                self.edges[eid] = (stmt, module);
+            }
+        }
+        for eid in set(old) - set(owned) {
+            self.unwatch(eid);
+            self.edges.pop(eid, None);
+        }
+        self.owned[mid] = owned;
+        self.changed(module);
+    }
+
+    def changed(module: uni.Module) {
+        mid = id(module);
+        for eid in self.owned.get(mid, []) {
+            self.enqueue(eid);
+        }
+        for eid in self.readers.get(mid, {}) {
+            self.enqueue(eid);
+        }
+        path = module.loc.mod_path;
+        if path {
+            for eid in self.path_readers.get(os.path.abspath(path), {}) {
+                self.enqueue(eid);
+            }
+        }
+    }
+
+    def forget(module: uni.Module) {
+        self.changed(module);
+        mid = id(module);
+        self.modules.pop(mid, None);
+        self.references.pop(mid, None);
+        for eid in self.readers.pop(mid, {}) {
+            self.reads.get(eid, set()).discard(mid);
+        }
+        removed = self.owned.pop(mid, []);
+        for eid in removed {
+            self.unwatch(eid);
+            self.edges.pop(eid, None);
+        }
+    }
+
+    def forget_path(path: str) {
+        path = os.path.abspath(path);
+        for module in list(self.modules.values()) {
+            if module.loc.mod_path and os.path.abspath(module.loc.mod_path) == path {
+                self.forget(module);
+            }
+        }
+    }
+
+    def observe(module: uni.Module) {
+        self.track(module);
+        eid = self.current;
+        if eid is not None {
+            self.readers.setdefault(id(module), {})[eid] = True;
+            self.reads.setdefault(eid, set()).add(id(module));
+        }
+    }
+
+    def observe_path(path: str) {
+        eid = self.current;
+        if eid is not None {
+            path = os.path.abspath(path);
+            self.path_readers.setdefault(path, {})[eid] = True;
+            self.paths.setdefault(eid, set()).add(path);
+        }
+    }
+
+    def unwatch(eid: int) {
+        for mid in self.reads.pop(eid, set()) {
+            readers = self.readers.get(mid, {});
+            readers.pop(eid, None);
+            if not readers {
+                self.readers.pop(mid, None);
+            }
+        }
+        for path in self.paths.pop(eid, set()) {
+            readers = self.path_readers.get(path, {});
+            readers.pop(eid, None);
+            if not readers {
+                self.path_readers.pop(path, None);
+            }
+        }
+    }
+
+    def refs(module: uni.Module) -> dict[int, set[int]] {
+        import from jaclang.compiler.placement.placement_solver { _ref_top_ids }
+        self.observe(module);
+        mid = id(module);
+        cached = self.references.get(mid);
+        if cached is None {
+            cached = {id(top): _ref_top_ids(module, top) for top in module.body};
+            self.references[mid] = cached;
+        }
+        return cached;
+    }
+
+    def drain(prog: any) {
+        import from jaclang.compiler.placement.placement_solver {
+            _pull_boundary_import
+        }
+        if self.solving {
+            return;
+        }
+        self.solving = True;
+        try {
+            while self.cursor < len(self.queue) {
+                eid = self.queue[self.cursor];
+                self.cursor += 1;
+                self.pending.discard(eid);
+                pair = self.edges.get(eid);
+                if pair is None {
+                    continue;
+                }
+                self.unwatch(eid);
+                self.current = eid;
+                try {
+                    _pull_boundary_import(pair[0], pair[1], prog);
+                } except Exception {
+                    self.enqueue(eid);
+                    raise;
+                }
+            }
+        } finally {
+            self.current = None;
+            self.solving = False;
+            self.queue = self.queue[self.cursor:];
+            self.cursor = 0;
+        }
+    }
+}

--- a/jac/jaclang/compiler/placement/placement_work.jac
+++ b/jac/jaclang/compiler/placement/placement_work.jac
@@ -1,10 +1,3 @@
-"""Program-local placement dependencies, valid until a module's symbols change.
-
-An import is revisited only when a module it read changes. The queue also
-accepts modules materialized during a solve; reentrant solves share that queue.
-This is analysis state for a live compilation, separate from persisted JIR.
-"""
-
 import os;
 import jaclang.compiler.frontend.unitree as uni;
 
@@ -13,7 +6,6 @@ obj PlacementWork {
     has modules: dict[int, uni.Module] = {},
         edges: dict[int, tuple[uni.Import, uni.Module]] = {},
         owned: dict[int, list[int]] = {},
-        # Dictionaries act as ordered sets, preserving dependency discovery order.
         readers: dict[int, dict[int, bool]] = {},
         path_readers: dict[str, dict[int, bool]] = {},
         reads: dict[int, set[int]] = {},

--- a/jac/tests/cli/test_console_renderer.jac
+++ b/jac/tests/cli/test_console_renderer.jac
@@ -12,6 +12,25 @@ delegates to a real renderer.
 
 import from jaclang.cli.console { JacConsole, ConsoleRenderer, Span, console }
 
+test "live status text refreshes while the current module is still compiling" {
+    import io;
+    import from jaclang.cli.console { _Spinner }
+    stream = io.StringIO();
+    spinner = _Spinner("", stream, ["."], "", "", interval=0);
+    ticks: list[int] = [0];
+    def progress -> str {
+        ticks[0] += 1;
+        if ticks[0] == 2 {
+            spinner._stop.set();
+        }
+        return f"0 completed · 1 active · {ticks[0]}.0s";
+    }
+    spinner.update(progress);
+    spinner._run();
+    assert "0 completed · 1 active · 1.0s" in stream.getvalue();
+    assert "0 completed · 1 active · 2.0s" in stream.getvalue();
+}
+
 
 # Every public method of the console surface. Each must live on the facade.
 glob _FACADE_METHODS: list[str] = [

--- a/jac/tests/compiler/test_compile_progress.jac
+++ b/jac/tests/compiler/test_compile_progress.jac
@@ -54,3 +54,42 @@ test "a listener only hears the compile it was attached for" {
     JacProgram().compile(main_path);
     assert seen == [] , f"a detached listener heard {seen}";
 }
+
+test "nested compilation completes dependencies before their importer" {
+    main_path = _project();
+    active: list[str] = [];
+    finished: list[str] = [];
+    def on_finished(path: str) {
+        assert active and active[-1] == path;
+        active.pop();
+        finished.append(path);
+    }
+    with compile_progress.listen(active.append, on_finished) {
+        JacProgram().compile(main_path);
+    }
+    assert not active;
+    assert finished[-1] == main_path;
+    assert "util.jac" in [os.path.basename(p) for p in finished];
+}
+
+test "exceptions finish active work and detach both listeners" {
+    import from unittest.mock { patch }
+    import from jaclang.compiler.driver.compiler { JacCompiler }
+    started: list[str] = [];
+    finished: list[str] = [];
+    main_path = _project();
+    with patch.object(
+        JacCompiler, "_compile_once", side_effect=RuntimeError("failed")
+    ) {
+        try {
+            with compile_progress.listen(started.append, finished.append) {
+                JacProgram().compile(main_path);
+            }
+            assert False , "expected the compiler failure";
+        } except RuntimeError {}
+    }
+    assert started == [main_path];
+    assert finished == started;
+    JacProgram().compile(main_path);
+    assert started == [main_path] and finished == [main_path];
+}

--- a/jac/tests/compiler/test_placement_work.jac
+++ b/jac/tests/compiler/test_placement_work.jac
@@ -1,0 +1,199 @@
+"""Placement converges without repeatedly solving an unchanged import graph."""
+
+import os;
+import tempfile;
+import from unittest.mock { patch }
+import from tests.support { JAC_ROOT }
+import jaclang.compiler.frontend.unitree as uni;
+import jaclang.compiler.placement.placement_solver as solver;
+import from jaclang.compiler.driver.program { JacProgram }
+import from jaclang.compiler.frontend.constant { CodeContext }
+
+def _compile -> tuple[JacProgram, uni.Module] {
+    prog = JacProgram();
+    path = os.path.join(
+        JAC_ROOT, "tests", "compiler", "fixtures", "codespace", "infer_xmod_app.jac"
+    );
+    mod = prog.compile(path, no_cgen=True);
+    assert not prog.errors_had , [str(e) for e in prog.errors_had];
+    return (prog, mod);
+}
+
+test "unchanged and unrelated modules do not rescan the solved import graph" {
+    (prog, mod) = _compile();
+    solver.solve_program_placement(mod, prog);
+    with patch.object(
+        solver, "_pull_boundary_import", wraps=solver._pull_boundary_import
+    ) as pulls {
+        with patch.object(solver, "_ref_top_ids", wraps=solver._ref_top_ids) as refs {
+            solver.solve_program_placement(mod, prog);
+            solver.solve_program_placement(mod, prog);
+            other = prog.parse_str(
+                "def unrelated -> int { return 1; }", "/tmp/placement-unrelated.jac"
+            );
+            solver.solve_program_placement(other, prog);
+            assert pulls.call_count == 0 , pulls.call_count;
+            assert refs.call_count == 0 , refs.call_count;
+        }
+    }
+}
+
+test "symbol refresh invalidates references while placement changes reuse them" {
+    (prog, mod) = _compile();
+    work = solver.placement_work(prog);
+    with patch.object(solver, "_ref_top_ids", wraps=solver._ref_top_ids) as refs {
+        work.refresh(mod);
+        before = work.refs(mod);
+        assert refs.call_count == len(mod.body);
+        work.changed(mod);
+        assert work.refs(mod) is before;
+        assert refs.call_count == len(mod.body);
+        work.refresh(mod);
+        assert work.refs(mod) == before;
+        assert refs.call_count == 2 * len(mod.body);
+    }
+}
+
+test "an interrupted solve retains its pending import for the next attempt" {
+    (prog, mod) = _compile();
+    work = solver.placement_work(prog);
+    work.changed(mod);
+    with patch.object(
+        solver, "_pull_boundary_import", side_effect=RuntimeError("interrupted")
+    ) {
+        try {
+            solver.solve_program_placement(mod, prog);
+            assert False , "the interrupted solve must propagate its exception";
+        } except RuntimeError {}
+    }
+    assert work.pending;
+    assert not work.solving;
+    solver.solve_program_placement(mod, prog);
+    assert not work.pending;
+    with patch.object(
+        solver, "_pull_boundary_import", wraps=solver._pull_boundary_import
+    ) as pulls {
+        solver.solve_program_placement(mod, prog);
+        assert pulls.call_count == 0;
+    }
+}
+
+test "replacement during solving preserves the active queue and wakes importers" {
+    (prog, mod) = _compile();
+    work = solver.placement_work(prog);
+    target = next(
+        m
+        for m in work.modules.values()
+        if m.name == "infer_xmod_util"
+    );
+    dependent_edges = set(work.readers.get(id(target), set()));
+    assert dependent_edges;
+    work.solving = True;
+    try {
+        replacement = JacProgram().parse_str(
+            "def helper -> int { return 1; }", target.loc.mod_path
+        );
+        prog.install_module(target.loc.mod_path, replacement);
+        assert solver.placement_work(prog) is work;
+        assert dependent_edges <= work.pending;
+        assert id(target) not in work.modules;
+        assert id(target) not in work.references;
+    } finally {
+        work.solving = False;
+    }
+}
+
+test "invalidating a module removes its reference graph and closure release drops all work" {
+    (prog, mod) = _compile();
+    work = solver.placement_work(prog);
+    work.refs(mod);
+    prog.invalidate_module(mod.loc.mod_path);
+    assert id(mod) not in work.modules;
+    assert id(mod) not in work.references;
+    with patch.dict(os.environ, {"JAC_NO_UNIT_EVICT": ""}) {
+        prog.release_compile_closure();
+    }
+    assert "work" not in prog.analysis.placement_state;
+}
+
+test "client placement reaches the end of a long import chain" {
+    with tempfile.TemporaryDirectory(prefix="jac-placement-chain-") as tmp {
+        for i in range(40) {
+            source = "def value -> int { return 1; }"
+                if i == 39
+                else (
+                    f"import from m{i + 1} {{ value as next_value }}\n"
+                    "def value -> int { return next_value(); }"
+                );
+            with open(os.path.join(tmp, f"m{i}.jac"), "w") as f {
+                f.write(source);
+            }
+        }
+        path = os.path.join(tmp, "app.jac");
+        with open(path, "w") as f {
+            f.write(
+                "import from m0 { value }\ndef app -> JsxElement { return <div>{value()}</div>; }"
+            );
+        }
+        prog = JacProgram();
+        mod = prog.compile(path, no_cgen=True);
+        assert not prog.errors_had , [str(e) for e in prog.errors_had];
+        for i in range(40) {
+            target = prog.find_module(os.path.join(tmp, f"m{i}.jac"));
+            assert target is not None , i;
+            ability = next(
+                top
+                for top in target.body
+                if isinstance(top, uni.Ability)
+            );
+            assert ability.code_context == CodeContext.CLIENT , i;
+            assert ability.codespace_dual , i;
+        }
+        with patch.object(
+            solver, "_pull_boundary_import", wraps=solver._pull_boundary_import
+        ) as pulls {
+            solver.solve_program_placement(mod, prog);
+            assert pulls.call_count == 0 , pulls.call_count;
+        }
+    }
+}
+
+test "a cyclic import graph converges and remains idle after solving" {
+    with tempfile.TemporaryDirectory(prefix="jac-placement-cycle-") as tmp {
+        for (name, other) in [("left", "right"), ("right", "left")] {
+            with open(os.path.join(tmp, name + ".jac"), "w") as f {
+                f.write(
+                    f"import from {other} {{ value as next_value }}\n"
+                    "def value(n: int) -> int {\n"
+                    "    return 1 if n == 0 else next_value(n - 1);\n}"
+                );
+            }
+        }
+        path = os.path.join(tmp, "app.jac");
+        with open(path, "w") as f {
+            f.write(
+                "import from left { value }\n"
+                "def app -> JsxElement { return <div>{value(4)}</div>; }"
+            );
+        }
+        prog = JacProgram();
+        mod = prog.compile(path, no_cgen=True);
+        assert not prog.errors_had , [str(e) for e in prog.errors_had];
+        for name in ["left", "right"] {
+            target = prog.find_module(os.path.join(tmp, name + ".jac"));
+            assert target is not None;
+            ability = next(
+                top
+                for top in target.body
+                if isinstance(top, uni.Ability)
+            );
+            assert ability.code_context == CodeContext.CLIENT;
+        }
+        with patch.object(
+            solver, "_pull_boundary_import", wraps=solver._pull_boundary_import
+        ) as pulls {
+            solver.solve_program_placement(mod, prog);
+            assert pulls.call_count == 0 , pulls.call_count;
+        }
+    }
+}

--- a/release_notes/unreleased/jaclang/8994.bugfix.md
+++ b/release_notes/unreleased/jaclang/8994.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Faster cold compilation and visible progress**: Avoid repeated placement analysis during client compilation while preserving JIR caching, and show completed modules, active compilations, and elapsed time during development startup.


### PR DESCRIPTION
Cold `jac create --awesome` / `jac run` repeatedly solved placement across the entire growing module hub and rebuilt the same symbol-reference graph. Replace those full scans with a program-local queue of import edges: only changes to an importer or a dependency it observed schedule another solve.

Cache local reference edges until symbol analysis is refreshed. Track dependencies through transitive closure checks and late module materialization, preserve the active queue across module replacement and exceptions, and remove obsolete subscriptions on refresh or eviction. Release this analysis state with the compile closure. Convergence no longer stops at an arbitrary 32 rounds. The persisted JIR format and cache remain unchanged.

Interactive development startup now shows completed modules, active compilations, elapsed time, and the current file. Completion events cover nested imports and exceptions, and the spinner refreshes elapsed time independently of compiler events. Redirected output stays concise.

Validation:
- 47 targeted tests passed for compiler progress, console rendering/capabilities, placement work, and Vite development startup. A real terminal run captured 414 live progress frames and completed client compilation.
- Release-note validation and `jac fmt --check --lintfix` pass for the changed files.
- 114 tests passed across placement inference/evidence/facts/pins, warm JIR, client artifacts, native placement, app kinds, and Vite development startup.
- New regressions cover unchanged and unrelated graphs, reference invalidation, interrupted solves, module replacement, lifecycle cleanup, a 40-module chain, and import cycles.
- All 114 generated demo JavaScript files match the baseline after normalizing temporary project paths.
- Full `jac run` startup emitted `arena.wasm` and reached Server ready; `jac browse` verified the rendered demo page.

Controlled cold-project comparison using the same compiler tree, with the pre-change placement solver for the baseline. Compiler setup was cached; both runs compiled 210 client modules:

| Measurement | Before | After |
| --- | ---: | ---: |
| Client compilation | 108.8s | 54.9s |
| Module placement solves | 24,954 | 1,813 |
| Import-edge evaluations | 29,032 | 1,889 |
| Reference analyses | 163,925 | 1,999 |

Warm client compilation still serves every module from JIR in 0.5s, with no placement analysis. These timings measure client compilation, not dependency installation or native/WASM startup.

