### PR TITLE
test(scale): fold the config unit tests into per-axis tables

### DIFF
--- a/jac/jaclang/scale/tests/apps/test_app_scale_overrides.jac
+++ b/jac/jaclang/scale/tests/apps/test_app_scale_overrides.jac
@@ -14,11 +14,7 @@ import from jaclang.scale.config.config_loader {
     normalize_gateway_config,
     reset_scale_config
 }
-import from jaclang.scale.config.validation {
-    STRICT_ENV,
-    validate_app_scale_config,
-    validate_scale_config
-}
+import from jaclang.scale.config.validation { STRICT_ENV, validate_app_scale_config }
 import from jaclang.scale.runtime.fleet { fleet_from_config }
 
 glob _TOML: str = '[project]\n'
@@ -173,14 +169,6 @@ test "an unknown per-app key is flagged with a suggestion" {
     assert len(msgs) == 1 , msgs;
     assert "apps.orders.scale" in msgs[0] , msgs[0];
     assert "did you mean 'cpu_limit'" in msgs[0] , msgs[0];
-}
-
-
-test "the old [scale.microservices] table is unknown to the schema" {
-    msgs = validate_scale_config({"microservices": {"routes": {}}});
-    assert len(msgs) == 1 , msgs;
-    assert "microservices" in msgs[0] , msgs[0];
-    assert "gateway" in JacScaleConfig().get_config_schema()["options"];
 }
 
 

--- a/jac/jaclang/scale/tests/deploy/test_gateway_config_isolation.jac
+++ b/jac/jaclang/scale/tests/deploy/test_gateway_config_isolation.jac
@@ -44,7 +44,7 @@ def _builder -> ManifestBuilder {
 }
 
 
