### PR TITLE
TEMP probe (do not merge): make silent cross-module type degradation observable (#8828)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,11 +208,6 @@ jobs:
         rep: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       JAC_NO_DEV_SOURCE: ""
-      JAC_XREF_PROBE: "1"
-      # Legs 7 and 8 run the sweep serially in one process: retained state
-      # accumulates over all 1049 files in sorted order, so if the flake is
-      # retained-state it should reproduce deterministically there.
-      JAC_CHECK_JOBS: ${{ matrix.rep >= 7 && '0' || '' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -241,7 +236,16 @@ jobs:
       # Two sweeps per leg: the first is cold (this job restores no cache),
       # the second reuses what the first wrote. Real CI fails both ways, so
       # both are samples, and the second costs a fraction of the first.
+      # Probe env is step-scoped: at job level it leaks into jac-kit's warm-up
+      # smoke test, whose `echo "$out" | grep -q 42` under pipefail breaks on
+      # the extra stderr (round 2 attempt 1 died there on every leg).
       - name: Run jac check with the XREF probe
+        env:
+          JAC_XREF_PROBE: "1"
+          # Legs 7 and 8 run the sweep serially in one process: retained
+          # state accumulates over all 1049 files in sorted order, so if the
+          # flake is retained-state it should reproduce deterministically.
+          JAC_CHECK_JOBS: ${{ matrix.rep >= 7 && '0' || '' }}
         run: |
           set +e
           IGNORE_ARGS="tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rep: [1, 2, 3, 4]
+        rep: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       JAC_NO_DEV_SOURCE: ""
       JAC_XREF_PROBE: "1"
@@ -234,24 +234,39 @@ jobs:
             "httpx>=0.27.0" "loguru>=0.7.2,<0.8.0" \
             --global
 
+      # Two sweeps per leg: the first is cold (this job restores no cache),
+      # the second reuses what the first wrote. Real CI fails both ways, so
+      # both are samples, and the second costs a fraction of the first.
       - name: Run jac check with the XREF probe
         run: |
           set +e
           IGNORE_ARGS="tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ')"
-          jac check . --ignore $IGNORE_ARGS --nowarn 2> "probe-${{ matrix.rep }}.err"
-          echo "check_exit=$?"
-          echo "===== XREF orphan/fail summary (rep ${{ matrix.rep }}) ====="
-          grep -oE '\[XREF-(ORPHAN|FAIL)\].*' "probe-${{ matrix.rep }}.err" \
-            | sort | uniq -c | sort -rn | head -80
-          echo "===== totals ====="
-          echo "orphans: $(grep -c 'XREF-ORPHAN' "probe-${{ matrix.rep }}.err")"
-          echo "fails:   $(grep -c 'XREF-FAIL' "probe-${{ matrix.rep }}.err")"
+          for SWEEP in 1 2; do
+            TAG="${{ matrix.rep }}-$SWEEP"
+            echo "::group::sweep $TAG"
+            SECONDS=0
+            jac check . --ignore $IGNORE_ARGS --nowarn > "out-$TAG.log" 2> "probe-$TAG.err"
+            RC=$?
+            echo "sweep=$TAG exit=$RC seconds=$SECONDS"
+            tail -n 3 "out-$TAG.log"
+            echo "failed files:"
+            sed -n '/failed files/,$p' "out-$TAG.log" | head -20
+            echo "orphans: $(grep -c 'XREF-ORPHAN' "probe-$TAG.err")"
+            echo "xref fails: $(grep -c 'XREF-FAIL' "probe-$TAG.err")"
+            echo "cycle stubs: $(grep -c 'CYCLE-STUB' "probe-$TAG.err")"
+            echo "-- orphan/fail/cycle detail (top 60) --"
+            grep -oE '\[(XREF-ORPHAN|XREF-FAIL|CYCLE-STUB)\].*' "probe-$TAG.err" \
+              | sort | uniq -c | sort -rn | head -60
+            echo "::endgroup::"
+          done
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: xref-probe-${{ matrix.rep }}
-          path: probe-${{ matrix.rep }}.err
+          path: |
+            probe-${{ matrix.rep }}-*.err
+            out-${{ matrix.rep }}-*.log
           if-no-files-found: ignore
 
   jac-check:
@@ -465,9 +480,9 @@ jobs:
   # Pure PR-metadata policy: no kit, no jac. Docs code blocks are validated
   # by the suite (tests/cli/test_docs_code_blocks.jac) in the test lanes.
   contribution-checks:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     name: Contribution Checks
     needs: changes
-    if: ${{ github.event_name != 'push' || needs.changes.outputs.docs == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
@@ -530,8 +545,8 @@ jobs:
   # pools run at auto and JAC_TEST_RSS_LOG leaves a per-file trail if a
   # box ever dies again.
   test-compiler:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -583,8 +598,8 @@ jobs:
 
   # Everything except the compiler tests.
   test-runtime:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -635,8 +650,8 @@ jobs:
   #   has one and recompiles. Fails the same way with the native pipeline
   #   off.
   test-in-package-sealed:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' || needs.changes.outputs.byllm == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -687,8 +702,8 @@ jobs:
   # (tests/compiler/test_no_llvm_degradation.jac, via JAC_LLVM_SHIM=none).
 
   test-client:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -727,8 +742,8 @@ jobs:
   # has (test_byllm.jac, test_auth_cutover.jac, test_firebase_auth_sso.jac).
   # Those findings are a follow-up on the test files, not on this lane.
   test-packages-and-docs:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.byllm == 'true' || needs.changes.outputs.docs == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: ""
@@ -759,8 +774,8 @@ jobs:
             jac/tests/cli/test_docs_code_blocks.jac
 
   test-scale:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: ""
@@ -816,12 +831,8 @@ jobs:
   # failure-path leg ships the binary into the pods, and that must be the one
   # built from this checkout.
   test-scale-k8s:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: >-
-      (github.event_name != 'pull_request' ||
-       needs.changes.outputs.core == 'true' ||
-       needs.changes.outputs.scale == 'true') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-k8s')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -901,8 +912,8 @@ jobs:
   # aarch64 cross lane: in-house ELF linker + arch-parameterized musl from the
   # kit, binaries run under qemu-user.
   test-native-aarch64:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
     runs-on: ubuntu-latest
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -930,8 +941,8 @@ jobs:
   # launcher materializes through, the walk-up import shape the stub is built
   # with, and an end-to-end fused-runtime boot of a freshly compiled na host.
   test-launcher-jac:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
@@ -956,8 +967,8 @@ jobs:
   # launcher itself is Jac; its trailer codec, payload tool and boot path are
   # covered by `jac test` in the kit lanes below.
   test-bootstrap:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: changes
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -978,8 +989,8 @@ jobs:
   # (tests/client/test_cef_dispatch_build.jac, in test-client's lane).
 
   test-jac-pack-smoke:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' || needs.changes.outputs.byllm == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       JAC_NO_DEV_SOURCE: "1"
@@ -1432,8 +1443,8 @@ jobs:
   # instead of a second copy of it. The PR lane lints install.sh; the nightly
   # one does not (it exercises the published installer, not this checkout).
   installer-test:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && needs.changes.outputs.installer == 'true') }}
     uses: ./.github/workflows/_installer.yml
     with:
       shellcheck: true
@@ -1446,12 +1457,12 @@ jobs:
   # on ordinary compiler churn, which is what put a 44-68 min leg on the
   # critical path of every native PR to begin with.
   macos-native:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'macos')) }}
