### PR TITLE
ci: stabilize Linux release builds on the CI runner

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -154,7 +154,7 @@ jobs:
           # #8805 is fixed and the leg should carry a release again; that
           # restores it as a blocking leg and a required asset in one edit.
           LEGS='[
-            {"os": "ubuntu-latest",    "platform": "linux-x86_64",  "zig_target": "x86_64-linux-gnu.2.17"},
+            {"os": "blacksmith-4vcpu-ubuntu-2404", "platform": "linux-x86_64", "zig_target": "x86_64-linux-gnu.2.17"},
             {"os": "ubuntu-24.04-arm", "platform": "linux-aarch64", "zig_target": "aarch64-linux-gnu.2.17"},
             {"os": "macos-14",         "platform": "macos-aarch64"},
             {"os": "macos-15-intel",   "platform": "macos-x86_64",  "zig_target": "x86_64-macos.12.0", "manual": true}


### PR DESCRIPTION
The Linux x86_64 release job was terminated by runner shutdown twice on `ubuntu-latest`, after 23m49s and 25m33s (exit 143). macOS and Linux ARM64 completed successfully. Use `blacksmith-4vcpu-ubuntu-2404`, the runner already used by the passing CI binary build, for the Linux x86_64 release leg.

The target remains `x86_64-linux-gnu.2.17`; tag checkout, smoke tests, checksums, required-platform validation, and publication guards are unchanged. This infrastructure-only change permits a recovery build from the existing `v0.37.10` tag without moving the tag or changing release source.

Validation: actionlint passed; git diff --check passed. Recovery run will validate the runner change end to end.

Failed attempts: https://github.com/jaseci-labs/jac/actions/runs/34272680480