-test "k8s_safe_name only ever yields an RFC 1123 name" {
+test "k8s_safe_name yields an RFC 1123 name or refuses, naming the input" {
     import re;
     rfc1123 = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$");
     for raw in [
@@ -60,36 +60,24 @@ test "k8s_safe_name only ever yields an RFC 1123 name" {
         assert rfc1123.`match(safe) , f"{raw!r} produced non-RFC-1123 name {safe!r}";
         assert len(safe) <= 253 , f"{raw!r} produced a {len(safe)}-char name";
     }
-}
-
-
-test "k8s_safe_name refuses an unresolved env placeholder" {
-    raised = False;
-    try {
-        k8s_safe_name("${SHARED_DATA_PVC}");
-    } except ValueError as e {
-        raised = True;
-        assert "SHARED_DATA_PVC" in str(e);
-        assert "placeholder" in str(e);
-    }
-    assert raised , "expected an unresolved placeholder to raise";
-}
-
-
-test "k8s_safe_name rejects a name with nothing usable left" {
-    raised = False;
-    try {
-        k8s_safe_name("!!!");
-    } except ValueError as e {
-        raised = True;
-        assert "!!!" in str(e);
-    }
-    assert raised , "expected a name with no usable characters to raise";
-}
-
-
-test "the gateway keeps its reserved short name" {
     assert k8s_safe_name(GATEWAY_NAME) == "gateway";
+    # (input, text the ValueError must carry)
+    for row in [
+        ("${SHARED_DATA_PVC}", ["SHARED_DATA_PVC", "placeholder"]),
+        ("!!!", ["!!!"])
+    ] {
+        (raw, fragments) = row;
+        raised = "";
+        try {
+            k8s_safe_name(raw);
+        } except ValueError as e {
+            raised = str(e);
+        }
+        assert raised , f"{raw!r} was accepted instead of refused";
+        for fragment in fragments {
+            assert fragment in raised , f"{raw!r}: {raised}";
+        }
+    }
 }
 
 

--- a/jac/jaclang/scale/tests/misc/test_config_loader.jac
+++ b/jac/jaclang/scale/tests/misc/test_config_loader.jac
@@ -13,109 +13,64 @@ import from jaclang.scale.deploy.target.kubernetes.kubernetes_config {
 }
 
 
-test "get_gateway_config returns ingress block" {
-    cfg = JacScaleConfig();
-    cfg._config = {
-        "gateway": {
-            "ingress": {
-                "enabled": True,
-                "host": "jac-shop.local",
-                "ingress_class_name": "nginx",
-                "annotations": {"nginx.ingress.kubernetes.io/proxy-body-size": "10m"}
-            }
-        }
+glob _GATEWAY_KEYS: set[str] = {
+         "colocate",
+         "gateway_port",
+         "gateway_host",
+         "http_forward_timeout",
+         "rate_limit",
+         "cors",
+         "identity",
+         "ingress",
+         "logs",
+         "tracing",
+         "shared_volumes"
+     };
+
+
+test "get_gateway_config fills every section and never reads the fleet from the environment" {
+    ingress = {
+        "enabled": True,
+        "host": "jac-shop.local",
+        "ingress_class_name": "nginx",
+        "annotations": {"nginx.ingress.kubernetes.io/proxy-body-size": "10m"}
     };
-    out = cfg.get_gateway_config();
-    assert "ingress" in out;
-    ing = out["ingress"];
-    assert ing["enabled"] is True;
-    assert ing["host"] == "jac-shop.local";
-    assert ing["ingress_class_name"] == "nginx";
-    assert ing["annotations"]["nginx.ingress.kubernetes.io/proxy-body-size"] == "10m";
-}
-
-
-test "get_gateway_config ingress defaults to {} when section absent" {
-    cfg = JacScaleConfig();
-    cfg._config = {"gateway": {"colocate": False}};
-    out = cfg.get_gateway_config();
-    assert out["ingress"] == {};
-}
-
-
-test "get_gateway_config preserves all sections (regression guard)" {
-    cfg = JacScaleConfig();
-    cfg._config = {
-        "gateway": {
-            "colocate": False,
-            "gateway_port": 9000,
-            "http_forward_timeout": 60,
-            "replicas": 2,
-            "ingress": {"enabled": False}
-        }
-    };
-    out = cfg.get_gateway_config();
-    expected_keys: set[str] = {
-        "colocate",
-        "gateway_port",
-        "gateway_host",
-        "http_forward_timeout",
-        "replicas",
-        "rate_limit",
-        "cors",
-        "identity",
-        "ingress",
-        "logs",
-        "tracing",
-        "shared_volumes"
-    };
-    missing = expected_keys - set(out.keys());
-    assert not missing , f"missing keys: {missing}";
-    assert out["gateway_port"] == 9000;
-    assert out["replicas"] == 2;
-}
-
-
-test "get_gateway_config logs block defaults to {} when absent" {
-    cfg = JacScaleConfig();
-    cfg._config = {"gateway": {}};
-    out = cfg.get_gateway_config();
-    assert out["logs"] == {};
-}
-
-
-test "get_gateway_config logs block round-trips enabled flag" {
-    cfg = JacScaleConfig();
-    cfg._config = {"gateway": {"logs": {"enabled": True}}};
-    out = cfg.get_gateway_config();
-    assert out["logs"] == {"enabled": True};
-}
-
-
-test "get_gateway_config colocates by default" {
-    cfg = JacScaleConfig();
-    cfg._config = {"gateway": {"gateway_port": 8000}};
-    assert cfg.get_gateway_config()["colocate"] is True;
-    cfg._config = {};
-    assert cfg.get_gateway_config()["colocate"] is True;
-}
-
-
-test "get_gateway_config preserves an explicit colocate = false" {
-    cfg = JacScaleConfig();
-    cfg._config = {"gateway": {"colocate": False}};
-    assert cfg.get_gateway_config()["colocate"] is False;
-}
-
-
-test "get_gateway_config never reads the fleet from the environment" {
-    cfg = JacScaleConfig();
-    cfg._config = {"gateway": {}};
+    # (raw config, values the normalized gateway block must carry)
+    cases = [
+        ({}, {"colocate": True, "ingress": {}, "logs": {}}),
+        ({"gateway": {"gateway_port": 8000}}, {"colocate": True, "gateway_port": 8000}),
+        ({"gateway": {"colocate": False}}, {"colocate": False, "ingress": {}}),
+        ({"gateway": {"logs": {"enabled": True}}}, {"logs": {"enabled": True}}),
+        ({"gateway": {"ingress": ingress}}, {"ingress": ingress}),
+        (
+            {
+                "gateway": {
+                    "colocate": False,
+                    "gateway_port": 9000,
+                    "http_forward_timeout": 60,
+                    "replicas": 2,
+                    "ingress": {"enabled": False}
+                }
+            },
+            {"gateway_port": 9000, "replicas": 2, "ingress": {"enabled": False}}
+        )
+    ];
     os.environ["JAC_SV_FLEET"] = '{"root": "web", "members": []}';
     try {
-        out = cfg.get_gateway_config();
-        assert "routes" not in out;
-        assert "members" not in out;
+        for row in cases {
+            (raw, expected) = row;
+            cfg = JacScaleConfig();
+            cfg._config = raw;
+            out = cfg.get_gateway_config();
+            missing = _GATEWAY_KEYS - set(out.keys());
+            assert not missing , f"{raw!r}: missing keys {missing}";
+            for (key, want) in expected.items() {
+                assert out[key] == want , f"{raw!r}: {key} = {out[key]!r}, expected {want!r}";
+            }
+            assert "routes" not in out and "members" not in out , (
+                f"{raw!r}: the fleet leaked in from the environment"
+            );
+        }
     } finally {
         del os.environ["JAC_SV_FLEET"];
     }
@@ -158,7 +113,7 @@ test "config sections read by config_loader are schema-declared (#8000 1.2)" {
 }
 
 
-test "get_kubernetes_config leaves the cached config dict unmutated" {
+test "get_kubernetes_config derives its keys without writing them back, so repeated calls agree" {
     # load() returns the cached dict by reference; deriving kubernetes keys
     # must not write them back, or later readers of the raw config see
     # derived values as if the user had configured them.
@@ -167,23 +122,10 @@ test "get_kubernetes_config leaves the cached config dict unmutated" {
         "kubernetes": {"namespace": "demo"},
         "monitoring": {"namespace": "demo_metrics"}
     };
-    cfg.get_kubernetes_config();
+    first = cfg.get_kubernetes_config();
+    assert cfg.get_kubernetes_config() == first;
     leaked = cfg._config["kubernetes"];
     assert leaked == {"namespace": "demo"} , f"derived keys leaked into the cached config: {leaked}";
-}
-
-
-test "repeated get_kubernetes_config calls return equal results" {
-    # Pre-copy, every call stacked derived keys onto the cached dict, so the
-    # result depended on how many times it had been called before.
-    cfg = JacScaleConfig();
-    cfg._config = {
-        "kubernetes": {"namespace": "demo"},
-        "monitoring": {"namespace": "demo_metrics"}
-    };
-    first = cfg.get_kubernetes_config();
-    second = cfg.get_kubernetes_config();
-    assert first == second;
 }
 
 
@@ -269,35 +211,10 @@ test "the monitoring namespace is sanitized on every path, and only a rewrite wa
 
 
 # KubernetesConfig's has-declaration is the only place a [scale.kubernetes]
-# default lives, so these drive a real jac.toml through the real loader rather
+# default lives, so this drives a real jac.toml through the real loader rather
 # than asserting against a second copy of the defaults.
 
-test "an unwritten [scale.kubernetes] key resolves to the declaration" {
-    with tempfile.TemporaryDirectory() as project {
-        (Path(project) / "jac.toml").write_text(
-            '[project]\nname = "decl-app"\nversion = "0.0.1"\n'
-        );
-        resolved = JacScaleConfig(project_dir=Path(project)).get_kubernetes_config();
-        declared = KubernetesConfig();
-        for name in [
-            "min_replicas",
-            "max_replicas",
-            "cpu_utilization_target",
-            "memory_utilization_target",
-            "readiness_initial_delay",
-            "liveness_failure_threshold",
-            "container_port"
-        ] {
-            got = resolved[name];
-            want = getattr(declared, name);
-            assert got == want , f"{name} resolved to {got!r}, not the declared {want!r}";
-        }
-        assert resolved["app_name"] == "decl-app";
-    }
-}
-
-
-test "every [scale.kubernetes] key a user writes reaches the resolved config" {
+test "every [scale.kubernetes] key reaches the resolved config, written, declared, or derived" {
     # One sweep over every declared scalar field, so a key dropped between the
     # toml and the resolved config fails by name instead of waiting for someone
     # to notice their setting had no effect (#8401 was one such field).
@@ -314,10 +231,22 @@ test "every [scale.kubernetes] key a user writes reaches the resolved config" {
         "prometheus_admin_password",
         "service_dependencies"
     };
+    # Left out of the toml, so they must resolve to the declaration itself;
+    # app_name is left out so it derives from [project].name instead.
+    unwritten: set[str] = {
+        "app_name",
+        "min_replicas",
+        "max_replicas",
+        "cpu_utilization_target",
+        "memory_utilization_target",
+        "readiness_initial_delay",
+        "liveness_failure_threshold",
+        "container_port"
+    };
     written: dict[str, any] = {};
     lines: list[str] = [];
     for f in fields(KubernetesConfig) {
-        if f.name in not_written {
+        if f.name in not_written or f.name in unwritten {
             continue;
         }
         val = getattr(declared, f.name);
@@ -337,12 +266,13 @@ test "every [scale.kubernetes] key a user writes reaches the resolved config" {
         }
         written[f.name] = new_val;
     }
-    assert len(written) > 30 , (
+    assert len(written) > 25 , (
         f"only {len(written)} keys were probed; the sweep stopped covering the section"
     );
     with tempfile.TemporaryDirectory() as project {
         (Path(project) / "jac.toml").write_text(
             '[project]\nname = "sweep-app"\nversion = "0.0.1"\n\n'
+            '[scale.admin]\nusername = "metrics-admin"\n\n'
             '[scale.kubernetes]\n'
                 + "\n".join(lines)
                 + "\n"
@@ -358,19 +288,13 @@ test "every [scale.kubernetes] key a user writes reaches the resolved config" {
         assert missing == [] , (
             f"a written [scale.kubernetes] key never reached the resolved config: {missing}"
         );
-    }
-}
-
-
-test "a value from another section reaches the kubernetes config" {
-    # admin_username is emitted by the loader from [scale.admin], not written
-    # under [scale.kubernetes], so it exercises the hand-off the sweep skips.
-    with tempfile.TemporaryDirectory() as project {
-        (Path(project) / "jac.toml").write_text(
-            '[project]\nname = "admin-app"\nversion = "0.0.1"\n\n'
-            '[scale.admin]\nusername = "metrics-admin"\n'
-        );
-        resolved = JacScaleConfig(project_dir=Path(project)).get_kubernetes_config();
+        for name in sorted(unwritten - {"app_name"}) {
+            got = resolved[name];
+            want = getattr(declared, name);
+            assert got == want , f"{name} resolved to {got!r}, not the declared {want!r}";
+        }
+        assert resolved["app_name"] == "sweep-app";
+        # admin_username comes from [scale.admin], the hand-off the sweep skips.
         assert resolved["admin_username"] == "metrics-admin";
     }
 }

--- a/jac/jaclang/scale/tests/misc/test_config_validation.jac
+++ b/jac/jaclang/scale/tests/misc/test_config_validation.jac
@@ -42,61 +42,74 @@ def _collect_default_mismatches(
     }
 }
 
-test "unknown section is flagged with a suggestion" {
-    msgs = validate_scale_config({"gatway": {"colocate": True}});
-    assert len(msgs) == 1 , f"expected 1 finding, got {msgs}";
-    assert "gatway" in msgs[0] , msgs[0];
-    assert "did you mean 'gateway'" in msgs[0] , msgs[0];
-}
-
-test "unknown nested key is flagged with a suggestion" {
-    msgs = validate_scale_config({"kubernetes": {"cpu_limits": "1000m"}});
-    assert len(msgs) == 1 , f"expected 1 finding, got {msgs}";
-    assert "scale.kubernetes" in msgs[0] , msgs[0];
-    assert "did you mean 'cpu_limit'" in msgs[0] , msgs[0];
-}
-
-test "gateway nested unknown key is flagged" {
-    msgs = validate_scale_config({"gateway": {"gateway_prot": 8001}});
-    assert len(msgs) == 1 , f"expected 1 finding, got {msgs}";
-    assert "scale.gateway" in msgs[0] , msgs[0];
-    assert "did you mean 'gateway_port'" in msgs[0] , msgs[0];
-}
-
-test "open dict sections accept arbitrary keys" {
-    cfg = {
-        "secrets": {"MY_API_KEY": "${MY_API_KEY}"},
-        "kubernetes": {"labels": {"team": "core"}},
-        "gateway": {
-            "env": {"LOG_LEVEL": "DEBUG"},
-            "deployment_overlay": {"spec": {"replicas": 2}},
-            "hpa": {"behavior": {"scaleDown": {"stabilizationWindowSeconds": 600}}}
+test "an unknown key is reported once, at its path, with a suggestion" {
+    # (config, text the single finding must carry)
+    cases = [
+        ({"gatway": {"colocate": True}}, ["gatway", "did you mean 'gateway'"]),
+        (
+            {"kubernetes": {"cpu_limits": "1000m"}},
+            ["scale.kubernetes", "did you mean 'cpu_limit'"]
+        ),
+        (
+            {"gateway": {"gateway_prot": 8001}},
+            ["scale.gateway", "did you mean 'gateway_port'"]
+        ),
+        (
+            {"deploy": {"target": "kuberntes"}},
+            ["kuberntes", "did you mean 'kubernetes'"]
+        ),
+        ({"microservices": {"routes": {}}}, ["microservices"]),
+        ({"sso": "not-a-table", "bogus": 1}, ["bogus"])
+    ];
+    for row in cases {
+        (cfg, fragments) = row;
+        msgs = validate_scale_config(cfg);
+        assert len(msgs) == 1 , f"{cfg!r}: expected 1 finding, got {msgs}";
+        for fragment in fragments {
+            assert fragment in msgs[0] , f"{cfg!r}: {msgs[0]}";
         }
-    };
-    msgs = validate_scale_config(cfg);
-    assert msgs == [] , f"expected no findings, got {msgs}";
+    }
 }
 
-test "valid config produces no findings" {
-    cfg = {
-        "sso": {"host": "http://localhost:8000"},
-        "server": {"structured_logs": False},
-        "kubernetes": {"namespace": "prod", "cpu_limit": "1000m"},
-        "fat_bundle": True,
-        "seal_timeout": 120
-    };
-    assert validate_scale_config(cfg) == [];
-}
-
-test "non-dict section values do not crash the validator" {
-    msgs = validate_scale_config({"sso": "not-a-table", "bogus": 1});
-    assert len(msgs) == 1 , f"expected only the bogus finding, got {msgs}";
-    assert "bogus" in msgs[0] , msgs[0];
-}
-
-test "empty or missing config is fine" {
-    assert validate_scale_config({}) == [];
-    assert validate_scale_config(None) == [];
+test "declared, open-dict, and platform-injected keys produce no findings" {
+    for cfg in [
+        {},
+        None,
+        {
+            "sso": {"host": "http://localhost:8000"},
+            "server": {"structured_logs": False},
+            "kubernetes": {"namespace": "prod", "cpu_limit": "1000m"},
+            "fat_bundle": True,
+            "seal_timeout": 120
+        },
+        {
+            "secrets": {"MY_API_KEY": "${MY_API_KEY}"},
+            "kubernetes": {"labels": {"team": "core"}},
+            "gateway": {
+                "env": {"LOG_LEVEL": "DEBUG"},
+                "deployment_overlay": {"spec": {"replicas": 2}},
+                "hpa": {"behavior": {"scaleDown": {"stabilizationWindowSeconds": 600}}}
+            }
+        },
+        {
+            "storage": {"backend": "postgres", "type": "sv"},
+            "deploy": {"target": "kubernetes"},
+            "tracing": {"enabled": True},
+            "scheduler": {"enabled": True}
+        },
+        {
+            "gateway": {
+                "colocate": False,
+                "boot_health_timeout": 60.0,
+                "boot_max_wait": 120,
+                "health_monitor_interval": 10.0,
+                "route_refresh_seconds": 5.0
+            }
+        }
+    ] {
+        msgs = validate_scale_config(cfg);
+        assert msgs == [] , f"{cfg!r}: expected no findings, got {msgs}";
+    }
 }
 
 test "every default config key is declared in the schema" {
@@ -186,46 +199,25 @@ test "the [scale.kubernetes] schema agrees with the declaration it documents" {
 }
 
 
-test "reporting does not raise outside strict mode" {
+test "strict mode raises on findings only while its env name is set and non-empty" {
+    import from jaclang.project.config_schema { schema_strict_enabled }
+    findings = validate_scale_config({"gatway": {}});
     os.environ.pop(STRICT_ENV, None);
-    report_schema_findings(validate_scale_config({"gatway": {}}), "scale", STRICT_ENV);
-}
-
-test "strict env raises on unknown keys" {
+    report_schema_findings(findings, "scale", STRICT_ENV);
     os.environ[STRICT_ENV] = "1";
     try {
-        raised = False;
+        raised = "";
         try {
-            report_schema_findings(
-                validate_scale_config({"gatway": {}}), "scale", STRICT_ENV
-            );
+            report_schema_findings(findings, "scale", STRICT_ENV);
         } except ValueError as e {
-            raised = True;
-            assert "gatway" in str(e) , str(e);
+            raised = str(e);
         }
-        assert raised , "expected ValueError in strict mode";
-    } finally {
-        os.environ.pop(STRICT_ENV, None);
-    }
-}
-
-test "strict env ignores a clean config" {
-    os.environ[STRICT_ENV] = "1";
-    try {
+        assert "gatway" in raised , f"strict mode did not raise on an unknown key: {raised!r}";
         report_schema_findings(
             validate_scale_config({"server": {"structured_logs": False}}),
             "scale",
             STRICT_ENV
         );
-    } finally {
-        os.environ.pop(STRICT_ENV, None);
-    }
-}
-
-test "an empty strict-env name never escalates" {
-    import from jaclang.project.config_schema { schema_strict_enabled }
-    os.environ[STRICT_ENV] = "1";
-    try {
         assert not schema_strict_enabled("");
         report_schema_findings(["some finding"], "byllm", "");
     } finally {
@@ -358,42 +350,20 @@ test "shipped jac.toml files validate clean" {
     assert checked > 0 , f"sweep found no [scale] tables under {repo}";
 }
 
-test "platform-injected and capability-intent keys are recognized" {
-    cfg = {
-        "storage": {"backend": "postgres", "type": "sv"},
-        "deploy": {"target": "kubernetes"},
-        "tracing": {"enabled": True},
-        "scheduler": {"enabled": True}
-    };
-    msgs = validate_scale_config(cfg);
-    assert msgs == [] , f"expected no findings, got {msgs}";
-}
-
-test "documented gateway boot keys are recognized" {
-    cfg = {
-        "gateway": {
-            "colocate": False,
-            "boot_health_timeout": 60.0,
-            "boot_max_wait": 120,
-            "health_monitor_interval": 10.0,
-            "route_refresh_seconds": 5.0
-        }
-    };
-    msgs = validate_scale_config(cfg);
-    assert msgs == [] , f"expected no findings, got {msgs}";
-}
-
-test "every known deploy target owns a config section" {
+test "a deploy target owns its config section exactly when the factory can build it" {
+    import from jaclang.scale.deploy.target.factory {
+        BUILTIN_TARGET_TYPES,
+        DeploymentTargetFactory
+    }
+    for name in BUILTIN_TARGET_TYPES {
+        assert name in known_deploy_targets() , name;
+    }
     for name in known_deploy_targets() {
         msgs = validate_scale_config(
             {"deploy": {"target": name}, name: {"namespace": "prod"}}
         );
         assert msgs == [] , f"target '{name}' section flagged: {msgs}";
     }
-}
-
-test "a registered plugin target owns its section" {
-    import from jaclang.scale.deploy.target.factory { DeploymentTargetFactory }
     assert "fly" not in known_deploy_targets();
     before = validate_scale_config({"fly": {"app_name": "demo"}});
     assert len(before) == 1 , f"expected 1 finding, got {before}";
@@ -408,20 +378,6 @@ test "a registered plugin target owns its section" {
         assert after == [] , f"registered target section flagged: {after}";
     } finally {
         DeploymentTargetFactory._registry.pop("fly", None);
-    }
-}
-
-test "a misspelled deploy target is reported instead of silencing its section" {
-    msgs = validate_scale_config({"deploy": {"target": "kuberntes"}});
-    assert len(msgs) == 1 , f"expected 1 finding, got {msgs}";
-    assert "kuberntes" in msgs[0] , msgs[0];
-    assert "did you mean 'kubernetes'" in msgs[0] , msgs[0];
-}
-
-test "known targets are exactly the ones the factory can build" {
-    import from jaclang.scale.deploy.target.factory { BUILTIN_TARGET_TYPES }
-    for name in BUILTIN_TARGET_TYPES {
-        assert name in known_deploy_targets() , name;
     }
 }
 


### PR DESCRIPTION
## Description

The scale config tests had grown one test per input value with identical setup. This folds each cluster into one test over a case table, where every row runs every assertion its siblings used to make separately. No assertion is dropped; one gets stronger.

| file | before | after |
| --- | --- | --- |
| `misc/test_config_loader.jac` | 17 | 7 |
| `misc/test_config_validation.jac` | 27 | 14 |
| `deploy/test_gateway_config_isolation.jac` | 6 | 3 |
| `apps/test_app_scale_overrides.jac` | 8 | 7 |

### What was folded

- **`get_gateway_config`, 8 to 1.** One table of raw configs and the values the normalized block must carry. The key-superset guard that used to run on one config now runs on all six, and the fleet-env check runs on every row.
- **`get_kubernetes_config` cache, 2 to 1.** Same setup, so one test asserts both that repeated calls agree and that nothing leaked into the cached dict.
- **Real-toml kubernetes, 3 to 1.** One project writes the sweep, holds seven keys back to prove they resolve to the declaration, derives `app_name` from `[project].name`, and carries the `[scale.admin]` hand-off. `app_name` is no longer written by the sweep, so the derived-slug path stays covered.
- **Unknown-key suggestions, 4 to 1 plus one row moved.** The `[scale.microservices]` finding moves here from the app-overrides file, where its siblings live. The non-dict-section case is a row too.
- **Clean configs, 5 to 1.** Empty, `None`, declared keys, open-dict sections, platform-injected keys, and documented gateway boot keys are one list.
- **Strict env, 4 to 1.** One setup and teardown for the four strict-mode behaviours.
- **Deploy targets, 3 to 1.** Factory list, per-target sections, and the registered-plugin case in one test.
- **`k8s_safe_name`, 4 to 1.** The RFC 1123 loop, the reserved gateway name, and the two refusals with their error text.

### Validation

All four files pass locally: 7, 14, 3, 7. `jac check` clean on all four, `jac fmt` no diff. Rebased on main after #8691, whose table-driven namespace test sits untouched in the loader file.

Part of the scale test consolidation plan; this is the pure-unit slice with no cluster or subprocess involvement.
