### PR TITLE
fix(client): validate runtime imports and smoke the jac run quickstart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1056,14 +1056,14 @@ jobs:
       # test in-process (jaclang.cli.guide_store), so the docs journey stop is
       # hermetic with no extra setup.
       # The site is a workspace whose service apps colocate in the served
-      # app's process by default, so `jac run --serve web` is the single
+      # app's process by default. Exercise the exact quickstart, `jac run`, in the single
       # process serving stack. The fleet topology (`--fleet`: one local
       # process per service app behind the gateway) gets its own pass over
       # the same journey below.
-      - name: Start site server in background
+      - name: Start the quickstart with bare jac run
         working-directory: site
         run: |
-          timeout 1200 jac run --serve web > /tmp/site-server.log 2>&1 &
+          timeout 1200 jac run > /tmp/site-server.log 2>&1 &
           SERVER_PID=$!
           echo "SITE_PID=$SERVER_PID" >> $GITHUB_ENV
           echo "site server starting with PID $SERVER_PID..."
@@ -1099,7 +1099,7 @@ jobs:
         run: |
           HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 http://localhost:8000)
           echo "site root endpoint: HTTP $HTTP_CODE"
-          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 500 ]; then
+          if [ "$HTTP_CODE" -eq 200 ]; then
             echo "site server responding correctly"
           else
             echo "Unexpected HTTP $HTTP_CODE"
@@ -1138,11 +1138,19 @@ jobs:
           SITE_JOURNEY_ARTIFACTS: /tmp
         run: bash scripts/site-browse-journey.sh http://localhost:8000
 
+      - name: Verify development mode and no dependency scan errors
+        run: |
+          grep -q 'Development (with HMR)' /tmp/site-server.log
+          if grep -E 'Failed to scan for dependencies|No matching export|Could not start Vite dev server' /tmp/site-server.log; then
+            echo "::error::the quickstart client failed despite a live server process"
+            exit 1
+          fi
+
       - name: Dump server thread stacks on failure
         if: failure()
         run: |
           pip install py-spy >/dev/null 2>&1 || true
-          for p in $(pgrep -f "jac run --serve"); do
+          for p in $(pgrep -f "jac run"); do
             echo "=== py-spy dump pid $p ==="
             sudo env "PATH=$PATH" py-spy dump --pid "$p" --nonblocking || true
           done
@@ -1168,9 +1176,52 @@ jobs:
           jac browse close 2>/dev/null || true
           if [ -n "${{ env.SITE_PID }}" ]; then
             kill ${{ env.SITE_PID }} 2>/dev/null || true
-            sleep 3
+            for i in $(seq 1 30); do
+              kill -0 ${{ env.SITE_PID }} 2>/dev/null || break
+              sleep 1
+            done
             kill -9 ${{ env.SITE_PID }} 2>/dev/null || true
           fi
+
+      - name: Build the production artifact
+        working-directory: site
+        run: jac build --output dist
+
+      - name: Serve the production artifact outside the source project
+        working-directory: ${{ runner.temp }}
+        run: |
+          timeout 1200 jac run --port 8000 "${{ github.workspace }}/site/dist/site.jab" > /tmp/site-artifact.log 2>&1 &
+          echo "ARTIFACT_PID=$!" >> $GITHUB_ENV
+
+      - name: Wait for the production artifact
+        run: |
+          for i in $(seq 1 60); do
+            if ! kill -0 "${{ env.ARTIFACT_PID }}" 2>/dev/null; then
+              cat /tmp/site-artifact.log
+              exit 1
+            fi
+            if curl -sf --max-time 10 http://localhost:8000/ -o /dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          cat /tmp/site-artifact.log
+          exit 1
+
+      - name: Browse the production artifact (same journey)
+        timeout-minutes: 15
+        run: bash scripts/site-browse-journey.sh http://localhost:8000
+
+      - name: Stop the production artifact
+        if: always()
+        run: |
+          jac browse close 2>/dev/null || true
+          if [ -n "${{ env.ARTIFACT_PID }}" ]; then
+            kill "${{ env.ARTIFACT_PID }}" 2>/dev/null || true
+            sleep 3
+            kill -9 "${{ env.ARTIFACT_PID }}" 2>/dev/null || true
+          fi
+          cat /tmp/site-artifact.log 2>/dev/null || true
 
       # The other topology for the same site: `jac run --fleet` puts the
       # gateway in front of one local process per service app, with the
@@ -1224,7 +1275,7 @@ jobs:
         if: failure()
         run: |
           pip install py-spy >/dev/null 2>&1 || true
-          for p in $(pgrep -f "jac run --serve"); do
+          for p in $(pgrep -f "jac run"); do
             echo "=== py-spy dump pid $p ==="
             sudo env "PATH=$PATH" py-spy dump --pid "$p" --nonblocking || true
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,13 +249,15 @@ jobs:
       # saved ~7 MB and restored nothing. There is no digest-agnostic
       # fallback key: a generation directory from another compiler digest
       # is dead weight to restore.
