### PR TITLE
fix(cli): announce project analysis before serving imports

### DIFF
--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -1270,6 +1270,7 @@ impl serve(
     lng = filename.split('.')[-1];
 
     try {
+        console.print("Jac is analyzing your project. Please be patient...");
         Jac.jac_import(target=mod, base_path=base, lng=lng);
         if Jac.get_program().errors_had {
             for error in Jac.get_program().errors_had {


### PR DESCRIPTION
## Description

`jac run` can appear hung while its initial source import analyzes the project. Print “Jac is analyzing your project. Please be patient...” immediately before that import in the serving path, so users see an explanation before the observed roughly 18-second pause.

This is a one-line change based directly on upstream main. Serving already enables line-buffered output before reaching this point.

Validation: parsed the modified Jac file with no syntax diagnostics; `git diff --check` passes. Confirmed the message precedes `Jac.jac_import` in `serve`. No compiler or runtime behavior changes.