+    if: false  # TEMP probe branch: lane disabled (#8828)
     uses: ./.github/workflows/_macos-native.yml
 
   test-managed-android:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     needs: [changes, build-kit]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
@@ -1487,8 +1498,8 @@ jobs:
   # must be added to needs below by hand; always() so failures upstream fail
   # the gate instead of skipping it (skipped required checks count as passing).
   everything-passed:
+    if: false  # TEMP probe branch: lane disabled (#8828)
     name: Everything Passed
-    if: always()
     needs:
       - changes
       - build-kit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,66 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # TEMPORARY (#8828 validation): repeats the whole-tree sweep with the
+  # XREF probe on, to capture which cross-module class reference orphans
+  # on a run that fails. Delete before merge.
+  jac-check-xref-probe:
+    needs: [changes, build-kit]
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        rep: [1, 2, 3, 4]
+    env:
+      JAC_NO_DEV_SOURCE: ""
+      JAC_XREF_PROBE: "1"
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - uses: ./.github/actions/jac-kit
+
+      - name: Install plugin deps so jac check resolves scale/byllm imports
+        run: |
+          jac install \
+            "python-dotenv>=1.2.1,<2.0.0" \
+            "prometheus-client>=0.21.0,<1.0.0" \
+            "opentelemetry-sdk>=1.27.0,<2.0.0" \
+            "opentelemetry-exporter-otlp-proto-http>=1.27.0,<2.0.0" \
+            "apscheduler>=3.11.2,<4.0.0" "kubernetes>=34.1.0,<35.0.0" \
+            "docker>=7.1.0,<8.0.0" "boto3>=1.40.0,<2.0.0" \
+            "google-cloud-firestore>=2.21.0,<3.0.0" "google-cloud-storage>=2.19.0,<3.0.0" \
+            "firebase-admin>=6.0.0,<8.0.0" "requests>=2.32.0,<3.0.0" \
+            --global
+          jac install \
+            "litellm>=1.75.2,<=1.82.6" "pillow>=12.0.0,<13.0.0" \
+            "httpx>=0.27.0" "loguru>=0.7.2,<0.8.0" \
+            --global
+
+      - name: Run jac check with the XREF probe
+        run: |
+          set +e
+          IGNORE_ARGS="tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ')"
+          jac check . --ignore $IGNORE_ARGS --nowarn 2> "probe-${{ matrix.rep }}.err"
+          echo "check_exit=$?"
+          echo "===== XREF orphan/fail summary (rep ${{ matrix.rep }}) ====="
+          grep -oE '\[XREF-(ORPHAN|FAIL)\].*' "probe-${{ matrix.rep }}.err" \
+            | sort | uniq -c | sort -rn | head -80
+          echo "===== totals ====="
+          echo "orphans: $(grep -c 'XREF-ORPHAN' "probe-${{ matrix.rep }}.err")"
+          echo "fails:   $(grep -c 'XREF-FAIL' "probe-${{ matrix.rep }}.err")"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: xref-probe-${{ matrix.rep }}
+          path: probe-${{ matrix.rep }}.err
+          if-no-files-found: ignore
+
   jac-check:
     needs: [changes, build-kit]
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,10 @@ jobs:
     env:
       JAC_NO_DEV_SOURCE: ""
       JAC_XREF_PROBE: "1"
