### PR TITLE
style: jac fmt --lintfix guide_store.impl.jac so main's jac-check passes again

### DIFF
--- a/jac/jaclang/cli/impl/guide_store.impl.jac
+++ b/jac/jaclang/cli/impl/guide_store.impl.jac
@@ -598,7 +598,7 @@ impl guide_sections(g: Guide) -> list[GuideSection] {
         base = re.sub(r"[\s-]+", "-", base).strip("-") or "section";
         ordinal = counts.get(base, 0) + 1;
         slug = base if ordinal == 1 else f"{base}-{ordinal}";
-        # A literal heading can collide with a generated duplicate suffix.
+
         while slug in [h[3] for h in headings] {
             ordinal += 1;
             slug = f"{base}-{ordinal}";


### PR DESCRIPTION
Main's jac-check has failed since #9046 on `jac fmt --lintfix jac/jaclang/cli/impl/guide_store.impl.jac`: the commit landed a comment the deslop lint (strip-comments) removes, so the fmt gate fails on a file no open PR touches. One line, formatter output verbatim, `jac fmt --check --lintfix` passes locally after it.