+      # Retries must be able to rule out a stale analysis/runtime cache.
       - name: Restore JIR analysis cache
+        if: github.run_attempt == 1
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/.cache/jac
-          key: jac-check-cache-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-${{ github.sha }}
+          key: jac-check-cache-v2-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-${{ github.sha }}
           restore-keys: |
-            jac-check-cache-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-
+            jac-check-cache-v2-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-
 
       - uses: ./.github/actions/jac-kit
 
@@ -376,11 +378,11 @@ jobs:
           jac check . --ignore $IGNORE_ARGS --nowarn
 
       - name: Save JIR analysis cache
-        if: always()
+        if: success()
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/.cache/jac
-          key: jac-check-cache-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-${{ github.sha }}
+          key: jac-check-cache-v2-${{ runner.os }}-${{ hashFiles('jac/jaclang/compiler/**', 'jac/jaclang/runtime/**', 'jac/jaclang/lib/**', 'jac/jaclang/jac0core/**', 'jac/jaclang/jac0.py', 'jac/jaclang/meta_importer.py', 'jac/jaclang/bootstrap_manifest.py', 'jac/jaclang/cli/cli_boot.jac', 'jac/jaclang/project/tomlio.jac', 'jac/jaclang/dist/precompile_bytecode.jac') }}-${{ github.sha }}
 
       - name: Error-code breakdown (label "type-error-report")
         if: contains(github.event.pull_request.labels.*.name, 'type-error-report')

