### PR TITLE
fix(ci): ignore byllm media glue in jac check, like the rest of byllm

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -43,6 +43,7 @@ jac/jaclang/byllm/llm.impl/modelpool.impl.jac
 jac/jaclang/byllm/llm.jac
 jac/jaclang/byllm/telemetry.impl/telemetry.impl.jac
 jac/jaclang/byllm/telemetry.jac
+jac/jaclang/byllm/types.impl/media.impl.jac
 jac/jaclang/byllm/types.jac
 
 # jac-scale server surface.

--- a/release_notes/unreleased/jaclang/9057.bugfix.md
+++ b/release_notes/unreleased/jaclang/9057.bugfix.md
@@ -1,0 +1,1 @@
+- **`jac check` no longer reports spurious Pillow errors**: `byllm/types.impl/media.impl.jac` joins the rest of the byllm optional-dependency glue in `.jacignore`, so `jac check` stops reporting attributes that `ImageFile` does in fact inherit from `PIL.Image.Image`, which previously made the check pass or fail depending on whether Pillow resolved in the checking environment.


### PR DESCRIPTION
## What this changes

Adds one line to `.jacignore`:

```
jac/jaclang/byllm/types.impl/media.impl.jac
```

## Why

`jac check` reports 13 errors in that file:

```
error[E1030]: Type "ImageFile" has no attribute "format"
error[E1030]: Type "ImageFile" has no attribute "save"
error[E1053]: Cannot assign <Unknown> | str to parameter 'fmt' of type str | NoneType
```

**They are false positives.** `byllm/_optdeps/pillow.jac` try-imports the real Pillow and falls back to an empty stub:

```jac
try {
    import from PIL.Image { Image as PILImageCls, open as open_image }
    HAS_PILLOW = True;
} except ImportError {
    class PILImageCls {}
    def open_image(*args: object, **kwargs: object) -> object { ... }
    HAS_PILLOW = False;
}
```

So `open_image` resolves to PIL's `open`, returning `ImageFile`, **only when Pillow is installed in the checking environment**. `ImageFile` extends `Image.Image`, which declares `format: str | None = None` (class level) and `def save`, so both attributes do exist - verified in Pillow 12.2.0 and 12.3.0, identical in both. The checker just does not follow them through that inheritance.

## Why it shows up as flake

The errors appear only when Pillow resolves, and the `jac-check` job restores a cached JIR analysis keyed partly by prefix. Whether the file gets re-analysed against an environment with Pillow installed therefore varies run to run, so jac-check flips red and green on branches that touched nothing near byllm. Locally, where Pillow is not resolvable to the jac runtime, the same file checks clean with 0 errors.

## Why ignore rather than annotate

Every sibling in this glue is already ignored - all of `llm.impl/*`, `telemetry*`, and `types.jac` itself - under a block whose comment reads "byllm - litellm/LLM-provider glue". This file is the same category of third-party glue and looks like a plain omission: `types.jac` is listed but its impl is not.

Annotating around a checker limitation would put noise in the source to work around a bug that is not in this file. **The underlying checker gap - class-level attribute annotations not being found through a base class in a third-party package - is worth its own issue, and this PR does not fix it.**

## Validation

`jac check jac/jaclang/byllm/types.impl/media.impl.jac` locally: 0 errors, warnings only, at both `3ad35097` and current `main` - which is what established the errors are environment-dependent rather than a regression in the file.

The ignore mechanism is the one already used by the nine sibling entries: the `jac-check` job splices `.jacignore` into `jac check . --ignore $IGNORE_ARGS`.