+      # Legs 7 and 8 run the sweep serially in one process: retained state
+      # accumulates over all 1049 files in sorted order, so if the flake is
+      # retained-state it should reproduce deterministically there.
+      JAC_CHECK_JOBS: ${{ matrix.rep >= 7 && '0' || '' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -244,6 +248,7 @@ jobs:
           for SWEEP in 1 2; do
             TAG="${{ matrix.rep }}-$SWEEP"
             echo "::group::sweep $TAG"
+            echo "jobs=${JAC_CHECK_JOBS:-auto}"
             SECONDS=0
             jac check . --ignore $IGNORE_ARGS --nowarn > "out-$TAG.log" 2> "probe-$TAG.err"
             RC=$?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rep: [1, 2, 3, 4, 5, 6, 7, 8]
+        rep: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     env:
       JAC_NO_DEV_SOURCE: ""
     steps:
@@ -245,11 +245,11 @@ jobs:
           # Legs 7 and 8 run the sweep serially in one process: retained
           # state accumulates over all 1049 files in sorted order, so if the
           # flake is retained-state it should reproduce deterministically.
-          JAC_CHECK_JOBS: ${{ matrix.rep >= 7 && '0' || '' }}
+          JAC_CHECK_JOBS: ${{ matrix.rep >= 11 && '0' || '' }}
         run: |
           set +e
           IGNORE_ARGS="tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ')"
-          for SWEEP in 1 2; do
+          for SWEEP in 1 2 3; do
             TAG="${{ matrix.rep }}-$SWEEP"
             echo "::group::sweep $TAG"
             echo "jobs=${JAC_CHECK_JOBS:-auto}"
@@ -264,8 +264,14 @@ jobs:
             echo "xref fails: $(grep -c 'XREF-FAIL' "probe-$TAG.err")"
             echo "cycle stubs: $(grep -c 'CYCLE-STUB' "probe-$TAG.err")"
             echo "-- orphan/fail/cycle detail (top 60) --"
+            echo "foreign recompiles: $(grep -c 'FOREIGN-RECOMPILE' "probe-$TAG.err")"
+            echo "mro-trunc dumps: $(grep -c '^\[MRO-TRUNC\] pid' "probe-$TAG.err")"
+            echo "e1053 dumps: $(grep -c '^\[E1053-DUMP\] pid' "probe-$TAG.err")"
+            echo "-- E1053 / MRO-TRUNC dumps (first 80 lines) --"
+            grep -E '^\[(E1053-DUMP|MRO-TRUNC)\]' "probe-$TAG.err" | head -80
+            echo "-- orphan/fail/cycle detail (top 20) --"
             grep -oE '\[(XREF-ORPHAN|XREF-FAIL|CYCLE-STUB)\].*' "probe-$TAG.err" \
-              | sort | uniq -c | sort -rn | head -60
+              | sort | uniq -c | sort -rn | head -20
             echo "::endgroup::"
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rep: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        rep: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     env:
       JAC_NO_DEV_SOURCE: ""
     steps:
@@ -242,10 +242,6 @@ jobs:
       - name: Run jac check with the XREF probe
         env:
           JAC_XREF_PROBE: "1"
-          # Legs 7 and 8 run the sweep serially in one process: retained
-          # state accumulates over all 1049 files in sorted order, so if the
-          # flake is retained-state it should reproduce deterministically.
-          JAC_CHECK_JOBS: ${{ matrix.rep >= 11 && '0' || '' }}
         run: |
           set +e
           IGNORE_ARGS="tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ')"

--- a/jac/jaclang/cli/commands/impl/analysis.impl.jac
+++ b/jac/jaclang/cli/commands/impl/analysis.impl.jac
@@ -125,6 +125,19 @@ def _check_file_job(request: dict[(str, any)]) -> dict[(str, any)] {
     import from jaclang.compiler.driver.compile_options { CompileOptions }
     opts = _wire_dict(request.get("opts"));
     file_path = str(request["path"]);
+    if os.environ.get("JAC_XREF_PROBE", "") {
+        import sys;
+        try {
+            import from jaclang.runtime.runtime { JacRuntime }
+            _sh = JacRuntime.get_compiler().selfhost.program;
+            _te = "set" if _sh.type_evaluator is not None else "none";
+            sys.stderr.write(
+                f"[WORKER] pid={os.getpid()} selfhost_hub={len(_sh.mod.hub)} "
+                f"selfhost_te={_te} file={file_path}"
+                    + "\n"
+            );
+        } except Exception {}
+    }
     result: dict[(str, any)] = {
         'path': file_path,
         'success': False,

--- a/jac/jaclang/compiler/driver/ifacecache.jac
+++ b/jac/jaclang/compiler/driver/ifacecache.jac
@@ -987,9 +987,30 @@ obj IfaceRegistry {
         }
     }
 
+    def _xref_fail(reason: str, module_path: str, class_name: str, extra: str = "") {
+        import os;
+        if not os.environ.get("JAC_XREF_PROBE", "") {
+            return;
+        }
+        import sys;
+        sys.stderr.write(
+            f"[XREF-FAIL] reason={reason} class={class_name} mod={module_path} {extra}"
+                + "\n"
+        );
+    }
+
     def resolve_shared(module_path: str, dotted: str, class_name: str) -> any {
+        import os;
+        forced = os.environ.get("JAC_XREF_FAIL_CLASSES", "");
+        if forced and class_name in forced.split(",") {
+            self._xref_fail("forced", module_path, class_name);
+            return None;
+        }
         mod = self.resolve_module(module_path);
         if mod is None or not dotted {
+            self._xref_fail(
+                "no_module" if mod is None else "no_dotted", module_path, class_name
+            );
             return None;
         }
         parts = dotted.split(".");
@@ -997,11 +1018,13 @@ obj IfaceRegistry {
         for part in parts[:-1] {
             scope = scope.find_scope(part);
             if scope is None {
+                self._xref_fail("no_scope", module_path, class_name, f"part={part}");
                 return None;
             }
         }
         sym = scope.names_in_scope.get(parts[-1]);
         if sym is None {
+            self._xref_fail("no_symbol", module_path, class_name, f"dotted={dotted}");
             return None;
         }
         resolved_type: any = None;
@@ -1012,13 +1035,17 @@ obj IfaceRegistry {
             } else {
                 resolved_type = self.prog.get_type_evaluator().get_type_of_symbol(sym);
             }
-        } except Exception {
+        } except Exception as e {
+            self._xref_fail("resolve_raised", module_path, class_name, f"err={e!r}");
             return None;
         }
         shared = resolved_type?._shared;
         if shared is not None {
             return shared;
         }
+        self._xref_fail(
+            "no_shared", module_path, class_name, f"type={type(resolved_type).__name__}"
+        );
         return None;
     }
 

--- a/jac/jaclang/compiler/driver/ifacecache.jac
+++ b/jac/jaclang/compiler/driver/ifacecache.jac
@@ -464,6 +464,12 @@ obj IfaceRegistry {
         self.building.add(resolved);
         try {
             self._event("dep_miss_compile");
+            if os.environ.get("JAC_XREF_PROBE", "") {
+                import sys;
+                sys.stderr.write(
+                    f"[DEP-MISS-COMPILE] pid={os.getpid()} path={resolved}" + "\n"
+                );
+            }
             import from jaclang.compiler.driver.compile_options { CompileOptions }
             self.prog.compile(
                 resolved,
@@ -639,6 +645,12 @@ obj IfaceRegistry {
             ent.replayed_token = self.closure_token;
         }
         self._event("dep_hydrate");
+        if os.environ.get("JAC_XREF_PROBE", "") {
+            import sys;
+            sys.stderr.write(
+                f"[IFACE-SERVE] pid={os.getpid()} kind=symtab path={resolved}" + "\n"
+            );
+        }
         if self.verifying is False and iface_verify_enabled() {
             self._verify_iface(resolved, ent);
         }
@@ -698,6 +710,12 @@ obj IfaceRegistry {
         self._replay_records(prof, err0, warn0);
         ent.replayed_token = self.closure_token;
         self._event("analysis_replay");
+        if os.environ.get("JAC_XREF_PROBE", "") {
+            import sys;
+            sys.stderr.write(
+                f"[IFACE-SERVE] pid={os.getpid()} kind=analysis path={resolved}" + "\n"
+            );
+        }
         if self.verifying is False and iface_verify_enabled() {
             self._verify_analysis(resolved, options, prof);
         }

--- a/jac/jaclang/compiler/driver/impl/program.impl.jac
+++ b/jac/jaclang/compiler/driver/impl/program.impl.jac
@@ -62,6 +62,17 @@ impl JacProgram.transitive_dependents(self: JacProgram, target_path: str) -> set
 }
 
 impl JacProgram.invalidate_module(self: JacProgram, resolved_path: str) -> None {
+    import os;
+    if os.environ.get("JAC_XREF_PROBE", "") {
+        import sys;
+        try {
+            sys.stderr.write(
+                f"[INVALIDATE] pid={os.getpid()} path={resolved_path} "
+                f"hub={len(self.mod.hub)} depth={self.scratch.compile_depth}"
+                    + "\n"
+            );
+        } except Exception {}
+    }
     work = self.analysis.placement_state.get('work');
     if work is not None {
         work.forget_path(resolved_path);

--- a/jac/jaclang/compiler/driver/impl/program.impl.jac
+++ b/jac/jaclang/compiler/driver/impl/program.impl.jac
@@ -187,6 +187,18 @@ impl JacProgram.load_dependency_module(
             events["untyped_foreign_tree_skipped"] = (
                 events.get("untyped_foreign_tree_skipped", 0) + 1
             );
+            import os;
+            if os.environ.get("JAC_XREF_PROBE", "") {
+                import sys;
+                try {
+                    sys.stderr.write(
+                        f"[FOREIGN-RECOMPILE] pid={os.getpid()} path={resolved_path} "
+                        f"importer={importer_path} self_hub={len(self.mod.hub)} "
+                        f"target_hub={len(target_hub)} depth={self.scratch.compile_depth}"
+                            + "\n"
+                    );
+                } except Exception {}
+            }
         }
         if resolved_path.endswith('.pyi') {
             import ast as py_ast;

--- a/jac/jaclang/compiler/driver/selfhost.jac
+++ b/jac/jaclang/compiler/driver/selfhost.jac
@@ -66,6 +66,17 @@ obj SelfHostCache {
         if os.environ.get("JAC_NO_UNIT_EVICT") {
             return;
         }
+        if os.environ.get("JAC_XREF_PROBE", "") {
+            import sys;
+            try {
+                sys.stderr.write(
+                    f"[EVICT] pid={os.getpid()} target={full_target} "
+                    f"selfhost_hub={len(self.program.mod.hub)} "
+                    f"selfhost_depth={self.program.scratch.compile_depth}"
+                        + "\n"
+                );
+            } except Exception {}
+        }
         if result is not None and result.gen.native_engine is not None {
             import from jaclang.compiler.frontend.codeinfo { CodeGenTarget }
             slim = CodeGenTarget();

--- a/jac/jaclang/compiler/passes/wasm_contract.jac
+++ b/jac/jaclang/compiler/passes/wasm_contract.jac
@@ -178,6 +178,11 @@ def check_host_call(call: any) -> None {
         provider.find_parent_of_type(Module)
     ).items() {
         if name not in methods {
+            import os;
+            if os.environ.get("JAC_XREF_PROBE", "") {
+                import from jaclang.compiler.types.probe_dump { dump_host_contract }
+                dump_host_contract(scope, host_type, name, sorted(methods.keys()));
+            }
             raise ValueError(f"Host is missing native import '{name}'");
         }
         supplied = function_contract(methods[name], host=True);

--- a/jac/jaclang/compiler/types/probe_dump.jac
+++ b/jac/jaclang/compiler/types/probe_dump.jac
@@ -57,7 +57,9 @@ def _state(prog: any, selfhost_prog: any, m: any) -> str {
     }
     in_t = "y" if mp in prog.mod.hub else "n";
     in_s = "y" if mp in selfhost_prog.mod.hub else "n";
-    return f"{state}[t={in_t},s={in_s}]";
+    kind = "cat" if m?.cat_kids is not None else "tree";
+    stub = ",stub" if getattr(m, "stub_only", False) else "";
+    return f"{state}[t={in_t},s={in_s},{kind}{stub}]";
 }
 
 def _rec(prog: any, selfhost_prog: any, t: any) -> str {

--- a/jac/jaclang/compiler/types/probe_dump.jac
+++ b/jac/jaclang/compiler/types/probe_dump.jac
@@ -1,0 +1,115 @@
+import os;
+import sys;
+import from jaclang.compiler.types.types { ClassType }
+import from jaclang.compiler.frontend.unitree { Module }
+
+def probe_on -> bool {
+    return bool(os.environ.get("JAC_XREF_PROBE", ""));
+}
+
+def truncated_mro(src: any) -> bool {
+    if not isinstance(src, ClassType) or src._shared is None {
+        return False;
+    }
+    names: set[str] = set();
+    for c in (src.shared.mro or []) {
+        names.add(c.shared.class_name);
+    }
+    for b in (src.shared.base_classes or []) {
+        if not isinstance(b, ClassType) or b._shared is None {
+            continue;
+        }
+        bmro = b.shared.mro or [];
+        if not bmro and (b.shared.base_classes or []) {
+            return True;
+        }
+        for c in bmro {
+            if c.shared.class_name not in names {
+                return True;
+            }
+        }
+    }
+    return False;
+}
+
+def _mod_of(t: any) -> any {
+    cur = t.shared.symbol_table if t._shared is not None else None;
+    while cur is not None and not isinstance(cur, Module) {
+        cur = cur.parent_scope;
+    }
+    return cur;
+}
+
+def _rec(prog: any, selfhost_prog: any, t: any) -> str {
+    if not isinstance(t, ClassType) or t._shared is None {
+        return f"<{type(t).__name__}>";
+    }
+    key = t.shared.canonical_key();
+    site = "<nokey>";
+    if key is not None {
+        site = f"{os.path.basename(key[0])}:{key[1]}:{key[2]}";
+    }
+    m = _mod_of(t);
+    state = "nomod";
+    if m is not None {
+        mp = m.loc.mod_path if m.loc is not None else "";
+        found = prog.find_module(mp) if mp else None;
+        if found is m {
+            state = "live";
+        } elif found is not None {
+            state = "stale";
+        } else {
+            state = "gone";
+        }
+        in_t = "y" if mp in prog.mod.hub else "n";
+        in_s = "y" if mp in selfhost_prog.mod.hub else "n";
+        state = f"{state}[t={in_t},s={in_s}]";
+    }
+    mro_names = ",".join([c.shared.class_name for c in (t.shared.mro or [])]);
+    base_names = ",".join(
+        [
+            (
+                b.shared.class_name
+                    if isinstance(b, ClassType) and b._shared is not None
+                    else type(b).__name__
+            ) for b in (t.shared.base_classes or [])
+        ]
+    );
+    return (
+        f"{t.shared.class_name}@{site} id={id(t.shared)} {state} "
+        f"mro=[{mro_names}] bases=[{base_names}]"
+    );
+}
+
+def dump_assign_fail(evaluator: any, src_type: any, dest_type: any, tag: str) {
+    try {
+        prog = evaluator.program;
+        selfhost_prog = prog._get_compiler().selfhost.program;
+        lines = [
+            f"[{tag}] pid={os.getpid()} src={_rec(prog, selfhost_prog, src_type)}",
+            f"[{tag}]   dest={_rec(prog, selfhost_prog, dest_type)}"
+        ];
+        if isinstance(src_type, ClassType) and src_type._shared is not None {
+            for b in (src_type.shared.base_classes or []) {
+                lines.append(f"[{tag}]   src.base={_rec(prog, selfhost_prog, b)}");
+                if isinstance(b, ClassType) and b._shared is not None {
+                    for bb in (b.shared.base_classes or []) {
+                        lines.append(
+                            f"[{tag}]     src.base.base={_rec(prog, selfhost_prog, bb)}"
+                        );
+                    }
+                }
+            }
+        }
+        te_state = "set" if selfhost_prog.type_evaluator is not None else "none";
+        lines.append(
+            f"[{tag}]   selfhost_te={te_state} "
+            f"selfhost_hub={len(selfhost_prog.mod.hub)} "
+            f"target_hub={len(prog.mod.hub)} "
+            f"depth={prog.scratch.compile_depth}/{selfhost_prog.scratch.compile_depth}"
+        );
+        sys.stderr.write("\n".join(lines) + "\n");
+    } except Exception as e {
+        sys.stderr.write(f"[{tag}-PROBE-ERR] {e!r}" + "\n");
+    }
+}

--- a/jac/jaclang/compiler/types/probe_dump.jac
+++ b/jac/jaclang/compiler/types/probe_dump.jac
@@ -40,6 +40,26 @@ def _mod_of(t: any) -> any {
     return cur;
 }
 
+def _state(prog: any, selfhost_prog: any, m: any) -> str {
+    if m is None {
+        return "nomod";
+    }
+    mp = m.loc.mod_path if m.loc is not None else "";
+    if prog is None {
+        return f"?[{os.path.basename(mp)}]";
+    }
+    found = prog.find_module(mp) if mp else None;
+    state = "gone";
+    if found is m {
+        state = "live";
+    } elif found is not None {
+        state = "stale";
+    }
+    in_t = "y" if mp in prog.mod.hub else "n";
+    in_s = "y" if mp in selfhost_prog.mod.hub else "n";
+    return f"{state}[t={in_t},s={in_s}]";
+}
+
 def _rec(prog: any, selfhost_prog: any, t: any) -> str {
     if not isinstance(t, ClassType) or t._shared is None {
         return f"<{type(t).__name__}>";
@@ -49,22 +69,7 @@ def _rec(prog: any, selfhost_prog: any, t: any) -> str {
     if key is not None {
         site = f"{os.path.basename(key[0])}:{key[1]}:{key[2]}";
     }
-    m = _mod_of(t);
-    state = "nomod";
-    if m is not None {
-        mp = m.loc.mod_path if m.loc is not None else "";
-        found = prog.find_module(mp) if mp else None;
-        if found is m {
-            state = "live";
-        } elif found is not None {
-            state = "stale";
-        } else {
-            state = "gone";
-        }
-        in_t = "y" if mp in prog.mod.hub else "n";
-        in_s = "y" if mp in selfhost_prog.mod.hub else "n";
-        state = f"{state}[t={in_t},s={in_s}]";
-    }
+    state = _state(prog, selfhost_prog, _mod_of(t));
     mro_names = ",".join([c.shared.class_name for c in (t.shared.mro or [])]);
     base_names = ",".join(
         [
@@ -81,33 +86,98 @@ def _rec(prog: any, selfhost_prog: any, t: any) -> str {
     );
 }
 
+def _progs(evaluator: any) -> tuple {
+    prog = evaluator.program;
+    return (prog, prog._get_compiler().selfhost.program);
+}
+
+def _tail(tag: str, prog: any, selfhost_prog: any) -> str {
+    te_state = "set" if selfhost_prog.type_evaluator is not None else "none";
+    return (
+        f"[{tag}]   selfhost_te={te_state} "
+        f"selfhost_hub={len(selfhost_prog.mod.hub)} "
+        f"target_hub={len(prog.mod.hub)} "
+        f"depth={prog.scratch.compile_depth}/{selfhost_prog.scratch.compile_depth}"
+    );
+}
+
 def dump_assign_fail(evaluator: any, src_type: any, dest_type: any, tag: str) {
     try {
-        prog = evaluator.program;
-        selfhost_prog = prog._get_compiler().selfhost.program;
+        (prog, sh) = _progs(evaluator);
         lines = [
-            f"[{tag}] pid={os.getpid()} src={_rec(prog, selfhost_prog, src_type)}",
-            f"[{tag}]   dest={_rec(prog, selfhost_prog, dest_type)}"
+            f"[{tag}] pid={os.getpid()} src={_rec(prog, sh, src_type)}",
+            f"[{tag}]   dest={_rec(prog, sh, dest_type)}"
         ];
         if isinstance(src_type, ClassType) and src_type._shared is not None {
             for b in (src_type.shared.base_classes or []) {
-                lines.append(f"[{tag}]   src.base={_rec(prog, selfhost_prog, b)}");
+                lines.append(f"[{tag}]   src.base={_rec(prog, sh, b)}");
                 if isinstance(b, ClassType) and b._shared is not None {
                     for bb in (b.shared.base_classes or []) {
-                        lines.append(
-                            f"[{tag}]     src.base.base={_rec(prog, selfhost_prog, bb)}"
-                        );
+                        lines.append(f"[{tag}]     src.base.base={_rec(prog, sh, bb)}");
                     }
                 }
             }
         }
-        te_state = "set" if selfhost_prog.type_evaluator is not None else "none";
-        lines.append(
-            f"[{tag}]   selfhost_te={te_state} "
-            f"selfhost_hub={len(selfhost_prog.mod.hub)} "
-            f"target_hub={len(prog.mod.hub)} "
-            f"depth={prog.scratch.compile_depth}/{selfhost_prog.scratch.compile_depth}"
-        );
+        lines.append(_tail(tag, prog, sh));
+        sys.stderr.write("\n".join(lines) + "\n");
+    } except Exception as e {
+        sys.stderr.write(f"[{tag}-PROBE-ERR] {e!r}" + "\n");
+    }
+}
+
+def dump_member_miss(evaluator: any, obj_type: any, member: str, tag: str) {
+    try {
+        (prog, sh) = _progs(evaluator);
+        lines = [
+            f"[{tag}] pid={os.getpid()} member={member} obj={_rec(prog, sh, obj_type)}"
+        ];
+        if isinstance(obj_type, ClassType) and obj_type._shared is not None {
+            for cls in (obj_type.shared.mro or []) {
+                hit = "miss";
+                try {
+                    syms: list = [];
+                    if cls.lookup_member_symbol(member, syms) {
+                        hit = "HIT";
+                    }
+                } except Exception as e {
+                    hit = f"err:{e!r}";
+                }
+                lines.append(f"[{tag}]   mro {hit} {_rec(prog, sh, cls)}");
+            }
+            for b in (obj_type.shared.base_classes or []) {
+                lines.append(f"[{tag}]   base={_rec(prog, sh, b)}");
+                if isinstance(b, ClassType) and b._shared is not None {
+                    for bb in (b.shared.base_classes or []) {
+                        lines.append(f"[{tag}]     base.base={_rec(prog, sh, bb)}");
+                    }
+                }
+            }
+        }
+        lines.append(_tail(tag, prog, sh));
+        sys.stderr.write("\n".join(lines) + "\n");
+    } except Exception as e {
+        sys.stderr.write(f"[{tag}-PROBE-ERR] {e!r}" + "\n");
+    }
+}
+
+def dump_host_contract(scope: any, host_type: any, name: str, methods: list) {
+    tag = "E5110-DUMP";
+    try {
+        import from jaclang.runtime.runtime { JacRuntime }
+        sh = JacRuntime.get_compiler().selfhost.program;
+        lines = [
+            f"[{tag}] pid={os.getpid()} missing={name} host={_rec(sh, sh, host_type)}",
+            f"[{tag}]   methods_seen={methods}"
+        ];
+        for base in (scope?.base_classes or []) {
+            bt = base?.type;
+            rec = _rec(sh, sh, bt) if isinstance(bt, ClassType) else "";
+            lines.append(
+                f"[{tag}]   base_expr={type(base).__name__} "
+                f"base.type={type(bt).__name__} {rec}"
+            );
+        }
+        lines.append(f"[{tag}]   selfhost_hub={len(sh.mod.hub)}");
         sys.stderr.write("\n".join(lines) + "\n");
     } except Exception as e {
         sys.stderr.write(f"[{tag}-PROBE-ERR] {e!r}" + "\n");

--- a/jac/jaclang/compiler/types/stubcat/reader.jac
+++ b/jac/jaclang/compiler/types/stubcat/reader.jac
@@ -964,6 +964,18 @@ obj StubCatalog {
                     resolved = None;
                 }
             }
+            if os.environ.get("JAC_XREF_PROBE", "") {
+                import sys;
+                tag = "XREF-ORPHAN" if resolved is None else "XREF-OK";
+                sys.stderr.write(
+                    f"[{tag}] {name} dotted={dotted} home={self.abs_path(
+                        self._mod_recs[xmid][1]
+                    )
+                        if xmid >= 0
+                        else '<none>'}"
+                        + "\n"
+                );
+            }
             if resolved is None {
                 resolved = ClassDetailsShared(
                     class_name=name,

--- a/jac/jaclang/compiler/types/stubcat/reader.jac
+++ b/jac/jaclang/compiler/types/stubcat/reader.jac
@@ -964,7 +964,8 @@ obj StubCatalog {
                     resolved = None;
                 }
             }
-            if os.environ.get("JAC_XREF_PROBE", "") {
+            _lvl = os.environ.get("JAC_XREF_PROBE", "");
+            if _lvl and (resolved is None or _lvl == "2") {
                 import sys;
                 tag = "XREF-ORPHAN" if resolved is None else "XREF-OK";
                 sys.stderr.write(

--- a/jac/jaclang/compiler/types/type_evaluator.impl/imported.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/imported.impl.jac
@@ -478,6 +478,11 @@ impl TypeEvaluator._import_module_from_path(
         if _pending is not None {
             mod = _pending;
         } else {
+            import os;
+            if os.environ.get("JAC_XREF_PROBE", "") {
+                import sys;
+                sys.stderr.write(f"[CYCLE-STUB] {resolved_path}" + "\n");
+            }
             return Module.make_stub(inject_name=Path(resolved_path).stem);
         }
     } else {

--- a/jac/jaclang/compiler/types/type_evaluator.impl/parameter_type_check.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/parameter_type_check.impl.jac
@@ -70,6 +70,11 @@ impl TypeEvaluator.validate_arg_types(
         if not verdict.ok {
             has_errors = True;
             if not checking_overload and not verdict.diagnosed {
+                import os;
+                if os.environ.get("JAC_XREF_PROBE", "") {
+                    import from jaclang.compiler.types.probe_dump { dump_assign_fail }
+                    dump_assign_fail(self, arg_type, expected, "E1053-DUMP");
+                }
                 self.emit_diag(
                     E1053,
                     arg,

--- a/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
@@ -2918,85 +2918,12 @@ impl TypeEvaluator._assign_class(
     }
     import os;
     if os.environ.get("JAC_XREF_PROBE", "") {
-        import sys;
-        try {
-            import from jaclang.compiler.frontend.unitree { Module as _ProbeModule }
-            prog = self.program;
-            selfhost_prog = prog._get_compiler().selfhost.program;
-
-            def _mod_of(t: any) -> any {
-                cur = t.shared.symbol_table if t._shared is not None else None;
-                while cur is not None and not isinstance(cur, _ProbeModule) {
-                    cur = cur.parent_scope;
-                }
-                return cur;
-            }
-
-            def _rec(t: any) -> str {
-                if not isinstance(t, ClassType) or t._shared is None {
-                    return f"<{type(t).__name__}>";
-                }
-                key = t.shared.canonical_key();
-                site = "<nokey>";
-                if key is not None {
-                    site = f"{os.path.basename(key[0])}:{key[1]}:{key[2]}";
-                }
-                m = _mod_of(t);
-                state = "nomod";
-                if m is not None {
-                    mp = m.loc.mod_path if m.loc is not None else "";
-                    found = prog.find_module(mp) if mp else None;
-                    if found is m {
-                        state = "live";
-                    } elif found is not None {
-                        state = "stale";
-                    } else {
-                        state = "gone";
-                    }
-                    in_t = "y" if mp in prog.mod.hub else "n";
-                    in_s = "y" if mp in selfhost_prog.mod.hub else "n";
-                    state = f"{state}[t={in_t},s={in_s}]";
-                }
-                mro_names = ",".join(
-                    [c.shared.class_name for c in (t.shared.mro or [])]
-                );
-                base_names = ",".join(
-                    [
-                        (
-                            b.shared.class_name
-                                if isinstance(b, ClassType) and b._shared is not None
-                                else type(b).__name__
-                        ) for b in (t.shared.base_classes or [])
-                    ]
-                );
-                return (
-                    f"{t.shared.class_name}@{site} id={id(t.shared)} {state} "
-                    f"mro=[{mro_names}] bases=[{base_names}]"
-                );
-            }
-
-            lines = [
-                f"[ASSIGN-FAIL] pid={os.getpid()} src={_rec(src_type)}",
-                f"[ASSIGN-FAIL]   dest={_rec(dest_type)}"
-            ];
-            for b in (src_type.shared.base_classes or []) {
-                lines.append(f"[ASSIGN-FAIL]   src.base={_rec(b)}");
-                if isinstance(b, ClassType) and b._shared is not None {
-                    for bb in (b.shared.base_classes or []) {
-                        lines.append(f"[ASSIGN-FAIL]     src.base.base={_rec(bb)}");
-                    }
-                }
-            }
-            te_state = "set" if selfhost_prog.type_evaluator is not None else "none";
-            lines.append(
-                f"[ASSIGN-FAIL]   selfhost_te={te_state} "
-                f"selfhost_hub={len(selfhost_prog.mod.hub)} "
-                f"target_hub={len(prog.mod.hub)} "
-                f"depth={prog.scratch.compile_depth}/{selfhost_prog.scratch.compile_depth}"
-            );
-            sys.stderr.write("\n".join(lines) + "\n");
-        } except Exception as e {
-            sys.stderr.write(f"[ASSIGN-FAIL-PROBE-ERR] {e!r}" + "\n");
+        import from jaclang.compiler.types.probe_dump {
+            dump_assign_fail,
+            truncated_mro
+        }
+        if truncated_mro(src_type) {
+            dump_assign_fail(self, src_type, dest_type, "MRO-TRUNC");
         }
     }
     return False;

--- a/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
@@ -896,6 +896,15 @@ impl TypeEvaluator._get_type_of_expression_core(
                             )
                         );
                         if not _has_tvars {
+                            import os;
+                            if os.environ.get("JAC_XREF_PROBE", "") {
+                                import from jaclang.compiler.types.probe_dump {
+                                    dump_member_miss
+                                }
+                                dump_member_miss(
+                                    self, lookup_type, expr.right.value, "E1030-DUMP"
+                                );
+                            }
                             self.emit_diag(
                                 E1030,
                                 expr.right,
@@ -1087,6 +1096,15 @@ impl TypeEvaluator._get_type_of_expression_core(
                             )
                         );
                         if not _has_tvars {
+                            import os;
+                            if os.environ.get("JAC_XREF_PROBE", "") {
+                                import from jaclang.compiler.types.probe_dump {
+                                    dump_member_miss
+                                }
+                                dump_member_miss(
+                                    self, base_type, expr.right.value, "E1030-DUMP"
+                                );
+                            }
                             self.emit_diag(
                                 E1030,
                                 expr.right,

--- a/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/types/type_evaluator.impl/type_evaluator.impl.jac
@@ -2916,6 +2916,89 @@ impl TypeEvaluator._assign_class(
             }
         }
     }
+    import os;
+    if os.environ.get("JAC_XREF_PROBE", "") {
+        import sys;
+        try {
+            import from jaclang.compiler.frontend.unitree { Module as _ProbeModule }
+            prog = self.program;
+            selfhost_prog = prog._get_compiler().selfhost.program;
+
+            def _mod_of(t: any) -> any {
+                cur = t.shared.symbol_table if t._shared is not None else None;
+                while cur is not None and not isinstance(cur, _ProbeModule) {
+                    cur = cur.parent_scope;
+                }
+                return cur;
+            }
+
+            def _rec(t: any) -> str {
+                if not isinstance(t, ClassType) or t._shared is None {
+                    return f"<{type(t).__name__}>";
+                }
+                key = t.shared.canonical_key();
+                site = "<nokey>";
+                if key is not None {
+                    site = f"{os.path.basename(key[0])}:{key[1]}:{key[2]}";
+                }
+                m = _mod_of(t);
+                state = "nomod";
+                if m is not None {
+                    mp = m.loc.mod_path if m.loc is not None else "";
+                    found = prog.find_module(mp) if mp else None;
+                    if found is m {
+                        state = "live";
+                    } elif found is not None {
+                        state = "stale";
+                    } else {
+                        state = "gone";
+                    }
+                    in_t = "y" if mp in prog.mod.hub else "n";
+                    in_s = "y" if mp in selfhost_prog.mod.hub else "n";
+                    state = f"{state}[t={in_t},s={in_s}]";
+                }
+                mro_names = ",".join(
+                    [c.shared.class_name for c in (t.shared.mro or [])]
+                );
+                base_names = ",".join(
+                    [
+                        (
+                            b.shared.class_name
+                                if isinstance(b, ClassType) and b._shared is not None
+                                else type(b).__name__
+                        ) for b in (t.shared.base_classes or [])
+                    ]
+                );
+                return (
+                    f"{t.shared.class_name}@{site} id={id(t.shared)} {state} "
+                    f"mro=[{mro_names}] bases=[{base_names}]"
+                );
+            }
+
+            lines = [
+                f"[ASSIGN-FAIL] pid={os.getpid()} src={_rec(src_type)}",
+                f"[ASSIGN-FAIL]   dest={_rec(dest_type)}"
+            ];
+            for b in (src_type.shared.base_classes or []) {
+                lines.append(f"[ASSIGN-FAIL]   src.base={_rec(b)}");
+                if isinstance(b, ClassType) and b._shared is not None {
+                    for bb in (b.shared.base_classes or []) {
+                        lines.append(f"[ASSIGN-FAIL]     src.base.base={_rec(bb)}");
+                    }
+                }
+            }
+            te_state = "set" if selfhost_prog.type_evaluator is not None else "none";
+            lines.append(
+                f"[ASSIGN-FAIL]   selfhost_te={te_state} "
+                f"selfhost_hub={len(selfhost_prog.mod.hub)} "
+                f"target_hub={len(prog.mod.hub)} "
+                f"depth={prog.scratch.compile_depth}/{selfhost_prog.scratch.compile_depth}"
+            );
+            sys.stderr.write("\n".join(lines) + "\n");
+        } except Exception as e {
+            sys.stderr.write(f"[ASSIGN-FAIL-PROBE-ERR] {e!r}" + "\n");
+        }
+    }
     return False;
 }
 


### PR DESCRIPTION
> **TEMPORARY, DO NOT MERGE.** Validation instrumentation only, for #8828. Close once the probe data is collected.

## Why

`jac-check` is still red on **7 of the last 19 CI runs on main (~37%)**, after #8886 merged and after the analysis cache key was bumped to `v2`. Two victims alternate, each a single file out of ~1048:

| File | Errors |
| --- | --- |
| `jac/jaclang/client/targets/register.jac` | 2x `E1053: Cannot assign StaticTarget/DesktopTarget to parameter 'target' of type ClientTarget` |
| `jac/jaclang/byllm/types.impl/media.impl.jac` | 13 errors, `ImageFile`/`Image` lose `format` and `save` |

Two things are ruled out by the run logs:

- **Cache lineage is not the mechanism.** Run `34305025862` was fully cold (`Cache not found for input keys`) and failed on `register.jac` anyway. Run `34362979411` restored a cache that had been saved by a **green** run and failed.
- **#8886 does not cover this path.** Its diff touches `compiler.impl.jac`, `operations.jac` and `type_evaluator.impl.jac` only, i.e. the typeshed lens flip. Neither the interface decoder nor the XREF resolver is in it.

The failing shape is specific: `WebTarget(ClientTarget)` and `MobileTarget(ClientTarget)` pass, while `StaticTarget(WebTarget)` and `DesktopTarget(WebTarget)` fail. Only classes that inherit through an intermediate module break.

## What this PR adds

Three sites degrade silently today. Each turns an unresolvable reference into an empty but plausible type record, rather than into an error or a cache miss:

1. `types/stubcat/reader.jac` (SH_XREF branch): a class whose home module cannot be resolved becomes a `ClassDetailsShared` that carries **the real class's canonical identity key** but an empty MRO, no base classes and an `_orphan_scope` (empty symbol table). It is memoized in `_shared_memo` and on `IfaceEntry.module`, so one bad decode follows the worker for the rest of its life.
2. `driver/ifacecache.jac` `resolve_shared`: six distinct `return None` paths, two of them bare `except Exception`, none counted or logged. `prog.analysis.cache_events` is never printed anywhere, so the whole interface cache is unobservable in CI.
3. `types/type_evaluator.impl/imported.impl.jac:481`: an import cycle yields an empty `Module.make_stub()`. Relevant here because `register.jac` and `registry.jac` import each other (`registry.jac:80` pulls `register_targets` inside `get_target_registry`).

There is also a writer/reader asymmetry worth noting: `build_module_iface` raises `IncoherentInterface` rather than persist an incoherent interface, while the reader happily fabricates one. And `persist_after_compile` writes `SEC_IFACE` unconditionally, dropping only the diagnostics profile when errors exist.

All probes are gated on `JAC_XREF_PROBE` and cost nothing when it is unset. `JAC_XREF_FAIL_CLASSES` forces a named class's XREF to orphan, for testing consequences.

## What I already validated locally

- **Positive control:** the XREF path really is exercised. A serial `jac check jac/jaclang/client/targets` performs 182 resolutions across 19 distinct home modules.
- **The injector works:** forcing `WebTarget` produced 2 orphans, forcing `ClientTarget` produced 4.
- **The orphan is NOT the cause of these particular errors.** With `WebTarget` orphaned, and again with `ClientTarget` orphaned, `register.jac` still **passes**. `ClassDetailsShared.same_class` compares canonical keys and the fabricated record carries the correct key, and `StaticTarget`'s MRO is read from the interface rather than recomputed from `base_classes`. So the fabricated record is benign for subtype checks and should only bite attribute lookup, which matches `media.impl` but not `register.jac`.

That is why this PR exists: local reproduction has hit its limit. A single-file `jac check` decodes zero XREFs, and a multi-file run serves the deps from interfaces but then **replays** cached diagnostics for the dependent, so the file is never re-checked. The failure needs the real pooled 1048-file sweep.

## The probe job

`jac-check-xref-probe` repeats the whole-tree sweep 4 times in parallel, `continue-on-error`, uploading each leg's stderr as an artifact. At the observed 37% base rate, 4 legs give roughly an 84% chance that at least one reproduces and reports which reference degraded and why. Legs that pass are still useful: they give the baseline orphan count on a green run, which is the comparison I could not get locally.

Expect every leg to run cold, since the probe job restores no cache and the compiler edits invalidate the key anyway.

## Checklist

- [x] `jac fmt --check --lintfix` clean on all three touched files (the `no-print` rule forced `sys.stderr.write`)
- [ ] Not for merge. Delete the branch once the probe artifacts are read.


