### PR TITLE
ci(release): avoid building Jac for release PR preparation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,11 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       inputs.action == 'create-pr'
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 40
+    timeout-minutes: 10
+    env:
+      # Run the release scripts with the published compiler. The root jac.toml
+      # otherwise reroutes the installed binary to this checkout's jaclang.
+      JAC_NO_DEV_SOURCE: "1"
     permissions:
       contents: write
       pull-requests: write
@@ -50,12 +54,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          submodules: true
 
-      - name: Set up jac (build the binary)
-        uses: ./.github/actions/setup-jac
+      # PR preparation only needs a released Jac runtime, not a source build.
+      - name: Install released jac binary
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          bash scripts/install.sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Validate versions against PyPI
+      - name: Validate version bump
         run: |
           jac run scripts/validate_release.jac \
             --jaclang "${{ inputs.jaclang }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,6 +252,10 @@ the MCP server, and the client/desktop runtimes are all bundled into the binary.
 4. **Close and reopen the PR** to make CI run. The PR is authored by `github-actions[bot]`, and GitHub does not run `pull_request` checks for PRs opened by the `GITHUB_TOKEN` actor (workflows triggered by `GITHUB_TOKEN` can't trigger further workflows, to prevent recursion). Closing and reopening makes the reopen event come from *you* (a real user), so the PR checks run and attach. *(Permanent fix: author the PR with a GitHub App / PAT token instead.)*
 5. Once the checks attach, enable **auto-merge** on the PR (or approve and merge manually when CI passes)
 
+PR preparation downloads the latest released Jac binary to run the version and
+release-note scripts. It sets `JAC_NO_DEV_SOURCE=1` to use the bundled compiler,
+so this job does not build Jac from source.
+
 ### Step 2: Approve the Release
 
 After the release PR is merged, the **Release** workflow triggers automatically:


### PR DESCRIPTION
## Description

The release workflow's `create-pr` action invokes `setup-jac`, which builds Jac whenever the binary cache misses. Install the latest released binary with `scripts/install.sh` and set `JAC_NO_DEV_SOURCE=1` so version and release-note scripts use its bundled compiler. PR preparation no longer needs a source build.

Reduce the job timeout to 10 minutes, remove the unnecessary submodule checkout, correct the validation step name, and document the runtime used for PR preparation.

Validation:
- `actionlint` passed for `.github/workflows/release.yml`.
- Using released Jac 0.37.11 (verified against the published checksum), ran validation and a complete patch release in a temporary copy. Confirmed the version bump, site pin, release-note assembly, consumed fragments, and GitHub Actions outputs.
- `git diff --check` passed.

No release note is needed for this internal workflow change.