--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -1493,31 +1493,34 @@ impl serve(
         return 1;
     } except KeyboardInterrupt {
         console.print('\nShutting down');
-        if hot_reloader is not None {
-            hot_reloader.stop();
-        }
-        for started_vite in vite_holder {
-            started_vite.terminate();
-            started_vite.`wait(timeout=5);
-        }
-        mach.close();
         return 0;
     } except Exception as e {
         import from jaclang.runtime.traceback_render { dump_traceback }
         import from jaclang.server.net { PortInUseError }
-        if hot_reloader is not None {
-            hot_reloader.stop();
-        }
-        for started_vite in vite_holder {
-            started_vite.terminate();
-        }
-        mach.close();
         if isinstance(e, PortInUseError) {
             raise;
         }
         console.error(f"Server error: {e}");
         console.error(dump_traceback(e));
         return 1;
+    } finally {
+        try {
+            if hot_reloader is not None {
+                hot_reloader.stop();
+            }
+        } finally {
+            import subprocess;
+            for started_vite in vite_holder {
+                started_vite.terminate();
+                try {
+                    started_vite.`wait(timeout=5);
+                } except subprocess.TimeoutExpired {
+                    started_vite.kill();
+                    started_vite.`wait();
+                }
+            }
+            mach.close();
+        }
     }
 }
 

--- a/jac/jaclang/client/impl/compiler.impl.jac
+++ b/jac/jaclang/client/impl/compiler.impl.jac
@@ -85,7 +85,7 @@ impl ViteCompiler._emit_wasm_module(self: ViteCompiler, module_path: Path) -> bo
         return False;
     }
     stem = native_wasm_stem(str(module_path));
-    dist = self.jac_client_compiler._get_client_dir() / 'dist';
+    dist = self.vite_bundler.output_dir;
     dist.mkdir(parents=True, exist_ok=True);
     out_path = dist / f"{stem}.wasm";
     out_path.write_bytes(wasm);

--- a/jac/jaclang/client/impl/jac_client_compiler.impl.jac
+++ b/jac/jaclang/client/impl/jac_client_compiler.impl.jac
@@ -253,6 +253,29 @@ impl JacClientCompiler.compile_dependencies_recursively(
     artifact = self.jac_compiler.compile_module(module_path);
     self._collect_na_modules(artifact);
     manifest = artifact.manifest;
+    for (dependency, names) in manifest.runtime_imports.items() {
+        if not names {
+            continue;
+        }
+        dependency_path = Path(dependency).resolve();
+        if native {
+            dependency_path = self._native_variant(dependency_path);
+        }
+        dependency_manifest = self.jac_compiler.compile_module(
+            dependency_path
+        ).manifest;
+        exported = set(dependency_manifest.exports + dependency_manifest.globals);
+        missing = sorted(set(names) - exported);
+        if missing {
+            raise ClientBundleError(
+                f"{module_path}: runtime import(s) {', '.join(
+                    missing
+                )} are not exported "
+                f"by {dependency_path}. Use :pub for runtime values; annotation-only "
+                "references must not produce runtime imports."
+            );
+        }
+    }
     exports_list = self.jac_compiler.extract_exports(manifest);
     collected_exports.update(exports_list);
     non_root_globals: dict[(str, any)] = {};

--- a/jac/jaclang/client/impl/jac_client_compiler.impl.jac
+++ b/jac/jaclang/client/impl/jac_client_compiler.impl.jac
@@ -488,7 +488,8 @@ impl JacClientCompiler.compile_runtime_utils(
     import importlib;
 
     for _m in re.finditer(
-        r'from\s+[\'"]((?:\./)?[^\'"]*html_tag_map\.js)[\'"]', runtimeutils_js
+        r'(?:from|import)\s+[\'"]((?:\./)?[^\'"]*html_tag_map\.js)[\'"]',
+        runtimeutils_js
     ) {
         rel = _m.group(1);
         if rel.startswith('./') {

--- a/jac/jaclang/compiler/backends/es/esast_gen_pass.impl/imports.impl.jac
+++ b/jac/jaclang/compiler/backends/es/esast_gen_pass.impl/imports.impl.jac
@@ -131,6 +131,9 @@ impl EsastGenPass.exit_import with uni.Import exit {
     } else {
         return;
     }
+    if resolved_path.endswith(".jac") {
+        self.module_import_paths[js_import_path] = resolved_path;
+    }
     source = self.sync_loc(es.Literal(value=js_import_path), jac_node=here.from_loc);
     specifiers:
         list[
@@ -488,4 +491,47 @@ impl EsastGenPass._import_item_named(name: str) -> (uni.ModuleItem | None) {
         }
     }
     return None;
+}
+
+impl EsastGenPass._finalize_runtime_imports(program: es.Program) -> None {
+    if not self.module_import_paths {
+        return;
+    }
+    manifest = self.client_manifest;
+    assert manifest is not None;
+    value_body = es.Program(
+        body=[
+            stmt
+            for stmt in program.body
+            if not isinstance(stmt, es.ImportDeclaration)
+        ]
+    );
+    referenced = {ref.name for ref in free_identifiers(value_body, set())};
+    for stmt in program.body {
+        if not isinstance(stmt, es.ImportDeclaration) {
+            continue;
+        }
+        source = stmt.source;
+        assert source is not None;
+        source_path = self.module_import_paths.get(str(source.value));
+        if source_path is None {
+            continue;
+        }
+        stmt.specifiers = [
+            spec
+            for spec in stmt.specifiers
+            if spec.local is not None and spec.local.name in referenced
+        ];
+        names: list[str] = [];
+        for spec in stmt.specifiers {
+            if isinstance(spec, es.ImportSpecifier) {
+                imported = spec.imported;
+                assert imported is not None;
+                names.append(imported.name);
+            } elif isinstance(spec, es.ImportDefaultSpecifier) {
+                names.append("default");
+            }
+        }
+        manifest.runtime_imports.setdefault(source_path, []).extend(names);
+    }
 }

--- a/jac/jaclang/compiler/backends/es/esast_gen_pass.impl/imports.impl.jac
+++ b/jac/jaclang/compiler/backends/es/esast_gen_pass.impl/imports.impl.jac
@@ -506,7 +506,26 @@ impl EsastGenPass._finalize_runtime_imports(program: es.Program) -> None {
             if not isinstance(stmt, es.ImportDeclaration)
         ]
     );
-    referenced = {ref.name for ref in free_identifiers(value_body, set())};
+
+    import re;
+    referenced: set[str] = set();
+    pending: list[any] = [value_body];
+    while pending {
+        value = pending.pop();
+        if isinstance(value, (es.Identifier, es.JsxIdentifier)) {
+            referenced.update(re.findall(r"[A-Za-z_$][A-Za-z0-9_$]*", value.name));
+        } elif isinstance(value, es.RawCode) {
+            referenced.update(re.findall(r"[A-Za-z_$][A-Za-z0-9_$]*", value.code));
+        } elif isinstance(value, es.Node) {
+            pending.extend(
+                child
+                for (key, child) in vars(value).items()
+                if key not in ("loc", "type")
+            );
+        } elif isinstance(value, (list, tuple)) {
+            pending.extend(value);
+        }
+    }
     for stmt in program.body {
         if not isinstance(stmt, es.ImportDeclaration) {
             continue;

--- a/jac/jaclang/compiler/backends/es/esast_gen_pass.impl/module.impl.jac
+++ b/jac/jaclang/compiler/backends/es/esast_gen_pass.impl/module.impl.jac
@@ -248,6 +248,7 @@ impl EsastGenPass.exit_module with uni.Module exit {
         );
     }
     program = self.sync_loc(es.Program(body=body), jac_node=here);
+    self._finalize_runtime_imports(program);
     here.gen.es_ast = program;
     here.gen.js = es_to_js(here.gen.es_ast);
     here.gen.client_manifest = self.client_manifest;

--- a/jac/jaclang/compiler/backends/es/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/backends/es/esast_gen_pass.jac
@@ -233,6 +233,7 @@ walker EsastGenPass(BaseAstGenPass[es.Statement]) {
         _ct_only_names: (set[str] | None) = None,
         child_passes: list[EsastGenPass] = [],
         imports: list[es.ImportDeclaration] = [],
+        module_import_paths: dict[str, str] = {},
         exports: list[es.ExportNamedDeclaration] = [],
         scope_stack: list[ScopeInfo] = [],
         scope_map: dict[(uni.UniScopeNode, ScopeInfo)] = {},
@@ -402,6 +403,7 @@ walker EsastGenPass(BaseAstGenPass[es.Statement]) {
     ) -> es.MemberExpression;
 
     can exit_module with uni.Module exit;
+    def _finalize_runtime_imports(program: es.Program) -> None;
     def _audit_free_identifiers(nd: uni.Module, program: es.Program) -> None;
     def _free_ident_site(
         names: list[uni.Name], free: FreeIdentifier

--- a/jac/jaclang/compiler/frontend/codeinfo.jac
+++ b/jac/jaclang/compiler/frontend/codeinfo.jac
@@ -26,6 +26,7 @@ obj ClientManifest {
         globals_values: dict[(str, any)] = field(default_factory=`dict),
         has_client: bool = False,
         imports: dict[(str, str)] = field(default_factory=`dict),
+        runtime_imports: dict[str, list[str]] = field(default_factory=`dict),
         endpoint_effects: dict[(str, dict)] = field(default_factory=`dict),
         tests: list[dict[(str, str)]] = field(default_factory=`list),
         server_imports: list[str] = field(default_factory=`list),

--- a/jac/jaclang/compiler/frontend/impl/codeinfo.impl.jac
+++ b/jac/jaclang/compiler/frontend/impl/codeinfo.impl.jac
@@ -108,6 +108,7 @@ impl ClientArtifact.to_bytes -> bytes {
     import pickle;
     return pickle.dumps(
         (
+            2,
             self.js,
             self.manifest,
             list(self.native_import_sources),
@@ -122,13 +123,21 @@ impl ClientArtifact.to_bytes -> bytes {
 impl ClientArtifact.from_bytes(raw: bytes) -> (ClientArtifact | None) {
     import pickle;
     try {
-        (js, manifest, native_import_sources, source_map, dep_digests, framework) = (
-            pickle.loads(raw)
-        );
+        (
+            version,
+            js,
+            manifest,
+            native_import_sources,
+            source_map,
+            dep_digests,
+            framework
+        ) = pickle.loads(raw);
     } except Exception {
         return None;
     }
-    if not isinstance(js, str) or not isinstance(manifest, ClientManifest) {
+    if version != 2
+        or not isinstance(js, str)
+        or not isinstance(manifest, ClientManifest) {
         return None;
     }
     return ClientArtifact(

--- a/jac/jaclang/server/endpoints/pages.jac
+++ b/jac/jaclang/server/endpoints/pages.jac
@@ -81,7 +81,7 @@ def register_page_endpoints(server: JacAPIServer) {
     asset_dist = settings.client_dist;
     if not asset_dist {
         import from jaclang.server.sealed_serve { client_dist_for }
-        source_path = getattr(server.introspector.module, '__file__', '') or '';
+        source_path = getattr(server.module, '__file__', '') or '';
         sealed_dist = client_dist_for(source_path) if source_path else None;
         if sealed_dist is not None {
             asset_dist = str(sealed_dist);

--- a/jac/jaclang/server/endpoints/pages.jac
+++ b/jac/jaclang/server/endpoints/pages.jac
@@ -155,7 +155,7 @@ def register_page_endpoints(server: JacAPIServer) {
     }
 
     def root_index(request: Request, **kwargs: JsonValue) -> Response {
-        index = client_dist_index(settings.client_dist);
+        index = client_dist_index(asset_dist);
         if index is not None {
             return file_response(request, str(index), cache_control='no-cache');
         }
@@ -266,7 +266,7 @@ def register_page_endpoints(server: JacAPIServer) {
                 request, str(candidate), cache_control=ASSET_CACHE_CONTROL
             );
         }
-        index = client_dist_index(settings.client_dist);
+        index = client_dist_index(asset_dist);
         if index is not None and not Path(file_path).suffix {
             return file_response(request, str(index), cache_control='no-cache');
         }

--- a/jac/jaclang/server/endpoints/pages.jac
+++ b/jac/jaclang/server/endpoints/pages.jac
@@ -78,6 +78,15 @@ def register_page_endpoints(server: JacAPIServer) {
     settings = server.resolved_settings();
     config = get_config();
     root_app = server.introspector.resolve_root_app();
+    asset_dist = settings.client_dist;
+    if not asset_dist {
+        import from jaclang.server.sealed_serve { client_dist_for }
+        source_path = getattr(server.introspector.module, '__file__', '') or '';
+        sealed_dist = client_dist_for(source_path) if source_path else None;
+        if sealed_dist is not None {
+            asset_dist = str(sealed_dist);
+        }
+    }
 
     def render_page(request: Request, page_name: str, **kwargs: JsonValue) -> Response {
         sibling = sibling_app_dist(config, page_name, server.base_path);
@@ -218,9 +227,7 @@ def register_page_endpoints(server: JacAPIServer) {
     );
 
     def static_file(request: Request, file_path: str) -> Response {
-        candidate = find_static_candidate(
-            _static_base(server), file_path, settings.client_dist
-        );
+        candidate = find_static_candidate(_static_base(server), file_path, asset_dist);
         if candidate is None {
             return JSONResponse(
                 content={'error': 'Static file not found'}, status_code=404
@@ -253,9 +260,7 @@ def register_page_endpoints(server: JacAPIServer) {
         if file_path.startswith(API_PREFIXES) or file_path.startswith(CL_PREFIX) {
             return JSONResponse(content={'error': 'Not found'}, status_code=404);
         }
-        candidate = find_root_asset(
-            _static_base(server), file_path, settings.client_dist
-        );
+        candidate = find_root_asset(_static_base(server), file_path, asset_dist);
         if candidate is not None {
             return file_response(
                 request, str(candidate), cache_control=ASSET_CACHE_CONTROL

--- a/jac/tests/client/test_hmr_na_wasm.jac
+++ b/jac/tests/client/test_hmr_na_wasm.jac
@@ -227,3 +227,34 @@ test "a failed wasm emit does not reload the page" {
         "reloading on a failed emit swaps in nothing and hides the error"
     );
 }
+
+test "wasm and its import manifest follow the client bundle output directory" {
+    import json;
+    import from unittest.mock { patch }
+    import from jaclang.client.vite_client_bundle { ViteClientBundleBuilder }
+
+    with TemporaryDirectory() as tmp {
+        project = Path(tmp);
+        (project / "package.json").write_text('{"name":"wasm-output"}');
+        wasm = bytes.fromhex("0061736d01000000");
+        for output in [
+            project / ".jac" / "client" / "web" / "dist",
+            project / "custom-output"
+        ] {
+            builder = ViteClientBundleBuilder(
+                vite_package_json=project / "package.json", vite_output_dir=output
+            );
+            compiler = builder._get_compiler();
+            with patch(
+                "jaclang.compiler.backends.native.wasm_build.compile_to_wasm",
+                return_value=wasm
+            ) {
+                assert compiler._emit_wasm_module(project / "arena.jac");
+            }
+            assert (output / "arena.wasm").read_bytes() == wasm;
+            manifest = json.loads((output / "arena.wasm.imports.json").read_text());
+            assert manifest["imports"] == {};
+        }
+        assert not (project / ".jac" / "client" / "dist" / "arena.wasm").exists();
+    }
+}

--- a/jac/tests/client/test_runtime_import_contract.jac
+++ b/jac/tests/client/test_runtime_import_contract.jac
@@ -1,0 +1,127 @@
+import from pathlib { Path }
+import from tempfile { TemporaryDirectory }
+import from jaclang.client.vite_client_bundle { ViteClientBundleBuilder }
+import from jaclang.client.client_bundle { ClientBundleError }
+import from jaclang.project.config { set_config }
+
+def _compiler(project: Path) -> any {
+    (project / "package.json").write_text('{"name":"imports","version":"0.0.0"}');
+    (project / "jac.toml").write_text(
+        '[project]\nname = "imports"\nkind = "web-app"\n'
+        '[placement.pins]\n"provider" = "client"\n"main" = "client"\n'
+    );
+    builder = ViteClientBundleBuilder(vite_package_json=project / "package.json");
+    compiler = builder._get_compiler().jac_client_compiler;
+    compiler.compiled_dir = project / "compiled";
+    return compiler;
+}
+
+test "annotation imports disappear but values and module effects survive" {
+    with TemporaryDirectory() as tmp {
+        set_config(None);
+        project = Path(tmp);
+        compiler = _compiler(project);
+        (project / "provider.jac").write_text(
+            'obj Session { has name: str = ""; }\n'
+            'obj:pub Value { has name: str = "value"; }\n'
+            'def:pub session -> Session { return Session(); }\n'
+        );
+        (project / "main.jac").write_text(
+            'import from .provider { Session as State, Value as Item, session }\n'
+            'def:pub app -> any {\n'
+            '    state: State = session();\n'
+            '    item = Item();\n'
+            '    return <div>{state.name}{item.name}</div>;\n'
+            '}\n'
+        );
+        try {
+            compiler.compile_dependencies_recursively(
+                project / "main.jac", source_root=project
+            );
+            js = (project / "compiled" / "main.js").read_text();
+            imports = "\n".join(
+                line
+                for line in js.splitlines()
+                if line.startswith("import ")
+            );
+            assert "Session" not in imports , imports;
+            assert "Value as Item" in imports , imports;
+            assert "session" in imports , imports;
+            # The same checks must apply when compiler artifacts come from cache.
+            compiler.compile_dependencies_recursively(
+                project / "main.jac", source_root=project
+            );
+        } finally {
+            set_config(None);
+        }
+    }
+}
+
+test "missing runtime exports fail before either client bundler starts" {
+    with TemporaryDirectory() as tmp {
+        set_config(None);
+        project = Path(tmp);
+        compiler = _compiler(project);
+        (project / "provider.jac").write_text('obj Hidden { has name: str = ""; }\n');
+        (project / "main.jac").write_text(
+            'import from .provider { Hidden }\n'
+            'def:pub app -> any { value = Hidden(); return <div>{value.name}</div>; }\n'
+        );
+        try {
+            failed = False;
+            try {
+                compiler.compile_dependencies_recursively(
+                    project / "main.jac", source_root=project
+                );
+            } except ClientBundleError as error {
+                failed = True;
+                assert "runtime import(s)" in str(error) , str(error);
+                assert "Hidden" in str(error) and "provider.jac" in str(error) , str(
+                    error
+                );
+            }
+            assert failed , "invalid runtime imports reached the bundler";
+        } finally {
+            set_config(None);
+        }
+    }
+}
+
+test "an annotation-only binding preserves module evaluation" {
+    with TemporaryDirectory() as tmp {
+        set_config(None);
+        project = Path(tmp);
+        compiler = _compiler(project);
+        (project / "provider.jac").write_text(
+            'obj Session { has name: str = ""; }\n'
+            'glob:pub loads: int = 0;\n'
+            'with entry { loads += 1; }\n'
+        );
+        (project / "main.jac").write_text(
+            'import from .provider { Session }\n'
+            'def:pub app(value: Session) -> any { return <div>{value.name}</div>; }\n'
+        );
+        try {
+            compiler.compile_dependencies_recursively(
+                project / "main.jac", source_root=project
+            );
+            js = (project / "compiled" / "main.js").read_text();
+            assert 'import "./provider.js";' in js , js;
+            assert (project / "compiled" / "provider.js").is_file();
+        } finally {
+            set_config(None);
+        }
+    }
+}
+
+test "client artifact caches preserve the runtime import contract" {
+    import pickle;
+    import from jaclang.compiler.frontend.codeinfo { ClientArtifact, ClientManifest }
+    manifest = ClientManifest(runtime_imports={"provider.jac": ["Value"]});
+    artifact = ClientArtifact(js="", manifest=manifest);
+    restored = ClientArtifact.from_bytes(artifact.to_bytes());
+    assert restored is not None;
+    assert restored.manifest.runtime_imports == manifest.runtime_imports;
+    legacy = pickle.dumps(("", manifest, [], [], {}, ""));
+    assert ClientArtifact.from_bytes(legacy) is None;
+}

--- a/jac/tests/client/test_runtime_import_contract.jac
+++ b/jac/tests/client/test_runtime_import_contract.jac
@@ -125,3 +125,53 @@ test "client artifact caches preserve the runtime import contract" {
     legacy = pickle.dumps(("", manifest, [], [], {}, ""));
     assert ClientArtifact.from_bytes(legacy) is None;
 }
+
+test "jsx references and shadowed names retain their runtime imports" {
+    with TemporaryDirectory() as tmp {
+        set_config(None);
+        project = Path(tmp);
+        compiler = _compiler(project);
+        (project / "provider.jac").write_text(
+            'def:pub Button -> any { return <button>ok</button>; }\n'
+            'def:pub value -> int { return 1; }\n'
+        );
+        (project / "main.jac").write_text(
+            'import from .provider { Button, value }\n'
+            'def shadow(value: int) -> int { return value; }\n'
+            'def:pub app -> any { assert value() == 1; return <Button />; }\n'
+        );
+        try {
+            compiler.compile_dependencies_recursively(
+                project / "main.jac", source_root=project
+            );
+            js = (project / "compiled" / "main.js").read_text();
+            imports = "\n".join(
+                line
+                for line in js.splitlines()
+                if line.startswith("import ")
+            );
+            assert "Button" in imports and "value" in imports , imports;
+        } finally {
+            set_config(None);
+        }
+    }
+}
+
+test "native runtime emits dependencies for bare imports" {
+    with TemporaryDirectory() as tmp {
+        set_config(None);
+        project = Path(tmp);
+        compiler = _compiler(project);
+        try {
+            (js, exports) = compiler.compile_runtime_utils(
+                compiler.NATIVE_RUNTIME_FILE
+            );
+            assert "html_tag_map.js" in js;
+            assert (
+                project / "compiled" / "targets" / "react_native" / "html_tag_map.js"
+            ).is_file();
+        } finally {
+            set_config(None);
+        }
+    }
+}

--- a/jac/tests/client/test_sealed_serve.jac
+++ b/jac/tests/client/test_sealed_serve.jac
@@ -161,6 +161,7 @@ test "sealed static endpoints use the image even with an unrelated runtime base"
     import from types { SimpleNamespace }
     import from unittest.mock { MagicMock, patch }
     import from jaclang.server.endpoints.pages { register_page_endpoints }
+    import from jaclang.server.server { JacAPIServer, ModuleIntrospector }
 
     with tempfile.TemporaryDirectory() as tmp {
         img_root = _sealed_root(tmp);
@@ -170,10 +171,9 @@ test "sealed static endpoints use the image even with an unrelated runtime base"
         (dist / "arena.wasm.imports.json").write_text('{"imports":{}}');
         unrelated = Path(tmp) / "elsewhere";
         unrelated.mkdir();
-        server: any = MagicMock();
-        server.introspector.module = SimpleNamespace(
-            __file__=str(Path(img_root) / "main.jac")
-        );
+        server: any = MagicMock(spec=JacAPIServer);
+        server.introspector = MagicMock(spec=ModuleIntrospector);
+        server.module = SimpleNamespace(__file__=str(Path(img_root) / "main.jac"));
         server.introspector.resolve_root_app.return_value = "app";
         server.resolved_settings.return_value = SimpleNamespace(client_dist="");
         with patch("jaclang.server.endpoints.pages.get_config", return_value=None), patch(

--- a/jac/tests/client/test_sealed_serve.jac
+++ b/jac/tests/client/test_sealed_serve.jac
@@ -156,3 +156,44 @@ test "jac build inside a sealed host builds the nested project's bundle" {
         shutil.rmtree(tmp, ignore_errors=True);
     }
 }
+
+test "sealed static endpoints use the image even with an unrelated runtime base" {
+    import from types { SimpleNamespace }
+    import from unittest.mock { MagicMock, patch }
+    import from jaclang.server.endpoints.pages { register_page_endpoints }
+
+    with tempfile.TemporaryDirectory() as tmp {
+        img_root = _sealed_root(tmp);
+        dist = Path(img_root) / ".jac" / "client" / "dist";
+        wasm = bytes.fromhex("0061736d01000000");
+        (dist / "arena.wasm").write_bytes(wasm);
+        (dist / "arena.wasm.imports.json").write_text('{"imports":{}}');
+        unrelated = Path(tmp) / "elsewhere";
+        unrelated.mkdir();
+        server: any = MagicMock();
+        server.introspector.module = SimpleNamespace(
+            __file__=str(Path(img_root) / "main.jac")
+        );
+        server.introspector.resolve_root_app.return_value = "app";
+        server.resolved_settings.return_value = SimpleNamespace(client_dist="");
+        with patch("jaclang.server.endpoints.pages.get_config", return_value=None), patch(
+            "jaclang.server.endpoints.pages._static_base", return_value=str(unrelated)
+        ) {
+            register_page_endpoints(server);
+            routes = {
+                call.args[0].path: call.args[0].callback
+                for call in server.add_endpoint.call_args_list
+            };
+            request = SimpleNamespace(method="GET", headers={});
+            response = routes["/static/{file_path:path}"](request, "arena.wasm");
+            assert response.status_code == 200;
+            assert response.body == wasm;
+            assert response.content_type_header() == "application/wasm";
+            response = routes["/static/{file_path:path}"](
+                request, "arena.wasm.imports.json"
+            );
+            assert response.status_code == 200;
+            assert json.loads(response.body) == {"imports": {}};
+        }
+    }
+}

--- a/jac/tests/client/test_sealed_serve.jac
+++ b/jac/tests/client/test_sealed_serve.jac
@@ -167,6 +167,11 @@ test "sealed static endpoints use the image even with an unrelated runtime base"
         img_root = _sealed_root(tmp);
         dist = Path(img_root) / ".jac" / "client" / "dist";
         wasm = bytes.fromhex("0061736d01000000");
+        html = '<html><head><link rel="stylesheet" href="/static/client.HOSTHASH.css"></head><body>sealed app</body></html>';
+        (dist / "index.html").write_text(html);
+        (dist / "client.HOSTHASH.css").write_text(
+            ".uppercase{text-transform:uppercase}"
+        );
         (dist / "arena.wasm").write_bytes(wasm);
         (dist / "arena.wasm.imports.json").write_text('{"imports":{}}');
         unrelated = Path(tmp) / "elsewhere";
@@ -185,6 +190,16 @@ test "sealed static endpoints use the image even with an unrelated runtime base"
                 for call in server.add_endpoint.call_args_list
             };
             request = SimpleNamespace(method="GET", headers={});
+            for (route, args) in [("/", []), ("/{file_path:path}", ["wait-wuuut"])] {
+                response = routes[route](request, *args);
+                assert response.status_code == 200;
+                assert response.body.decode() == html;
+            }
+            response = routes["/static/{file_path:path}"](
+                request, "client.HOSTHASH.css"
+            );
+            assert response.status_code == 200;
+            assert b"text-transform:uppercase" in response.body;
             response = routes["/static/{file_path:path}"](request, "arena.wasm");
             assert response.status_code == 200;
             assert response.body == wasm;

--- a/jac/tests/compiler/backends/es/test_js_generation.jac
+++ b/jac/tests/compiler/backends/es/test_js_generation.jac
@@ -370,11 +370,11 @@ test "category1 named imports generate correct js" {
         "import { helper } from \"./utils.js\";",
         "import { formatter as format } from \"../lib.js\";",
         "import { settings } from \"../../config.js\";",
-        "import { renderJsxTree, jacLogin, jacLogout } from \"@jac/runtime\";",
+        "import { jacLogin } from \"@jac/runtime\";",
 
     ];
     for pattern in imports {
-        assert pattern in js_code;
+        assert pattern in js_code , f"Missing {pattern}: {js_code}";
     }
 
     assert "function example_usage()" in js_code;

--- a/release_notes/unreleased/jaclang/9011.bugfix.md
+++ b/release_notes/unreleased/jaclang/9011.bugfix.md
@@ -1,1 +1,1 @@
-Fix annotation-only client imports breaking development startup, validate runtime imports consistently, and exercise bare `jac run` in packaged smoke tests. Preserve existing CLI behavior and clean up Vite on server shutdown.
+- **Client: Fix development runtime imports**: Remove annotation-only imports that break development startup, preserve JSX and embedded JavaScript references, and validate remaining runtime imports consistently. Exercise bare `jac run` in packaged smoke tests and clean up Vite on server shutdown without changing CLI behavior.

--- a/release_notes/unreleased/jaclang/9011.bugfix.md
+++ b/release_notes/unreleased/jaclang/9011.bugfix.md
@@ -1,0 +1,1 @@
+Fix annotation-only client imports breaking development startup, validate runtime imports consistently, and exercise bare `jac run` in packaged smoke tests. Preserve existing CLI behavior and clean up Vite on server shutdown.


### PR DESCRIPTION
## Description

Bare `jac run` starts web apps with Vite/HMR. Annotation-only Jac imports such as `Session` and `JacYacState` could survive JavaScript lowering without matching runtime exports, causing development startup to fail. Pack smoke exercised production serving and missed that first-run failure.

- Remove Jac import bindings with no emitted runtime references while preserving module evaluation. Retain references from JSX and embedded JavaScript, record and validate remaining imports in the shared client compiler, and invalidate older cached artifacts. Native runtime assembly handles bare side-effect imports.
- Run the pack smoke browser journey through the exact bare `jac run` quickstart, check HMR startup and dependency-scan errors, then repeat the journey against a built `.jab` served outside the source project. Keep fleet coverage.
- Stop the hot reloader and Vite when the server exits, including normal shutdown.
- Emit Wasm and its import manifest beside the selected client bundle so app-specific and custom outputs reach sealed artifacts. Resolve sealed assets from the served module, and serve built entry HTML for root/client routes so production stylesheet links are preserved.
- Save type-check caches only after successful checks and skip restoring them on retries. Start a new cache namespace to discard entries saved by failed checks.

The CLI surface and existing `--serve` behavior remain unchanged.

## Validation

- Added regressions for import retention/removal, missing exports, module evaluation, artifact cache compatibility, JSX/assertion references, shadowing, and native runtime dependencies.
- Added regressions for app-specific/custom Wasm outputs and sealed HTML, stylesheet, and Wasm serving from an unrelated runtime base. All eight HMR/Wasm tests and all five sealed-image tests passed locally, including the nested-project build.
- Focused import-contract and CLI compatibility tests: 19 passed. JavaScript-generation, SSO, and Solid tests also passed in CI.
- [Full CI passed on `c9124794e`](https://github.com/jaseci-labs/jac/actions/runs/34113575944), including the overall check. Pack smoke passed all three browser journeys: bare `jac run`, the production artifact outside the source project, and fleet gateway serving. Compiler, client, runtime, scale, Kubernetes, bootstrap, and Android jobs passed.
- Workflow YAML parsing, smoke shell syntax, targeted formatting, and `git diff --check` passed.
- Full CI type check: 1,020 files passed with a fresh cache. The previous restored cache repeatedly produced 13 missing Pillow-member diagnostics in unchanged byLLM code; the cache change discarded those entries and provides a cold retry path.
- Local limitations: an existing asset test differs in macOS `/var` versus `/private/var` path spelling. The full local type check passed 1,017 files and failed three files that passed in CI. The commit hook was bypassed after existing ES backend diagnostics in files listed in `.jacignore`; relevant formatting and targeted checks were run directly.
