### PR TITLE
Fix main CI console tests using the unintended native backend

### DIFF
--- a/jac/tests/language/test_console.jac
+++ b/jac/tests/language/test_console.jac
@@ -14,12 +14,23 @@ glob FIXTURES = os.path.join(JAC_ROOT, "tests", "language", "fixtures"),
      ESC = '\x1b[';
 
 """Run jac and return (stdout, stderr) tuple."""
-def run_jac(args: list[str], env_override: dict | None = None) -> tuple[str, str] {
+def run_jac(
+    args: list[str],
+    env_override: dict | None = None,
+    expected_returncode: int | None = None
+) -> tuple[str, str] {
     env = os.environ.copy();
     if env_override {
         env.update(env_override);
     }
+    # Exercise the Python console renderer, not native fd-level output.
+    if args[0] == 'run' {
+        args = [args[0], '--backend', 'python'] + args[1:];
+    }
     result = subprocess.run(['jac'] + args, capture_output=True, text=True, env=env);
+    if expected_returncode is not None {
+        assert result.returncode == expected_returncode , f"jac {args} exited {result.returncode}: stdout={result.stdout!r}, stderr={result.stderr!r}";
+    }
     return (result.stdout, result.stderr);
 }
 
@@ -66,7 +77,7 @@ test "error messages are readable" {
 # Encoding: escape sequences and non-ASCII chars in f-strings (raw_unicode_escape fix)
 # =============================================================================
 test "fstring escape sequences are decoded correctly" {
-    (stdout, _) = run_jac(['run', FSTRING_ENCODING_FILE]);
+    (stdout, _) = run_jac(['run', FSTRING_ENCODING_FILE], expected_returncode=0);
     assert 'ESC_NEWLINE:\nhello world' in stdout , "\\n escape not decoded in f-string";
     assert 'ESC_TAB:\there world' in stdout , "\\t escape not decoded in f-string";
     assert 'ESC_ANSI:\x1b[0mworld' in stdout , "\\x1b escape not decoded in f-string";
@@ -76,7 +87,7 @@ test "fstring escape sequences are decoded correctly" {
 }
 
 test "4-byte emoji literals in f-strings are not garbled" {
-    (stdout, _) = run_jac(['run', FSTRING_ENCODING_FILE]);
+    (stdout, _) = run_jac(['run', FSTRING_ENCODING_FILE], expected_returncode=0);
     assert 'EMOJI_BOOK:📚 world' in stdout , "📚 garbled in f-string";
     assert 'EMOJI_CHAT:💬 world' in stdout , "💬 garbled in f-string";
     assert 'EMOJI_BUG:🐛 world' in stdout , "🐛 garbled in f-string";
@@ -95,7 +106,7 @@ test "Windows console encoding handles unencodable Unicode" {
     # This test verifies that characters outside cp1252 don't crash on Windows.
     # On Windows cmd/PowerShell (without WT_SESSION), unencodable chars are replaced.
     # On Linux/Mac/Windows Terminal, they pass through unchanged.
-    (stdout, _) = run_jac(['run', FSTRING_ENCODING_FILE]);
+    (stdout, _) = run_jac(['run', FSTRING_ENCODING_FILE], expected_returncode=0);
 
     # The file contains emoji (📚💬🐛🚀) which can't be encoded in cp1252.
     # Test should not crash - output should contain either the emoji or replacement char.
@@ -127,7 +138,7 @@ test "jac check E1001 snippet preserves list comprehension RHS" {
 }
 
 test "all edge case patterns preserved" {
-    (stdout, stderr) = run_jac(['run', EDGE_CASES_FILE]);
+    (stdout, stderr) = run_jac(['run', EDGE_CASES_FILE], expected_returncode=0);
 
     # Patterns that must appear exactly in output
     must_contain = [
@@ -173,6 +184,6 @@ test "all edge case patterns preserved" {
     ];
 
     for pattern in must_contain {
-        assert pattern in stdout , f"Pattern was corrupted or stripped: {pattern}";
+        assert pattern in stdout , f"Pattern was corrupted or stripped: {pattern}; stdout={stdout!r}; stderr={stderr!r}";
     }
 }


### PR DESCRIPTION
## Problem and change

Upstream main's CI run [34244972462](https://github.com/jaseci-labs/jac/actions/runs/34244972462) failed only `test-runtime`: `all edge case patterns preserved` reported missing `#2000`. The console suite launches `jac run` with automatic backend selection, which can execute these fixtures natively instead of exercising Python console output. Running the fixture with the same sealed CI kit reproduces corrupted JSON values. The existing missing-pattern assertion does not report subprocess exit status or stderr.

Select `--backend python` for this suite's `run` commands. Keep all existing output assertions, check successful fixtures' exit codes, and include captured stdout/stderr in failure messages. Diagnostic `check` commands and intentionally invalid fixtures retain their existing behavior.

This scopes console regressions to the intended backend. It does not fix the separately observed native JSON corruption or change native compiler tests.

## Validation

- Console suite with the local source compiler: **11 passed**.
- Console suite with main's exact sealed `jac-kit`, `JAC_NO_DEV_SOURCE=1`, and an isolated runtime cache: **11 passed**.
- `jac fmt --lintfix` and `git diff --check` passed.

Tests only; no user-facing release note.
