### PR TITLE
fix: bound native parser and client build memory lifetimes

### DIFF
--- a/jac/jaclang/client/client_bundle.jac
+++ b/jac/jaclang/client/client_bundle.jac
@@ -23,6 +23,13 @@ obj ClientBundle {
         hash: str;
 }
 
+obj ClientBuildInputs {
+    has module_name: str,
+        client_functions: list[str],
+        client_globals: list[str],
+        assets: dict[str, bytes] = {};
+}
+
 obj _CachedBundle {
     has signature: str,
         bundle: ClientBundle;

--- a/jac/jaclang/client/compiler.jac
+++ b/jac/jaclang/client/compiler.jac
@@ -2,7 +2,11 @@ import contextlib;
 import from pathlib { Path }
 import from types { ModuleType }
 import from typing { TYPE_CHECKING }
-import from jaclang.client.client_bundle { ClientBundleError }
+import from jaclang.client.client_bundle {
+    ClientBuildInputs,
+    ClientBundle,
+    ClientBundleError
+}
 import from jaclang.client.jac_client_compiler { JacClientCompiler }
 import from jaclang.client.vite_bundler { ViteBundler }
 import type from jaclang.compiler.frontend.codeinfo { ClientArtifact, ClientManifest }
@@ -32,10 +36,16 @@ class ViteCompiler {
     def _owes_wasm(self: ViteCompiler, module_path: Path) -> bool;
     def _emit_na_wasm(self: ViteCompiler, module_path: Path) -> None;
     def _emit_wasm_module(self: ViteCompiler, module_path: Path) -> bool;
-    def compile_and_bundle(
-        self: ViteCompiler, module: ModuleType, module_path: Path
-    ) -> tuple[str, str, list[str], list[str]];
+    def _wasm_targets(self: ViteCompiler, module_path: Path) -> list[Path];
+    def _compile_wasm_module(
+        self: ViteCompiler, module_path: Path
+    ) -> dict[str, bytes];
 
+    def prepare_bundle(
+        self: ViteCompiler, module: ModuleType, module_path: Path
+    ) -> ClientBuildInputs;
+
+    def bundle(self: ViteCompiler, inputs: ClientBuildInputs) -> ClientBundle;
     def compile(
         self: ViteCompiler, module: (ModuleType | None), module_path: Path
     ) -> tuple[list[str], list[str]];

--- a/jac/jaclang/client/impl/compiler.impl.jac
+++ b/jac/jaclang/client/impl/compiler.impl.jac
@@ -14,17 +14,49 @@ impl ViteCompiler.compile(
     return (client_exports, client_globals);
 }
 
-impl ViteCompiler.compile_and_bundle(
+impl ViteCompiler.prepare_bundle(
     self: ViteCompiler, module: ModuleType, module_path: Path
-) -> tuple[str, str, list[str], list[str]] {
+) -> ClientBuildInputs {
+    import json;
+    import from jaclang.runtime.runtime { JacRuntime as Jac }
+    import from jaclang.compiler.boundary_audit { boundary_audit }
     (client_exports, client_globals) = self.compile(module, module_path);
+    assets: dict[str, bytes] = {};
+    for target in self._wasm_targets(module_path) {
+        assets.update(self._compile_wasm_module(target));
+    }
+    assets["boundaries.json"] = json.dumps(
+        boundary_audit(
+            Jac.get_program(),
+            list(self.jac_client_compiler.jac_compiler.boundary_contracts.values())
+        ),
+        indent=2
+    ).encode(
+        "utf-8"
+    );
+    return ClientBuildInputs(
+        module_name=module.__name__,
+        client_functions=client_exports,
+        client_globals=client_globals,
+        assets=assets
+    );
+}
 
-    entry_file = self.compiled_dir / '_entry.js';
-    self.vite_bundler.build(entry_file=entry_file);
-    (bundle_code, bundle_hash) = self.vite_bundler.read_bundle();
-
-    self._emit_na_wasm(module_path);
-    return (bundle_code, bundle_hash, client_exports, client_globals);
+impl ViteCompiler.bundle(
+    self: ViteCompiler, inputs: ClientBuildInputs
+) -> ClientBundle {
+    self.vite_bundler.build(entry_file=self.compiled_dir / '_entry.js');
+    (code, digest) = self.vite_bundler.read_bundle();
+    for (name, content) in inputs.assets.items() {
+        (self.vite_bundler.output_dir / name).write_bytes(content);
+    }
+    return ClientBundle(
+        module_name=inputs.module_name,
+        code=code,
+        hash=digest,
+        client_functions=inputs.client_functions,
+        client_globals=inputs.client_globals
+    );
 }
 
 impl ViteCompiler._owes_wasm(self: ViteCompiler, module_path: Path) -> bool {
@@ -52,9 +84,10 @@ impl ViteCompiler._owes_wasm(self: ViteCompiler, module_path: Path) -> bool {
     return False;
 }
 
-impl ViteCompiler._emit_na_wasm(self: ViteCompiler, module_path: Path) -> None {
+impl ViteCompiler._wasm_targets(self: ViteCompiler, module_path: Path) -> list[Path] {
+    targets: list[Path] = [];
     if self._owes_wasm(module_path) {
-        self._emit_wasm_module(module_path);
+        targets.append(module_path);
     }
 
     declared = sorted(
@@ -71,24 +104,40 @@ impl ViteCompiler._emit_na_wasm(self: ViteCompiler, module_path: Path) -> None {
             );
             continue;
         }
+        targets.append(target);
+    }
+    return targets;
+}
+
+impl ViteCompiler._emit_na_wasm(self: ViteCompiler, module_path: Path) -> None {
+    for target in self._wasm_targets(module_path) {
         self._emit_wasm_module(target);
     }
 }
 
 impl ViteCompiler._emit_wasm_module(self: ViteCompiler, module_path: Path) -> bool {
+    assets = self._compile_wasm_module(module_path);
+    dist = self.vite_bundler.output_dir;
+    dist.mkdir(parents=True, exist_ok=True);
+    for (name, content) in assets.items() {
+        (dist / name).write_bytes(content);
+    }
+    return bool(assets);
+}
+
+impl ViteCompiler._compile_wasm_module(
+    self: ViteCompiler, module_path: Path
+) -> dict[str, bytes] {
     import from jaclang.compiler.backends.native.wasm_build { compile_to_wasm }
     import from jaclang.compiler.frontend.codeinfo { native_wasm_stem }
     try {
         wasm = compile_to_wasm(str(module_path));
     } except Exception as e {
         console.error(f"na->wasm failed for '{module_path.name}': {e}");
-        return False;
+        return {};
     }
     stem = native_wasm_stem(str(module_path));
-    dist = self.vite_bundler.output_dir;
-    dist.mkdir(parents=True, exist_ok=True);
-    out_path = dist / f"{stem}.wasm";
-    out_path.write_bytes(wasm);
+    assets: dict[str, bytes] = {f"{stem}.wasm": wasm};
     console.print(f"  Native wasm module: /static/{stem}.wasm ({len(wasm)} bytes)");
 
     try {
@@ -96,10 +145,10 @@ impl ViteCompiler._emit_wasm_module(self: ViteCompiler, module_path: Path) -> bo
         import from jaclang.compiler.backends.native.wasm_build { wasm_import_map }
         import from jaclang.compiler.backends.native.wasm_host_abi { WASM_HOST_MODULE }
         imports = wasm_import_map(wasm);
-        manifest_path = dist / f"{stem}.wasm.imports.json";
-        manifest_path.write_text(
-            json.dumps({"abi": WASM_HOST_MODULE, "imports": imports}, indent=2),
-            encoding='utf-8',
+        assets[f"{stem}.wasm.imports.json"] = json.dumps(
+            {"abi": WASM_HOST_MODULE, "imports": imports}, indent=2
+        ).encode(
+            'utf-8'
         );
         app_ffi = [];
         for mod_nm in imports {
@@ -116,7 +165,7 @@ impl ViteCompiler._emit_wasm_module(self: ViteCompiler, module_path: Path) -> bo
     } except Exception as e {
         console.warning(f"Could not write wasm import manifest: {e}");
     }
-    return True;
+    return assets;
 }
 
 impl ViteCompiler.create_entry_file(self: ViteCompiler, module_path: Path) -> None {

--- a/jac/jaclang/client/impl/vite_client_bundle.impl.jac
+++ b/jac/jaclang/client/impl/vite_client_bundle.impl.jac
@@ -45,37 +45,28 @@ impl ViteClientBundleBuilder._emitted_digest(self: ViteClientBundleBuilder) -> s
     return emitted_tree_digest(self.vite_package_json.parent / 'compiled');
 }
 
+impl ViteClientBundleBuilder.prepare(
+    self: ViteClientBundleBuilder, module: ModuleType
+) -> ClientBuildInputs {
+    if not module.__file__ {
+        raise ClientBundleError(
+            f"Module '{module.__name__}' has no __file__ attribute"
+        );
+    }
+    return self._get_compiler().prepare_bundle(module, Path(module.__file__).resolve());
+}
+
+impl ViteClientBundleBuilder.bundle(
+    self: ViteClientBundleBuilder, inputs: ClientBuildInputs
+) -> ClientBundle {
+    return self._get_compiler().bundle(inputs);
+}
+
 impl ViteClientBundleBuilder._compile_bundle(
     self: ViteClientBundleBuilder, module: ModuleType, module_path: Path
 ) -> ClientBundle {
     compiler = self._get_compiler();
-    (bundle_code, bundle_hash, client_exports, client_globals) = compiler.compile_and_bundle(
-        module, module_path
-    );
-    import json;
-    import from jaclang.runtime.runtime { JacRuntime as Jac }
-    import from jaclang.compiler.boundary_audit { boundary_audit }
-    if self.vite_output_dir is not None {
-        (self.vite_output_dir / "boundaries.json").write_text(
-            json.dumps(
-                boundary_audit(
-                    Jac.get_program(),
-                    list(
-                        compiler.jac_client_compiler.jac_compiler.boundary_contracts.values()
-                    )
-                ),
-                indent=2
-            ),
-            encoding="utf-8"
-        );
-    }
-    return ClientBundle(
-        module_name=module.__name__,
-        code=bundle_code,
-        client_functions=client_exports,
-        client_globals=client_globals,
-        hash=bundle_hash
-    );
+    return compiler.bundle(compiler.prepare_bundle(module, module_path));
 }
 
 impl ViteClientBundleBuilder._get_compiler(

--- a/jac/jaclang/client/targets/impl/web_target.impl.jac
+++ b/jac/jaclang/client/targets/impl/web_target.impl.jac
@@ -111,16 +111,22 @@ impl WebTarget.build(
     }
 
     program = Jac.get_program();
-    before = len(program.errors_had);
-    program.compile(str(entry_file.resolve()));
-    if len(program.errors_had) > before {
-        errors = '\n'.join(str(e) for e in program.errors_had[before:]);
-        raise RuntimeError(f"Failed to compile {entry_file}:\n{errors}");
-    }
     loaded_mod = types.ModuleType(entry_file.stem);
     loaded_mod.__file__ = str(entry_file.resolve());
     builder = make_client_bundle_builder(project_dir);
-    builder.build(loaded_mod, force=True);
+    try {
+        before = len(program.errors_had);
+        program.compile(str(entry_file.resolve()));
+        if len(program.errors_had) > before {
+            errors = '\n'.join(str(e) for e in program.errors_had[before:]);
+            raise RuntimeError(f"Failed to compile {entry_file}:\n{errors}");
+        }
+        inputs = builder.prepare(loaded_mod);
+        function_name = _get_client_function_name(loaded_mod);
+    } finally {
+        program._get_compiler().release_compile_state(program);
+    }
+    builder.bundle(inputs);
     bundle_path = bundler.find_bundle();
     if not bundle_path {
         raise RuntimeError("Web build failed: bundle not found");
@@ -129,6 +135,7 @@ impl WebTarget.build(
         bundle_path=bundle_path,
         bundler=bundler,
         loaded_mod=loaded_mod,
+        function_name=function_name,
         project_dir=project_dir
     );
     if _pwa_enabled(project_dir) {
@@ -201,13 +208,13 @@ def _generate_index_html(
     bundle_path: Path,
     bundler: ViteBundler,
     loaded_mod: types.ModuleType,
+    function_name: str,
     project_dir: Path
 ) {
     import html;
     import json;
     import from jaclang.client.serving { HeaderBuilder }
 
-    function_name = _get_client_function_name(loaded_mod);
     module_name = loaded_mod.__name__;
     dist_dir = Path(bundler.output_dir);
     css_link = _build_css_link(bundler);

--- a/jac/jaclang/client/vite_client_bundle.jac
+++ b/jac/jaclang/client/vite_client_bundle.jac
@@ -5,6 +5,7 @@ import from types { ModuleType }
 import from typing { cast }
 import from jaclang.compiler.frontend.codeinfo { ClientArtifact }
 import from jaclang.client.client_bundle {
+    ClientBuildInputs,
     ClientBundle,
     ClientBundleBuilder,
     ClientBundleError
@@ -23,6 +24,14 @@ class ViteClientBundleBuilder(ClientBundleBuilder) {
     ) -> None;
 
     def _get_compiler(self: ViteClientBundleBuilder) -> ViteCompiler;
+    def prepare(
+        self: ViteClientBundleBuilder, module: ModuleType
+    ) -> ClientBuildInputs;
+
+    def bundle(
+        self: ViteClientBundleBuilder, inputs: ClientBuildInputs
+    ) -> ClientBundle;
+
     def _compile_bundle(
         self: ViteClientBundleBuilder, module: ModuleType, module_path: Path
     ) -> ClientBundle;

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/calls.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/calls.impl.jac
@@ -1111,7 +1111,7 @@ impl NaIRGenPass._codegen_receiver(nd: (uni.UniNode | None)) -> (ir.Value | None
 }
 
 impl NaIRGenPass._emit_take_ref(value: ir.Value, op: str, loc: str = "") -> None {
-    if isinstance(value.type, ir.PointerType) and not self._is_owned(value) {
+    if self._elem_kind(value.type) in ("rc_ptr", "str") and not self._is_owned(value) {
         self._emit_rc_retain(value, op=op, loc=loc);
         return;
     }
@@ -1710,10 +1710,7 @@ impl NaIRGenPass._codegen_call(nd: uni.FuncCall) -> (ir.Value | None) {
                         );
                     }
                     if _len_result is not None {
-                        if isinstance(arg_val.type, ir.PointerType)
-                            and self._is_owned(arg_val) {
-                            self._emit_rc_release_simple(arg_val, op="len_arg", loc="");
-                        }
+                        self._release_owned_args([arg_val], op="len_arg");
                         return _len_result;
                     }
                 }

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/comprehensions.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/comprehensions.impl.jac
@@ -583,11 +583,11 @@ impl NaIRGenPass._codegen_compr_walk_body(
         skip_bb = func.append_basic_block(name="compr.skip");
         all_cond = self._codegen_expr(conditionals[0]);
         if all_cond is not None {
-            all_cond = self._to_bool(all_cond);
+            all_cond = self._consume_bool(all_cond);
             for i in range(1, len(conditionals)) {
                 next_cond = self._codegen_expr(conditionals[i]);
                 if next_cond is not None {
-                    next_cond = self._to_bool(next_cond);
+                    next_cond = self._consume_bool(next_cond);
                     all_cond = self.builder.and_(all_cond, next_cond, name="compr.and");
                 }
             }
@@ -677,11 +677,11 @@ impl NaIRGenPass._codegen_compr_range_walk(
         skip_bb = func.append_basic_block(name="compr.range.skip");
         all_cond = self._codegen_expr(conditionals[0]);
         if all_cond is not None {
-            all_cond = self._to_bool(all_cond);
+            all_cond = self._consume_bool(all_cond);
             for i in range(1, len(conditionals)) {
                 next_cond = self._codegen_expr(conditionals[i]);
                 if next_cond is not None {
-                    next_cond = self._to_bool(next_cond);
+                    next_cond = self._consume_bool(next_cond);
                     all_cond = self.builder.and_(all_cond, next_cond, name="compr.and");
                 }
             }

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/container_helpers.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/container_helpers.impl.jac
@@ -1,4 +1,7 @@
 impl NaIRGenPass._elem_kind(elem_type: ir.Type) -> str {
+    if self._str_desc_ty is not None and elem_type == self._str_desc_ty {
+        return "str";
+    }
     if self?.jacval_type and elem_type == self.jacval_type {
         return "jacval";
     }
@@ -118,6 +121,9 @@ impl NaIRGenPass._emit_elem_retain(
     if self.rc_retain_fn is None {
         self._emit_rc_helpers();
     }
+    if _kind == "str" {
+        val = b.extract_value(val, 0, name="elem.str.root");
+    }
     b.call(
         self.rc_retain_fn,
         [b.bitcast(val, ir.IntType(8).as_pointer(), name="elem.retain.cast")]
@@ -137,6 +143,9 @@ impl NaIRGenPass._emit_elem_release(
     }
     if self.rc_release_simple_fn is None {
         self._emit_rc_helpers();
+    }
+    if _kind == "str" {
+        val = b.extract_value(val, 0, name="elem.str.root");
     }
     b.call(
         self.rc_release_simple_fn,
@@ -167,7 +176,9 @@ impl NaIRGenPass._emit_elem_trace(
         visit_builder.branch(done_bb);
         return ir.IRBuilder(done_bb);
     }
-    if kind == "rc_ptr" {
+    if kind == "str" {
+        b.call(visitor, [b.extract_value(val, 0, name="trace.str.root")]);
+    } elif kind == "rc_ptr" {
         b.call(visitor, [b.bitcast(val, i8p)]);
     }
     return b;

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/dicts.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/dicts.impl.jac
@@ -523,9 +523,9 @@ impl NaIRGenPass._codegen_dict_access(
     if _gh is not None {
         _get_args.append(_gh);
     }
-    result = self.builder.call(_get_fn, _get_args, name="dict.get");
+    borrowed = self.builder.call(_get_fn, _get_args, name="dict.get");
     self._release_owned_args([key_val], op="dict_get");
-    result = self._finish_borrowed_read(target_val, result);
+    result = self._finish_borrowed_read(target_val, borrowed);
     self._emit_runtime_raise(not_exists, "KeyError", "key not found");
     return result;
 }

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/dicts.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/dicts.impl.jac
@@ -518,18 +518,15 @@ impl NaIRGenPass._codegen_dict_access(
     }
     key_exists = self.builder.call(_has_fn, _has_args, name="dict.has");
     not_exists = self.builder.not_(key_exists, name="dict.nokey");
-    self._emit_runtime_raise(not_exists, "KeyError", "key not found");
     (_get_fn, _gh) = self._static_key_op(helpers, "get", key_node);
     _get_args = [target_val, key_val];
     if _gh is not None {
         _get_args.append(_gh);
     }
     result = self.builder.call(_get_fn, _get_args, name="dict.get");
-    if self._is_owned(target_val) and self._gc_mode() != "none" {
-        self._emit_take_ref(result, op="dict_get");
-        self._release_owned_args([target_val], op="call_arg");
-        return self._mark_reference_owned(result);
-    }
+    self._release_owned_args([key_val], op="dict_get");
+    result = self._finish_borrowed_read(target_val, result);
+    self._emit_runtime_raise(not_exists, "KeyError", "key not found");
     return result;
 }
 
@@ -552,7 +549,6 @@ impl NaIRGenPass._codegen_dict_set(
     if self._reject_ptr_into_raw_slot(None, value, val_type, "dict value assignment") {
         return;
     }
-    _orig_key = key_val;
     _orig_value = value;
     key_val = self._coerce_type(key_val, key_type);
     value = self._coerce_type(value, val_type);
@@ -566,22 +562,5 @@ impl NaIRGenPass._codegen_dict_set(
     }
     self._rc_call_with_ctx(_set_fn, _set_args, op="dict_set", loc=_dset_ctx_loc);
 
-    if (
-        isinstance(_orig_key.type, ir.PointerType)
-        and isinstance(key_type, ir.PointerType)
-        and self._is_owned(_orig_key)
-    ) {
-        self._emit_rc_release_simple(_orig_key, op="dict_set", loc=_dset_ctx_loc);
-    }
-
-    if (
-        isinstance(_orig_value.type, ir.PointerType)
-        and self._elem_kind(val_type) != "raw"
-        and self._is_owned(_orig_value)
-    ) {
-        _dset_loc = getattr(
-            _orig_value, 'jac_loc', f"{os.path.basename(self.ir_in.loc.mod_path)}:0"
-        );
-        self._emit_rc_release_simple(_orig_value, op="dict_set", loc=_dset_loc);
-    }
+    self._release_owned_args([key_val, value], op="dict_set");
 }

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -127,11 +127,7 @@ impl NaIRGenPass._codegen_expr(nd: (uni.UniNode | None)) -> (ir.Value | None) {
             }
         }
 
-        if isinstance(nd, uni.Expr)
-            and (
-                isinstance(_result.type, ir.PointerType)
-                or (self?.jacval_type and _result.type == self.jacval_type)
-            ) {
+        if isinstance(nd, uni.Expr) and self._elem_kind(_result.type) != "raw" {
             import from jaclang.compiler.passes.rc_facts_pass {
                 Ownership,
                 result_ownership
@@ -1287,22 +1283,9 @@ impl NaIRGenPass._codegen_compare_link(
     if op == Tok.KW_IS or op == Tok.KW_ISN {
         _opt_ident = self._identity_over_optional(left, right, op == Tok.KW_ISN);
         if _opt_ident is not None {
-            if release_operands
-                and isinstance(_cmp_left_orig.type, ir.PointerType)
-                and self._is_owned(_cmp_left_orig) {
-                self._emit_rc_release_simple(
-                    _cmp_left_orig,
-                    op="cmp_is_opt",
-                    loc=getattr(_cmp_left_orig, 'jac_loc', '')
-                );
-            }
-            if release_operands
-                and isinstance(_cmp_right_orig.type, ir.PointerType)
-                and self._is_owned(_cmp_right_orig) {
-                self._emit_rc_release_simple(
-                    _cmp_right_orig,
-                    op="cmp_is_opt",
-                    loc=getattr(_cmp_right_orig, 'jac_loc', '')
+            if release_operands {
+                self._release_owned_operands(
+                    _cmp_left_orig, _cmp_right_orig, op="cmp_is_opt"
                 );
             }
             return _opt_ident;
@@ -1316,22 +1299,9 @@ impl NaIRGenPass._codegen_compare_link(
                 right = self.builder.bitcast(right, left.type);
             }
             _is_result = self.builder.icmp_unsigned("==", left, right, name="is.eq");
-            if release_operands
-                and isinstance(_cmp_left_orig.type, ir.PointerType)
-                and self._is_owned(_cmp_left_orig) {
-                self._emit_rc_release_simple(
-                    _cmp_left_orig,
-                    op="cmp_is",
-                    loc=getattr(_cmp_left_orig, 'jac_loc', '')
-                );
-            }
-            if release_operands
-                and isinstance(_cmp_right_orig.type, ir.PointerType)
-                and self._is_owned(_cmp_right_orig) {
-                self._emit_rc_release_simple(
-                    _cmp_right_orig,
-                    op="cmp_is",
-                    loc=getattr(_cmp_right_orig, 'jac_loc', '')
+            if release_operands {
+                self._release_owned_operands(
+                    _cmp_left_orig, _cmp_right_orig, op="cmp_is"
                 );
             }
             return _is_result;
@@ -1350,22 +1320,9 @@ impl NaIRGenPass._codegen_compare_link(
                 right = self.builder.bitcast(right, left.type);
             }
             _isn_result = self.builder.icmp_unsigned("!=", left, right, name="is.ne");
-            if release_operands
-                and isinstance(_cmp_left_orig.type, ir.PointerType)
-                and self._is_owned(_cmp_left_orig) {
-                self._emit_rc_release_simple(
-                    _cmp_left_orig,
-                    op="cmp_isn",
-                    loc=getattr(_cmp_left_orig, 'jac_loc', '')
-                );
-            }
-            if release_operands
-                and isinstance(_cmp_right_orig.type, ir.PointerType)
-                and self._is_owned(_cmp_right_orig) {
-                self._emit_rc_release_simple(
-                    _cmp_right_orig,
-                    op="cmp_isn",
-                    loc=getattr(_cmp_right_orig, 'jac_loc', '')
+            if release_operands {
+                self._release_owned_operands(
+                    _cmp_left_orig, _cmp_right_orig, op="cmp_isn"
                 );
             }
             return _isn_result;
@@ -1387,19 +1344,8 @@ impl NaIRGenPass._codegen_compare_link(
     _cmp_result = self._emit_comparison(
         op, left, right, is_float, unsigned=_cmp_unsigned
     );
-    if release_operands
-        and isinstance(_cmp_left_orig.type, ir.PointerType)
-        and self._is_owned(_cmp_left_orig) {
-        self._emit_rc_release_simple(
-            _cmp_left_orig, op="cmp_op", loc=getattr(_cmp_left_orig, 'jac_loc', '')
-        );
-    }
-    if release_operands
-        and isinstance(_cmp_right_orig.type, ir.PointerType)
-        and self._is_owned(_cmp_right_orig) {
-        self._emit_rc_release_simple(
-            _cmp_right_orig, op="cmp_op", loc=getattr(_cmp_right_orig, 'jac_loc', '')
-        );
+    if release_operands {
+        self._release_owned_operands(_cmp_left_orig, _cmp_right_orig, op="cmp_op");
     }
     return _cmp_result;
 }
@@ -1503,13 +1449,7 @@ impl NaIRGenPass._codegen_compare_chain(
             else self.builder.and_(result, link, name=f"chain.and.{i}");
         cur = right;
     }
-    for _ov in operands {
-        if isinstance(_ov.type, ir.PointerType) and self._is_owned(_ov) {
-            self._emit_rc_release_simple(
-                _ov, op="cmp_chain", loc=getattr(_ov, 'jac_loc', '')
-            );
-        }
-    }
+    self._release_owned_args(operands, op="cmp_chain");
     return result;
 }
 
@@ -1576,7 +1516,7 @@ impl NaIRGenPass._codegen_unary(nd: uni.UnaryExpr) -> (ir.Value | None) {
             zero = ir.Constant(operand.type, 0);
             return self.builder.icmp_signed("==", operand, zero, name="not");
         }
-        return self.builder.not_(self._to_bool(operand), name="not");
+        return self.builder.not_(self._consume_bool(operand), name="not");
     } elif op == Tok.BW_NOT {
         if isinstance(operand.type, ir.IntType) {
             all_ones = ir.Constant(operand.type, -1);
@@ -1640,6 +1580,7 @@ impl NaIRGenPass._codegen_bool_expr(nd: uni.BoolExpr) -> (ir.Value | None) {
     result: ir.Value = first_value;
 
     for i in range(1, len(nd.values)) {
+        left_value = result;
         cond = self._to_bool(result);
         func = self.builder.function;
         rhs_bb = func.append_basic_block(name=f"bool.rhs.{i}");
@@ -1664,8 +1605,9 @@ impl NaIRGenPass._codegen_bool_expr(nd: uni.BoolExpr) -> (ir.Value | None) {
             return None;
         }
         target_t = self._bool_expr_unify_type(result.type, rhs_val.type);
+        bool_only = target_t is None;
         if target_t is None {
-            rhs_val = self._to_bool(rhs_val);
+            rhs_val = self._consume_bool(rhs_val);
             result = cond;
             target_t = ir.IntType(1);
         }
@@ -1688,6 +1630,9 @@ impl NaIRGenPass._codegen_bool_expr(nd: uni.BoolExpr) -> (ir.Value | None) {
         }
 
         self.builder.position_at_end(take_bb);
+        if bool_only {
+            self._release_owned_args([left_value], op="bool_drop");
+        }
         if result.type != target_t {
             if self._opt_ptr_payload_of(result.type) == target_t {
                 result = self.builder.extract_value(result, 1, name="bool.opt.lpv");
@@ -1718,7 +1663,7 @@ impl NaIRGenPass._codegen_if_else_expr(nd: uni.IfElseExpr) -> (ir.Value | None) 
     if cond is None {
         return None;
     }
-    cond = self._to_bool(cond);
+    cond = self._consume_bool(cond);
     func = self.builder.function;
     then_bb = func.append_basic_block(name="ternary.then");
     else_bb = func.append_basic_block(name="ternary.else");
@@ -1799,12 +1744,20 @@ impl NaIRGenPass._codegen_if_else_expr(nd: uni.IfElseExpr) -> (ir.Value | None) 
             }
         }
     }
+    owns_result = (then_val is not None and self._is_owned(then_val))
+        or (else_val is not None and self._is_owned(else_val));
     if then_open {
         self.builder.position_at_end(then_end_bb);
+        if owns_result and then_val is not None {
+            self._emit_take_ref(then_val, op="ternary_keep");
+        }
         self.builder.branch(merge_bb);
     }
     if else_open {
         self.builder.position_at_end(else_end_bb);
+        if owns_result and else_val is not None {
+            self._emit_take_ref(else_val, op="ternary_keep");
+        }
         self.builder.branch(merge_bb);
     }
     self.builder.position_at_end(merge_bb);
@@ -1814,7 +1767,7 @@ impl NaIRGenPass._codegen_if_else_expr(nd: uni.IfElseExpr) -> (ir.Value | None) 
     phi = self.builder.phi(then_val.type, name="ternary.result");
     phi.add_incoming(then_val, then_end_bb);
     phi.add_incoming(else_val, else_end_bb);
-    return phi;
+    return self._mark_owned(phi) if owns_result else phi;
 }
 
 impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None) {
@@ -2175,7 +2128,7 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
                         else _slice_list_spec;
                     result = self._codegen_list_slice(target_val, s, elem_type_name);
                     if result is not None {
-                        return result;
+                        return self._finish_borrowed_read(target_val, result);
                     }
                 }
             } else {
@@ -2185,7 +2138,7 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
                     and target_val.type == self._str_desc_ty {
                     result = self._codegen_string_slice(target_val, s, nd.target);
                     if result is not None {
-                        return result;
+                        return self._finish_borrowed_read(target_val, result);
                     }
                 }
                 target_val = self._str_norm_optional(target_val);
@@ -2194,12 +2147,12 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
                     if self._is_bytes_value(target_val) {
                         result = self._codegen_bytes_slice(target_val, s);
                         if result is not None {
-                            return result;
+                            return self._finish_borrowed_read(target_val, result);
                         }
                     } elif target_val.type == i8p {
                         result = self._codegen_string_slice(target_val, s, nd.target);
                         if result is not None {
-                            return result;
+                            return self._finish_borrowed_read(target_val, result);
                         }
                     } else {
                         elem_type_name = self._infer_list_elem_type(target_val);
@@ -2208,7 +2161,7 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
                                 target_val, s, elem_type_name
                             );
                             if result is not None {
-                                return result;
+                                return self._finish_borrowed_read(target_val, result);
                             }
                         }
                     }
@@ -2254,7 +2207,7 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
                                 );
                             }
                         }
-                        return result;
+                        return self._finish_borrowed_read(target_val, result);
                     }
                 }
             }
@@ -2281,9 +2234,10 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
                             1 if self._nogc_headerless() else 2,
                             name="chr.len"
                         );
-                        return self._codegen_string_index(
+                        result = self._codegen_string_index(
                             _ddata, _didx_val, len_val=_dlen
                         );
+                        return self._finish_borrowed_read(target_val, result);
                     }
                 }
             }
@@ -2396,7 +2350,7 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
                                     );
                                 }
                             }
-                            return result;
+                            return self._finish_borrowed_read(target_val, result);
                         }
                     }
                 }

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/function_state.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/function_state.impl.jac
@@ -95,7 +95,7 @@ impl NaIRGenPass._bind_function_parameter(
         slot = self._emit_closure_cell(name, value.type);
         self.builder.store(value, slot);
         self.local_vars[name] = slot;
-        if borrowed and isinstance(value.type, ir.PointerType) {
+        if borrowed and self._elem_kind(value.type) in ("rc_ptr", "str") {
             self._emit_rc_retain(value, op="param_cell", loc=name);
         }
         return;
@@ -103,7 +103,7 @@ impl NaIRGenPass._bind_function_parameter(
     slot = self._entry_alloca(value.type, name);
     self.builder.store(value, slot);
     self.local_vars[name] = slot;
-    if rebound and isinstance(value.type, ir.PointerType) {
+    if rebound and self._elem_kind(value.type) in ("rc_ptr", "str") {
         self._emit_rc_retain(value, op="param_promote", loc=name);
     } elif borrowed {
         self.param_vars.add(name);

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/objects.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/objects.impl.jac
@@ -2290,6 +2290,9 @@ impl NaIRGenPass._codegen_instantiation(
             }
         }
         self.builder.call(init_fn, coerced_args, name="call.init");
+        if not self._nogc_headerless() {
+            self._release_owned_args(coerced_args[1:], op="call_arg");
+        }
         self._emit_err_check(self._linked_callee_decl(init_fn));
     }
 
@@ -4310,7 +4313,11 @@ impl NaIRGenPass._emit_class_routed_call(
             _sargs[_i] = self._coerce_type(_sv, _sfunc.args[_i].type);
         }
     }
+    _release = self._transfer_own_args(
+        nd, _sfunc, _sargs, list(_sargs), offset=1 if _given_recv is not None else 0
+    );
     _sr = self.builder.call(_sfunc, _sargs, name=f"scall.{method_name}");
+    self._release_owned_args(_release, op="call_arg");
     self._emit_err_check(
         self._callee_ability_of(nd) or self._linked_callee_decl(_sfunc)
     );

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/refcount.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/refcount.impl.jac
@@ -598,12 +598,22 @@ impl NaIRGenPass._mark_owned(val: ir.Value) -> ir.Value {
 }
 
 impl NaIRGenPass._mark_reference_owned(result: ir.Value) -> ir.Value {
-    if isinstance(result.type, ir.PointerType)
-        or self._opt_ptr_payload_of(result.type) is not None
-        or (self?.jacval_type and result.type == self.jacval_type) {
+    if self._elem_kind(result.type) != "raw"
+        or self._opt_ptr_payload_of(result.type) is not None {
         return self._mark_owned(result);
     }
     return result;
+}
+
+impl NaIRGenPass._finish_borrowed_read(
+    owner: ir.Value, value: (ir.Value | None)
+) -> (ir.Value | None) {
+    if value is None or self._nogc_headerless() or not self._is_owned(owner) {
+        return value;
+    }
+    self._emit_take_ref(value, op="read");
+    self._release_owned_args([owner], op="read");
+    return self._mark_reference_owned(value);
 }
 
 
@@ -673,23 +683,14 @@ impl NaIRGenPass._nogc_borrow_local_assign(nd: object) -> bool {
 impl NaIRGenPass._release_owned_operands(
     left_orig: ir.Value, right_orig: ir.Value, op: str = ""
 ) -> None {
-    if isinstance(left_orig.type, ir.PointerType) and self._is_owned(left_orig) {
-        self._emit_rc_release_simple(
-            left_orig, op=op, loc=getattr(left_orig, 'jac_loc', '')
-        );
-    }
-    if isinstance(right_orig.type, ir.PointerType) and self._is_owned(right_orig) {
-        self._emit_rc_release_simple(
-            right_orig, op=op, loc=getattr(right_orig, 'jac_loc', '')
-        );
-    }
+    self._release_owned_args([left_orig, right_orig], op=op);
 }
 
 impl NaIRGenPass._release_owned_args(
     call_args: list[ir.Value], op: str = "call_arg"
 ) -> None {
     for _arg in call_args {
-        if isinstance(_arg.type, ir.PointerType) and self._is_owned(_arg) {
+        if self._elem_kind(_arg.type) in ("rc_ptr", "str") and self._is_owned(_arg) {
             self._emit_rc_release_simple(_arg, op=op, loc="");
         } elif (
             self?.jacval_type is not None
@@ -1225,6 +1226,35 @@ impl NaIRGenPass._emit_str_desc_helpers -> None {
     ub.ret(ub.call(self.str_new_fn, [_u_data, _u_len], name="u.copy"));
     self.str_unwrap_fn = uf;
 
+    if not _hl {
+        mf = self._define_function("__jac_str_materialize", ir.FunctionType(i8p, [desc]));
+        mf.linkage = "private";
+        mb = ir.IRBuilder(mf.append_basic_block("entry"));
+        null_bb = mf.append_basic_block("null");
+        probe_bb = mf.append_basic_block("probe");
+        keep_bb = mf.append_basic_block("keep");
+        copy_bb = mf.append_basic_block("copy");
+        owner = mb.extract_value(mf.args[0], 0, name="owner");
+        data = mb.extract_value(mf.args[0], _di, name="data");
+        size = mb.extract_value(mf.args[0], _li, name="size");
+        mb.cbranch(mb.icmp_unsigned("==", data, ir.Constant(i8p, None)), null_bb, probe_bb);
+        mb.position_at_end(null_bb);
+        mb.ret(ir.Constant(i8p, None));
+        mb.position_at_end(probe_bb);
+        terminator = mb.load(mb.gep(data, [size]));
+        complete = mb.and_(
+            mb.icmp_unsigned("==", data, owner),
+            mb.icmp_unsigned("==", terminator, ir.Constant(i8, 0))
+        );
+        mb.cbranch(complete, keep_bb, copy_bb);
+        mb.position_at_end(keep_bb);
+        self._emit_elem_retain(mb, i8p, owner);
+        mb.ret(owner);
+        mb.position_at_end(copy_bb);
+        mb.ret(mb.call(self.str_new_fn, [data, size], name="copy"));
+        self.str_materialize_fn = mf;
+    }
+
     incoming = self._define_function("__jac_str_import", ir.FunctionType(i8p, [i8p]));
     incoming.linkage = "private";
     incoming.args[0].name = "source";
@@ -1258,6 +1288,18 @@ impl NaIRGenPass._str_norm(val: ir.Value) -> ir.Value {
         self._mark_owned(_normed);
     }
     return _normed;
+}
+
+impl NaIRGenPass._str_materialize(val: ir.Value) -> ir.Value {
+    if self._nogc_headerless() {
+        return self._str_norm(val);
+    }
+    if self.str_materialize_fn is None {
+        self._emit_str_desc_helpers();
+    }
+    result = self.builder.call(self.str_materialize_fn, [val], name="s.materialized");
+    self._release_owned_args([val], op="str_materialize");
+    return self._mark_owned(result);
 }
 
 impl NaIRGenPass._str_norm_optional(val: ir.Value | None) -> (ir.Value | None) {
@@ -2249,11 +2291,14 @@ impl NaIRGenPass._emit_scope_cleanup(
             continue;
         }
 
-        if self._nogc_headerless()
-            and self._str_desc_ty is not None
+        if self._str_desc_ty is not None
             and isinstance(alloca.type, ir.PointerType)
             and alloca.pointee_type == self._str_desc_ty {
             if var_name == skip_var {
+                self.builder.store(ir.Constant(alloca.pointee_type, None), alloca);
+            } elif not self._nogc_headerless() {
+                val = self.builder.load(alloca, name=f"cleanup.{var_name}");
+                self._emit_rc_release_typed(val, op="scope_exit", loc=loc);
                 self.builder.store(ir.Constant(alloca.pointee_type, None), alloca);
             } elif var_name in self.nogc_owned_str_vars {
                 val = self.builder.load(alloca, name=f"cleanup.{var_name}");
@@ -2329,11 +2374,14 @@ impl NaIRGenPass._emit_loop_iter_cleanup(body_locals: list, loc: str = "") -> No
         if alloca is None {
             continue;
         }
-        if self._nogc_headerless()
-            and self._str_desc_ty is not None
+        if self._str_desc_ty is not None
             and isinstance(alloca.type, ir.PointerType)
             and alloca.pointee_type == self._str_desc_ty {
-            if var_name in self.nogc_owned_str_vars {
+            if not self._nogc_headerless() {
+                val = self.builder.load(alloca, name=f"iter.cleanup.{var_name}");
+                self._emit_rc_release_typed(val, op="iter_end", loc=loc);
+                self.builder.store(ir.Constant(alloca.pointee_type, None), alloca);
+            } elif var_name in self.nogc_owned_str_vars {
                 val = self.builder.load(alloca, name=f"iter.cleanup.{var_name}");
                 self._nogc_str_free_owned(val);
                 self.builder.store(ir.Constant(alloca.pointee_type, None), alloca);

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/refcount.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/refcount.impl.jac
@@ -1227,7 +1227,9 @@ impl NaIRGenPass._emit_str_desc_helpers -> None {
     self.str_unwrap_fn = uf;
 
     if not _hl {
-        mf = self._define_function("__jac_str_materialize", ir.FunctionType(i8p, [desc]));
+        mf = self._define_function(
+            "__jac_str_materialize", ir.FunctionType(i8p, [desc])
+        );
         mf.linkage = "private";
         mb = ir.IRBuilder(mf.append_basic_block("entry"));
         null_bb = mf.append_basic_block("null");
@@ -1237,7 +1239,9 @@ impl NaIRGenPass._emit_str_desc_helpers -> None {
         owner = mb.extract_value(mf.args[0], 0, name="owner");
         data = mb.extract_value(mf.args[0], _di, name="data");
         size = mb.extract_value(mf.args[0], _li, name="size");
-        mb.cbranch(mb.icmp_unsigned("==", data, ir.Constant(i8p, None)), null_bb, probe_bb);
+        mb.cbranch(
+            mb.icmp_unsigned("==", data, ir.Constant(i8p, None)), null_bb, probe_bb
+        );
         mb.position_at_end(null_bb);
         mb.ret(ir.Constant(i8p, None));
         mb.position_at_end(probe_bb);

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/region.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/region.impl.jac
@@ -264,7 +264,7 @@ impl NaIRGenPass._emit_struct_drop_fields_fn(type_name: str) -> (ir.Function | N
         for (fname, ftype) in field_types.items()
         if fname not in foreign_fields
             and (
-                isinstance(ftype, ir.PointerType)
+                self._elem_kind(ftype) != "raw"
                 or self._opt_ptr_payload_of(ftype) is not None
             )
             and field_indices.get(fname, -1) >= 0
@@ -325,13 +325,7 @@ impl NaIRGenPass._emit_struct_drop_fields_fn(type_name: str) -> (ir.Function | N
             continue;
         }
         fv = b.load(fp, name=f"dropf.{fname}");
-        _fv_ty = fv.type;
-        if isinstance(_fv_ty, ir.PointerType)
-            and isinstance(_fv_ty.pointee, ir.FunctionType) {
-            continue;
-        }
-        fv_i8 = b.bitcast(fv, i8p, name=f"dropf.{fname}.i8");
-        b.call(self.rc_release_simple_fn, [fv_i8]);
+        self._emit_elem_release(b, ftype, fv);
     }
     b.branch(done_bb);
 

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -206,6 +206,7 @@ impl NaIRGenPass._codegen_destroy_target(target: uni.Expr, nd: uni.DeleteStmt) -
             _fa_argtys = _forget_all_fn.function_type.args;
             self.builder.call(_forget_all_fn, [self._coerce_type(_hs, _fa_argtys[0])]);
         }
+        self._release_owned_args([_val], op="del_stmt");
         return;
     }
     if self._struct_name_of(target) is None
@@ -220,6 +221,7 @@ impl NaIRGenPass._codegen_destroy_target(target: uni.Expr, nd: uni.DeleteStmt) -
         _f_argtys = _forget_fn.function_type.args;
         self.builder.call(_forget_fn, [self._coerce_type(_h, _f_argtys[0])]);
     }
+    self._release_owned_args([_val], op="del_stmt");
 }
 
 impl NaIRGenPass._del_target_holds_graph(target: uni.Expr) -> bool {

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -126,19 +126,8 @@ impl NaIRGenPass._codegen_stmt(nd: uni.UniNode) -> None {
         self._codegen_ctrl(nd);
     } elif isinstance(nd, uni.ExprStmt) {
         _estmt_val = self._codegen_expr(nd.expr);
-        if (
-            _estmt_val is not None
-            and isinstance(_estmt_val.type, ir.PointerType)
-            and self._is_owned(_estmt_val)
-        ) {
-            self._emit_rc_release_simple(_estmt_val, op="discarded_call", loc="");
-        } elif (
-            _estmt_val is not None
-            and self?.jacval_type
-            and _estmt_val.type == self.jacval_type
-            and self._is_owned(_estmt_val)
-        ) {
-            self._emit_elem_release(self.builder, self.jacval_type, _estmt_val);
+        if _estmt_val is not None {
+            self._release_owned_args([_estmt_val], op="discarded_call");
         }
     } elif isinstance(nd, uni.TryStmt) {
         self._codegen_try(nd);
@@ -151,7 +140,7 @@ impl NaIRGenPass._codegen_stmt(nd: uni.UniNode) -> None {
     } elif isinstance(nd, uni.AssertStmt) {
         cond = self._codegen_required(nd.condition);
         if cond is not None {
-            cond_bool = self._to_bool(cond);
+            cond_bool = self._consume_bool(cond);
 
             is_false = self.builder.not_(cond_bool, name="assert.fail");
 
@@ -441,7 +430,7 @@ impl NaIRGenPass._codegen_return(nd: uni.ReturnStmt) -> None {
 
             if (
                 skip_var is None
-                and isinstance(val.type, ir.PointerType)
+                and self._elem_kind(val.type) in ("rc_ptr", "str")
                 and not self._is_owned(val)
             ) {
                 self._emit_rc_retain(
@@ -545,7 +534,7 @@ impl NaIRGenPass._codegen_if(nd: uni.IfStmt) -> None {
         return;
     }
 
-    cond = self._to_bool(cond);
+    cond = self._consume_bool(cond);
     func = self.builder.function;
     then_bb = func.append_basic_block(name="if.then");
     else_bb = func.append_basic_block(name="if.else");
@@ -652,7 +641,7 @@ impl NaIRGenPass._codegen_while(nd: uni.WhileStmt) -> None {
     self.builder.position_at_end(cond_bb);
     cond = self._codegen_required(nd.condition);
     if cond is not None {
-        cond = self._to_bool(cond);
+        cond = self._consume_bool(cond);
         self.builder.cbranch(cond, body_bb, end_bb);
     } else {
         self.builder.branch(end_bb);
@@ -788,7 +777,7 @@ impl NaIRGenPass._codegen_iter_for(nd: uni.IterForStmt) -> None {
     self.builder.position_at_end(cond_bb);
     cond = self._codegen_required(nd.condition);
     if cond is not None {
-        cond = self._to_bool(cond);
+        cond = self._consume_bool(cond);
         self.builder.cbranch(cond, body_bb, end_bb);
     } else {
         self.builder.branch(end_bb);
@@ -863,7 +852,7 @@ impl NaIRGenPass._codegen_match(nd: uni.MatchStmt) -> None {
             self._bind_match_pattern(`case.pattern, subj_val, subj_ty);
             gval = self._codegen_expr(`case.guard);
             if gval is not None {
-                self.builder.cbranch(self._to_bool(gval), body_bb, next_bb);
+                self.builder.cbranch(self._consume_bool(gval), body_bb, next_bb);
             } else {
                 self.builder.branch(next_bb);
             }
@@ -1394,7 +1383,7 @@ impl NaIRGenPass._match_value_eq(
     if cmp is None {
         return None;
     }
-    return self._to_bool(cmp);
+    return self._consume_bool(cmp);
 }
 
 impl NaIRGenPass._bind_match_pattern(
@@ -2400,7 +2389,13 @@ impl NaIRGenPass._codegen_assignment(nd: uni.Assignment) -> None {
 
             _is_raw_int_ptr = getattr(coerced, 'opname', '') == 'inttoptr';
             self._register_region_handle_var(nd, var_name);
-            if isinstance(alloca.pointee_type, ir.PointerType)
+            if (
+                isinstance(alloca.pointee_type, ir.PointerType)
+                or (
+                    self._elem_kind(alloca.pointee_type) == "str"
+                    and not self._nogc_headerless()
+                )
+            )
                 and not is_inplace_set_op {
                 if var_name in self.region_handle_vars {
                     _old_hdl = self.builder.load(alloca, name=f"{var_name}.old");
@@ -2420,7 +2415,7 @@ impl NaIRGenPass._codegen_assignment(nd: uni.Assignment) -> None {
                         or self._nogc_borrow_local_assign(nd) {
                         self.nogc_no_free_vars.add(var_name);
                     }
-                    if not self._is_owned(value)
+                    if not self._is_owned(coerced)
                         and not self._can_native_move_lower(nd) {
                         self._emit_rc_retain(
                             coerced,
@@ -2429,7 +2424,7 @@ impl NaIRGenPass._codegen_assignment(nd: uni.Assignment) -> None {
                                 if nd.loc
                                 else 0}"
                         );
-                    } elif self._is_owned(value) {
+                    } elif self._is_owned(coerced) {
                         self.rc_ops_elided += 1;
                     }
                     if not (

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -391,7 +391,8 @@ impl NaIRGenPass._codegen_return(nd: uni.ReturnStmt) -> None {
             if isinstance(nd.expr, uni.Name)
                 and nd.expr.sym_name in self.local_vars
                 and nd.expr.sym_name not in self.param_vars
-                and nd.expr.sym_name not in self.closure_cell_handles {
+                and nd.expr.sym_name not in self.closure_cell_handles
+                and not self._is_owned(val) {
                 skip_var = nd.expr.sym_name;
             } elif isinstance(nd.expr, uni.TupleVal) {
                 tup_elems = nd.expr.values or [];

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/types.impl.jac
@@ -1530,6 +1530,12 @@ impl NaIRGenPass._abi_sizeof(t: ir.Type) -> int {
     );
 }
 
+impl NaIRGenPass._consume_bool(val: ir.Value) -> ir.Value {
+    result = self._to_bool(val);
+    self._release_owned_args([val], op="condition");
+    return result;
+}
+
 impl NaIRGenPass._to_bool(val: ir.Value) -> ir.Value {
     if self._str_desc_ty is not None and val.type == self._str_desc_ty {
         return self.builder.icmp_signed(
@@ -2093,10 +2099,7 @@ impl NaIRGenPass._coerce_type_inner(val: ir.Value, target_type: ir.Type) -> ir.V
             return self.builder.call(self.str_wrap_raw_fn, [val], name="s.desc");
         }
         if val.type == _sd and target_type == _i8p_sd {
-            if self.str_unwrap_fn is None {
-                self._emit_str_desc_helpers();
-            }
-            return self.builder.call(self.str_unwrap_fn, [val], name="s.raw");
+            return self._str_materialize(val);
         }
         if target_type == _sd and self?.jacval_type and val.type == self.jacval_type {
             if self.str_unwrap_fn is None {
@@ -2123,11 +2126,8 @@ impl NaIRGenPass._coerce_type_inner(val: ir.Value, target_type: ir.Type) -> ir.V
         if val.type == _sd
             and isinstance(target_type, ir.IntType)
             and target_type.width == 64 {
-            if self.str_unwrap_fn is None {
-                self._emit_str_desc_helpers();
-            }
             return self.builder.ptrtoint(
-                self.builder.call(self.str_unwrap_fn, [val], name="s.raw"),
+                self._str_materialize(val),
                 target_type,
                 name="s.box"
             );

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.impl/types.impl.jac
@@ -2127,9 +2127,7 @@ impl NaIRGenPass._coerce_type_inner(val: ir.Value, target_type: ir.Type) -> ir.V
             and isinstance(target_type, ir.IntType)
             and target_type.width == 64 {
             return self.builder.ptrtoint(
-                self._str_materialize(val),
-                target_type,
-                name="s.box"
+                self._str_materialize(val), target_type, name="s.box"
             );
         }
     }

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.jac
@@ -325,6 +325,7 @@ walker NaIRGenPass(Transform) {
         str_wrap_raw_fn: (ir.Function | None) = None,
         str_import_fn: (ir.Function | None) = None,
         str_unwrap_fn: (ir.Function | None) = None,
+        str_materialize_fn: (ir.Function | None) = None,
         _str_desc_ty: (ir.IdentifiedStructType | None) = None,
         rc_roots_buf_gv: object = None,
         rc_roots_cap_gv: object = None,
@@ -1725,6 +1726,7 @@ walker NaIRGenPass(Transform) {
     def _str_desc_type -> ir.IdentifiedStructType;
     def _str_desc_kind -> str;
     def _str_norm(val: ir.Value) -> ir.Value;
+    def _str_materialize(val: ir.Value) -> ir.Value;
     def _str_norm_optional(val: ir.Value | None) -> (ir.Value | None);
     def _str_arg(val: ir.Value | None) -> (ir.Value | None);
     def _emit_str_desc_helpers -> None;
@@ -2090,6 +2092,10 @@ walker NaIRGenPass(Transform) {
     def _elem_spec_of(expr: (uni.UniNode | None)) -> (str | None);
     def _get_name(nd: (uni.UniNode | None)) -> (str | None);
     def _to_bool(val: ir.Value) -> ir.Value;
+    def _consume_bool(val: ir.Value) -> ir.Value;
+    def _finish_borrowed_read(
+        owner: ir.Value, value: (ir.Value | None)
+    ) -> (ir.Value | None);
     def _jacval_truthy(jv: ir.Value) -> ir.Value;
     def _jacval_is_none(jv: ir.Value, negate: bool) -> ir.Value;
     def _entry_alloca(var_type: ir.Type, name: str) -> ir.Value;

--- a/jac/jaclang/compiler/backends/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/backends/native/na_ir_gen_pass.jac
@@ -2096,6 +2096,7 @@ walker NaIRGenPass(Transform) {
     def _finish_borrowed_read(
         owner: ir.Value, value: (ir.Value | None)
     ) -> (ir.Value | None);
+
     def _jacval_truthy(jv: ir.Value) -> ir.Value;
     def _jacval_is_none(jv: ir.Value, negate: bool) -> ir.Value;
     def _entry_alloca(var_type: ir.Type, name: str) -> ir.Value;

--- a/jac/jaclang/compiler/driver/compiler.jac
+++ b/jac/jaclang/compiler/driver/compiler.jac
@@ -108,6 +108,7 @@ obj JacCompiler {
 
     has selfhost: SelfHostCache { getter; }
 
+    def release_compile_state(target_program: JacProgram) -> None;
     def stub_catalog -> StubCatalog | None;
     def ensure_stub_catalog -> StubCatalog | None;
     def note_stub_tree_served(path: str, program: JacProgram) -> None;

--- a/jac/jaclang/compiler/driver/impl/compiler.impl.jac
+++ b/jac/jaclang/compiler/driver/impl/compiler.impl.jac
@@ -2090,3 +2090,23 @@ impl JacCompiler._get_client_artifact(
     }
     return built;
 }
+
+impl JacCompiler.release_compile_state(target_program: JacProgram) -> None {
+    if os.environ.get("JAC_NO_UNIT_EVICT") {
+        return;
+    }
+    owner = target_program.context_root or target_program;
+    internal = self._selfhost.peek_program() if self._selfhost is not None else None;
+    if self._reentrant_depth
+        or owner.scratch.compile_depth
+        or (internal is not None and internal.scratch.compile_depth) {
+        raise RuntimeError("Cannot release compiler state during compilation");
+    }
+    owner.release_compile_closure(collect=False);
+    if internal is not None and internal is not owner {
+        internal.release_compile_closure(collect=False);
+    }
+
+    import gc;
+    gc.collect();
+}

--- a/jac/jaclang/compiler/native_compiler.jac
+++ b/jac/jaclang/compiler/native_compiler.jac
@@ -81,6 +81,8 @@ class NativeCompiler {
         L = self.lib;
         L.jac_str_new.argtypes = [c_char_p, c_int64];
         L.jac_str_new.restype = c_void_p;
+        L.jac_release.argtypes = [c_void_p];
+        L.jac_release.restype = None;
         for name in ("jc_run", "jc_annex") {
             fn = getattr(L, name);
             fn.argtypes = [c_void_p, c_void_p, c_int64, c_void_p, c_void_p, c_int64];
@@ -395,15 +397,21 @@ class NativeCompiler {
         ab = a.encode();
         bb = b.encode();
         pa = self.lib.jac_str_new(ab, len(ab));
-        pb = self.lib.jac_str_new(bb, len(bb));
-        return fn(
-            c_void_p(pa),
-            c_void_p(pa),
-            c_int64(len(ab)),
-            c_void_p(pb),
-            c_void_p(pb),
-            c_int64(len(bb))
-        );
+        pb = None;
+        try {
+            pb = self.lib.jac_str_new(bb, len(bb));
+            return fn(
+                c_void_p(pa),
+                c_void_p(pa),
+                c_int64(len(ab)),
+                c_void_p(pb),
+                c_void_p(pb),
+                c_int64(len(bb))
+            );
+        } finally {
+            self.lib.jac_release(pb);
+            self.lib.jac_release(pa);
+        }
     }
 
     def annex(self: NativeCompiler, annex_src: str, annex_path: str) -> int {

--- a/jac/tests/client/test_client_build_lifetime.jac
+++ b/jac/tests/client/test_client_build_lifetime.jac
@@ -1,0 +1,39 @@
+"""Standalone client builds finish compilation before starting the bundler."""
+
+import tempfile;
+import from pathlib { Path }
+import from unittest.mock { patch }
+import from jaclang.client.targets.web_target { WebTarget }
+import from jaclang.client.vite_bundler { ViteBundler }
+import from jaclang.runtime.runtime { JacRuntime as Jac }
+
+test "standalone client build releases application trees before bundling" {
+    with tempfile.TemporaryDirectory() as tmp {
+        root = Path(tmp).resolve();
+        entry = root / "main.jac";
+        entry.write_text('def:pub app -> any { return <div>lifetime</div>; }');
+        (root / "jac.toml").write_text(
+            '[project]\nname = "lifetime"\nkind = "web-app"\n'
+        );
+        (root / "package.json").write_text('{"name":"lifetime","version":"0.0.0"}');
+        reached: list[bool] = [];
+
+        def bundle(self: ViteBundler, *args: any, **kwargs: any) {
+            program = Jac.get_program();
+            assert not program.source_store.units , (
+                "application source trees remain live while the bundler runs"
+            );
+            assert not program.contexts , (
+                "application compilation contexts remain live while the bundler runs"
+            );
+            reached.append(True);
+            self.output_dir.mkdir(parents=True, exist_ok=True);
+            (self.output_dir / "client.js").write_text('export function app() {}');
+        }
+
+        with patch.object(ViteBundler, "build", bundle) {
+            WebTarget().build(entry, root);
+        }
+        assert reached == [True];
+    }
+}

--- a/jac/tests/client/test_client_build_lifetime.jac
+++ b/jac/tests/client/test_client_build_lifetime.jac
@@ -1,6 +1,7 @@
 """Standalone client builds finish compilation before starting the bundler."""
 
 import tempfile;
+import weakref;
 import from pathlib { Path }
 import from unittest.mock { patch }
 import from jaclang.client.targets.web_target { WebTarget }
@@ -10,14 +11,26 @@ import from jaclang.runtime.runtime { JacRuntime as Jac }
 test "standalone client build releases application trees before bundling" {
     with tempfile.TemporaryDirectory() as tmp {
         project_dir = Path(tmp).resolve();
-        entry = project_dir / "main.jac";
-        entry.write_text('def:pub app -> any { return <div>lifetime</div>; }');
+        entry_path = project_dir / "main.jac";
+        entry_path.write_text('def:pub launch -> any { return <div>lifetime</div>; }');
         (project_dir / "jac.toml").write_text(
             '[project]\nname = "lifetime"\nkind = "web-app"\n'
         );
-        (project_dir / "package.json").write_text('{"name":"lifetime","version":"0.0.0"}');
+        (project_dir / "package.json").write_text(
+            '{"name":"lifetime","version":"0.0.0"}'
+        );
+        Jac.set_full_target_path(str(entry_path));
         reached: list[bool] = [];
-
+        trees: list = [];
+        program = Jac.get_program();
+        original_compile = program.compile;
+        def compile(*args: any, **kwargs: any) -> any {
+            mod = original_compile(*args, **kwargs);
+            if mod.loc.mod_path == str(entry_path) {
+                trees.append(weakref.ref(mod));
+            }
+            return mod;
+        }
         def bundle(self: ViteBundler, *args: any, **kwargs: any) {
             program = Jac.get_program();
             assert not program.source_store.units , (
@@ -26,14 +39,76 @@ test "standalone client build releases application trees before bundling" {
             assert not program.contexts , (
                 "application compilation contexts remain live while the bundler runs"
             );
+            assert trees and all(ref() is None for ref in trees) , (
+                "the bundler starts while an application syntax tree is still reachable"
+            );
             reached.append(True);
             self.output_dir.mkdir(parents=True, exist_ok=True);
-            (self.output_dir / "client.js").write_text('export function app() {}');
+            (self.output_dir / "client.test.js").write_text(
+                'export function launch() {}'
+            );
         }
-
-        with patch.object(ViteBundler, "build", bundle) {
-            WebTarget().build(entry, project_dir);
+        with patch.object(program, "compile", compile), patch.object(
+            ViteBundler, "build", bundle
+        ) {
+            WebTarget().build(entry_path, project_dir);
         }
         assert reached == [True];
+        index = next(project_dir.rglob("index.html")).read_text();
+        assert '"function": "launch"' in index;
+    }
+}
+
+test "prepared native assets and exports survive the bundler clearing its output" {
+    import shutil;
+    import from types { ModuleType }
+    import from jaclang.client.compiler { ViteCompiler }
+    import from jaclang.client.vite_client_bundle { make_client_bundle_builder }
+    with tempfile.TemporaryDirectory() as tmp {
+        project_dir = Path(tmp).resolve();
+        entry_path = project_dir / "main.jac";
+        entry_path.write_text("# prepared build\n");
+        (project_dir / "jac.toml").write_text('[project]\nname = "prepared"\n');
+        Jac.set_full_target_path(str(entry_path));
+        loaded = ModuleType("prepared");
+        loaded.__file__ = str(entry_path);
+        builder = make_client_bundle_builder(project_dir);
+        assets = {
+            "native.wasm": b"\x00asm\x01\x00\x00\x00",
+            "native.wasm.imports.json": b'{"imports": {}}'
+        };
+        def bundle(self: ViteBundler, *args: any, **kwargs: any) {
+            if self.output_dir.exists() {
+                shutil.rmtree(self.output_dir);
+            }
+            self.output_dir.mkdir(parents=True);
+            (self.output_dir / "client.test.js").write_text(
+                "export const ready = true;"
+            );
+        }
+        with patch.object(
+            ViteCompiler, "compile", return_value=(["launch"], ["ready"])
+        ), patch.object(ViteCompiler, "_wasm_targets", return_value=[entry_path]), patch.object(
+            ViteCompiler, "_compile_wasm_module", return_value=assets
+        ), patch(
+            "jaclang.compiler.boundary_audit.boundary_audit",
+            return_value={"prepared": True}
+        ) {
+            inputs = builder.prepare(loaded);
+        }
+        with patch.object(ViteBundler, "build", bundle) {
+            result = builder.bundle(inputs);
+        }
+        assert result.module_name == "prepared";
+        assert result.client_functions == ["launch"];
+        assert result.client_globals == ["ready"];
+        assert result.code == "export const ready = true;";
+        output = builder._get_compiler().vite_bundler.output_dir;
+        for (name, content) in assets.items() {
+            assert (output / name).read_bytes() == content;
+        }
+        import json;
+        assert json.loads((output / "boundaries.json").read_text())
+            == {"prepared": True};
     }
 }

--- a/jac/tests/client/test_client_build_lifetime.jac
+++ b/jac/tests/client/test_client_build_lifetime.jac
@@ -9,13 +9,13 @@ import from jaclang.runtime.runtime { JacRuntime as Jac }
 
 test "standalone client build releases application trees before bundling" {
     with tempfile.TemporaryDirectory() as tmp {
-        root = Path(tmp).resolve();
-        entry = root / "main.jac";
+        project_dir = Path(tmp).resolve();
+        entry = project_dir / "main.jac";
         entry.write_text('def:pub app -> any { return <div>lifetime</div>; }');
-        (root / "jac.toml").write_text(
+        (project_dir / "jac.toml").write_text(
             '[project]\nname = "lifetime"\nkind = "web-app"\n'
         );
-        (root / "package.json").write_text('{"name":"lifetime","version":"0.0.0"}');
+        (project_dir / "package.json").write_text('{"name":"lifetime","version":"0.0.0"}');
         reached: list[bool] = [];
 
         def bundle(self: ViteBundler, *args: any, **kwargs: any) {
@@ -32,7 +32,7 @@ test "standalone client build releases application trees before bundling" {
         }
 
         with patch.object(ViteBundler, "build", bundle) {
-            WebTarget().build(entry, root);
+            WebTarget().build(entry, project_dir);
         }
         assert reached == [True];
     }

--- a/jac/tests/compiler/backends/native/fixtures/rc_string_lifetime.jac
+++ b/jac/tests/compiler/backends/native/fixtures/rc_string_lifetime.jac
@@ -2,6 +2,18 @@
 
 obj Text {
     has value: str;
+
+    def length(other: str) -> int {
+        return len(other);
+    }
+}
+
+obj TextList {
+    has values: list[str] = [];
+
+    def init(values: list[str]) {
+        self.values = values;
+    }
 }
 
 def local(value: str) -> int {
@@ -29,4 +41,78 @@ def identity(value: str) -> str {
 
 def call(value: str) -> int {
     return len(identity(value));
+}
+
+def constructor_call(value: str) -> int {
+    text = Text(value=identity(value));
+    return len(text.value);
+}
+
+def constructor_list(value: str) -> int {
+    texts = TextList(values=[value]);
+    return len(texts.values[0]);
+}
+
+def sliced(value: str) -> int {
+    tail = value[1:];
+    return len(tail) + 1;
+}
+
+def rebound(value: str) -> int {
+    value = value[1:];
+    return len(value) + 1;
+}
+
+def temporary_index(value: str) -> int {
+    return len([value][0]);
+}
+
+def temporary_condition(value: str) -> int {
+    if [value] {
+        return len(value);
+    }
+    return 0;
+}
+
+def discarded(value: str) -> int {
+    identity(value);
+    return len(value);
+}
+
+def compared(value: str) -> int {
+    return len(value) if identity(value) == value else 0;
+}
+
+def class_call(value: str) -> int {
+    return Text.length(Text(value=value), identity(value));
+}
+
+def view_field(value: str) -> int {
+    text = Text(value=value[1:-1]);
+    return len(text.value) + 2;
+}
+
+def borrowed_view_field(value: str) -> int {
+    view = value[1:-1];
+    text = Text(value=view);
+    return len(text.value) + 2;
+}
+
+def compared_view(value: str) -> int {
+    return len(value) if value[:3] == "bor" else 0;
+}
+
+def mixed_condition(value: str) -> int {
+    if [value] or False {
+        return len(value);
+    }
+    return 0;
+}
+
+def conditional_owned(value: str) -> int {
+    return len(identity(value) if len(value) > 0 else value);
+}
+
+def conditional_borrowed(value: str) -> int {
+    return len(identity(value) if len(value) == 0 else value);
 }

--- a/jac/tests/compiler/backends/native/fixtures/rc_string_lifetime.jac
+++ b/jac/tests/compiler/backends/native/fixtures/rc_string_lifetime.jac
@@ -1,0 +1,32 @@
+"""A caller-owned string must outlive borrows without accumulating references."""
+
+obj Text {
+    has value: str;
+}
+
+def local(value: str) -> int {
+    copy = value;
+    return len(copy);
+}
+
+def field(value: str) -> int {
+    text = Text(value=value);
+    return len(text.value);
+}
+
+def loop(value: str) -> int {
+    count = 0;
+    for i in range(3) {
+        copy = value;
+        count += len(copy);
+    }
+    return count;
+}
+
+def identity(value: str) -> str {
+    return value;
+}
+
+def call(value: str) -> int {
+    return len(identity(value));
+}

--- a/jac/tests/compiler/backends/native/fixtures/rc_string_lifetime.jac
+++ b/jac/tests/compiler/backends/native/fixtures/rc_string_lifetime.jac
@@ -6,6 +6,11 @@ obj Text {
     def length(other: str) -> int {
         return len(other);
     }
+
+    def tail -> str {
+        view = self.value[1:];
+        return view;
+    }
 }
 
 obj TextList {
@@ -115,4 +120,8 @@ def conditional_owned(value: str) -> int {
 
 def conditional_borrowed(value: str) -> int {
     return len(identity(value) if len(value) == 0 else value);
+}
+
+def returned_view(value: str) -> int {
+    return len(Text(value=value).tail()) + 1;
 }

--- a/jac/tests/compiler/backends/native/fixtures/rc_string_lifetime.jac
+++ b/jac/tests/compiler/backends/native/fixtures/rc_string_lifetime.jac
@@ -125,3 +125,32 @@ def conditional_borrowed(value: str) -> int {
 def returned_view(value: str) -> int {
     return len(Text(value=value).tail()) + 1;
 }
+
+def dict_read(value: str) -> int {
+    values = {value: len(value)};
+    return values[value];
+}
+
+def dict_write(value: str) -> int {
+    values: dict[str, str] = {};
+    values[value] = value;
+    return len(values) * len(value);
+}
+
+def dict_missing(value: str) -> int {
+    values: dict[str, int] = {};
+    try {
+        return values[value];
+    } except KeyError {
+        return len(value);
+    }
+}
+
+node Item {
+    has value: str;
+}
+
+def destroyed_temporary(value: str) -> int {
+    del [Item(value=value)];
+    return len(value);
+}

--- a/jac/tests/compiler/backends/native/fixtures/rc_string_lifetime.jac
+++ b/jac/tests/compiler/backends/native/fixtures/rc_string_lifetime.jac
@@ -146,11 +146,20 @@ def dict_missing(value: str) -> int {
     }
 }
 
-node Item {
-    has value: str;
+node Item {}
+
+def descendants(item: Item) -> list[Item] {
+    return [item-->];
 }
 
-def destroyed_temporary(value: str) -> int {
-    del [Item(value=value)];
-    return len(value);
+def empty_items -> list[Item] {
+    return [];
+}
+
+def identity_items(items: list[Item]) -> list[Item] {
+    return items;
+}
+
+def destroy_items(items: list[Item]) {
+    del identity_items(items);
 }

--- a/jac/tests/compiler/backends/native/test_native_string_lifetime.jac
+++ b/jac/tests/compiler/backends/native/test_native_string_lifetime.jac
@@ -1,0 +1,46 @@
+"""Count live references, independently of RSS and allocator caching."""
+
+import ctypes;
+import os;
+import from tests.support { TESTS_DIR, native_force_opts }
+import from jaclang.compiler.driver.program { JacProgram }
+import from jaclang.compiler.frontend.codeinfo { HDR_RC_OFF }
+import from jaclang.compiler.native_compiler { ensure_loaded }
+
+test "native string roots balance across locals fields loops and calls" {
+    kernel = ensure_loaded();
+    if kernel is None {
+        return;
+    }
+    program = JacProgram();
+    options = native_force_opts();
+    options.memory_profile = "managed";
+    options.no_ir_cache = True;
+    mod = program.compile(
+        os.path.join(TESTS_DIR, "compiler", "backends", "native", "fixtures",
+            "rc_string_lifetime.jac"), options=options
+    );
+    assert not program.errors_had , [str(e) for e in program.errors_had];
+    engine = mod.gen.native_engine;
+    assert engine is not None;
+    make = kernel.lib.jac_str_new;
+    release = kernel.lib.jac_release;
+    release.argtypes = [ctypes.c_void_p];
+    release.restype = None;
+    value = b"borrowed";
+    for (name, copies) in [("local", 1), ("field", 1), ("loop", 3), ("call", 1)] {
+        buffer_ptr = make(value, len(value));
+        address = engine.get_function_address(name);
+        assert address , f"missing fixture function {name}";
+        fn = ctypes.CFUNCTYPE(
+            ctypes.c_int64, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int64
+        )(address);
+        try {
+            assert fn(buffer_ptr, buffer_ptr, len(value)) == copies * len(value);
+            refs = ctypes.c_int64.from_address(buffer_ptr + HDR_RC_OFF).value;
+            assert refs == 1 , f"{name} left {refs} references to the input string";
+        } finally {
+            release(buffer_ptr);
+        }
+    }
+}

--- a/jac/tests/compiler/backends/native/test_native_string_lifetime.jac
+++ b/jac/tests/compiler/backends/native/test_native_string_lifetime.jac
@@ -2,13 +2,13 @@
 
 import ctypes;
 import os;
-import from tests.support { TESTS_DIR }
+import from tests.support { TESTS_DIR, get_func }
 import from jaclang.compiler.driver.program { JacProgram }
 import from jaclang.compiler.driver.compile_options { CompileOptions }
 import from jaclang.compiler.frontend.codeinfo { HDR_RC_OFF }
 import from jaclang.compiler.native_compiler { ensure_loaded }
 
-test "native string roots balance across locals fields loops and calls" {
+test "native string and temporary roots balance across storage and calls" {
     kernel = ensure_loaded();
     if kernel is None {
         return;
@@ -63,16 +63,16 @@ test "native string roots balance across locals fields loops and calls" {
         ("returned_view", 1),
         ("dict_read", 1),
         ("dict_write", 1),
-        ("dict_missing", 1),
-        ("destroyed_temporary", 1)
+        ("dict_missing", 1)
     ] {
         buffer_ptr = make(value, len(value));
-        address = engine.get_function_address(name);
-        assert address , f"missing fixture function {name}";
-        fn = ctypes.CFUNCTYPE(
-            ctypes.c_int64, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int64
-        )(
-            address
+        fn = get_func(
+            engine,
+            name,
+            ctypes.c_int64,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_int64
         );
         try {
             assert fn(buffer_ptr, buffer_ptr, len(value)) == copies * len(value);
@@ -84,4 +84,18 @@ test "native string roots balance across locals fields loops and calls" {
         }
     }
     assert all(count == 1 for count in references.values()) , references;
+
+    make_items = get_func(engine, "empty_items", ctypes.c_void_p);
+    destroy_items = get_func(engine, "destroy_items", None, ctypes.c_void_p);
+    items_root = make_items();
+    assert items_root;
+    try {
+        assert ctypes.c_int64.from_address(items_root + HDR_RC_OFF).value == 1;
+        destroy_items(items_root);
+        assert ctypes.c_int64.from_address(items_root + HDR_RC_OFF).value == 1 , (
+            "graph deletion retained its temporary target list"
+        );
+    } finally {
+        release(items_root);
+    }
 }

--- a/jac/tests/compiler/backends/native/test_native_string_lifetime.jac
+++ b/jac/tests/compiler/backends/native/test_native_string_lifetime.jac
@@ -2,8 +2,9 @@
 
 import ctypes;
 import os;
-import from tests.support { TESTS_DIR, native_force_opts }
+import from tests.support { TESTS_DIR }
 import from jaclang.compiler.driver.program { JacProgram }
+import from jaclang.compiler.driver.compile_options { CompileOptions }
 import from jaclang.compiler.frontend.codeinfo { HDR_RC_OFF }
 import from jaclang.compiler.native_compiler { ensure_loaded }
 
@@ -13,12 +14,22 @@ test "native string roots balance across locals fields loops and calls" {
         return;
     }
     program = JacProgram();
-    options = native_force_opts();
-    options.memory_profile = "managed";
-    options.no_ir_cache = True;
+    options = CompileOptions(
+        force_codespace="native",
+        force_target_program=True,
+        memory_profile="managed",
+        no_ir_cache=True
+    );
     mod = program.compile(
-        os.path.join(TESTS_DIR, "compiler", "backends", "native", "fixtures",
-            "rc_string_lifetime.jac"), options=options
+        os.path.join(
+            TESTS_DIR,
+            "compiler",
+            "backends",
+            "native",
+            "fixtures",
+            "rc_string_lifetime.jac"
+        ),
+        options=options
     );
     assert not program.errors_had , [str(e) for e in program.errors_had];
     engine = mod.gen.native_engine;
@@ -28,19 +39,44 @@ test "native string roots balance across locals fields loops and calls" {
     release.argtypes = [ctypes.c_void_p];
     release.restype = None;
     value = b"borrowed";
-    for (name, copies) in [("local", 1), ("field", 1), ("loop", 3), ("call", 1)] {
+    references: dict[str, int] = {};
+    for (name, copies) in [
+        ("local", 1),
+        ("field", 1),
+        ("loop", 3),
+        ("call", 1),
+        ("constructor_call", 1),
+        ("constructor_list", 1),
+        ("sliced", 1),
+        ("rebound", 1),
+        ("temporary_index", 1),
+        ("temporary_condition", 1),
+        ("discarded", 1),
+        ("compared", 1),
+        ("class_call", 1),
+        ("view_field", 1),
+        ("borrowed_view_field", 1),
+        ("compared_view", 1),
+        ("mixed_condition", 1),
+        ("conditional_owned", 1),
+        ("conditional_borrowed", 1)
+    ] {
         buffer_ptr = make(value, len(value));
         address = engine.get_function_address(name);
         assert address , f"missing fixture function {name}";
         fn = ctypes.CFUNCTYPE(
             ctypes.c_int64, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int64
-        )(address);
+        )(
+            address
+        );
         try {
             assert fn(buffer_ptr, buffer_ptr, len(value)) == copies * len(value);
-            refs = ctypes.c_int64.from_address(buffer_ptr + HDR_RC_OFF).value;
-            assert refs == 1 , f"{name} left {refs} references to the input string";
+            references[name] = ctypes.c_int64.from_address(
+                buffer_ptr + HDR_RC_OFF
+            ).value;
         } finally {
             release(buffer_ptr);
         }
     }
+    assert all(count == 1 for count in references.values()) , references;
 }

--- a/jac/tests/compiler/backends/native/test_native_string_lifetime.jac
+++ b/jac/tests/compiler/backends/native/test_native_string_lifetime.jac
@@ -60,7 +60,11 @@ test "native string roots balance across locals fields loops and calls" {
         ("mixed_condition", 1),
         ("conditional_owned", 1),
         ("conditional_borrowed", 1),
-        ("returned_view", 1)
+        ("returned_view", 1),
+        ("dict_read", 1),
+        ("dict_write", 1),
+        ("dict_missing", 1),
+        ("destroyed_temporary", 1)
     ] {
         buffer_ptr = make(value, len(value));
         address = engine.get_function_address(name);

--- a/jac/tests/compiler/backends/native/test_native_string_lifetime.jac
+++ b/jac/tests/compiler/backends/native/test_native_string_lifetime.jac
@@ -59,7 +59,8 @@ test "native string roots balance across locals fields loops and calls" {
         ("compared_view", 1),
         ("mixed_condition", 1),
         ("conditional_owned", 1),
-        ("conditional_borrowed", 1)
+        ("conditional_borrowed", 1),
+        ("returned_view", 1)
     ] {
         buffer_ptr = make(value, len(value));
         address = engine.get_function_address(name);

--- a/jac/tests/compiler/test_module_release.jac
+++ b/jac/tests/compiler/test_module_release.jac
@@ -51,6 +51,42 @@ test "a fully compiled module is collectable after release_compile_closure" {
     );
 }
 
+test "a compiler phase boundary collects both application and selfhost trees" {
+    prog = JacProgram();
+    compiler = prog._get_compiler();
+    internal = compiler.selfhost.program;
+    (_, app_ref, _, _) = _probe(prog);
+    (_, internal_ref, _, _) = _probe(internal);
+    compiler.release_compile_state(prog);
+    assert app_ref() is None;
+    assert internal_ref() is None;
+    assert not prog.source_store.units;
+    assert not internal.source_store.units;
+    # Releasing working state must leave the compiler reusable.
+    (_, next_ref, _, _) = _probe(prog);
+    assert next_ref() is not None;
+    compiler.release_compile_state(prog);
+    assert next_ref() is None;
+}
+
+test "a compiler phase boundary rejects release during an active compile" {
+    prog = JacProgram();
+    (_, mod_ref, _, _) = _probe(prog);
+    prog.scratch.compile_depth += 1;
+    try {
+        try {
+            prog._get_compiler().release_compile_state(prog);
+        } except RuntimeError {
+            assert mod_ref() is not None;
+            return;
+        }
+        assert False , "compiler state was released while compilation was active";
+    } finally {
+        prog.scratch.compile_depth -= 1;
+        prog._get_compiler().release_compile_state(prog);
+    }
+}
+
 glob STUB_SRC: str = (
          "import sys;\n"
          "with entry {\n"

--- a/jac/tests/compiler/test_native_kernel.jac
+++ b/jac/tests/compiler/test_native_kernel.jac
@@ -141,7 +141,7 @@ def _rss_kb -> (int | None) {
 test "kernel materialization releases every borrowed input reference" {
     import ctypes;
     import from jaclang.compiler.native_compiler { ensure_loaded }
-    import from jaclang.compiler.backends.native.na_constants { HDR_RC_OFF }
+    import from jaclang.compiler.frontend.codeinfo { HDR_RC_OFF }
     kernel = ensure_loaded();
     if kernel is None {
         return;
@@ -162,8 +162,8 @@ test "kernel materialization releases every borrowed input reference" {
         assert not kernel.take_diags();
         assert not kernel.take_lexdiags();
         kernel.take_comments();
-        for (name, root) in [("source", source_root), ("path", path_root)] {
-            refs = ctypes.c_int64.from_address(root + HDR_RC_OFF).value;
+        for (name, buffer_ptr) in [("source", source_root), ("path", path_root)] {
+            refs = ctypes.c_int64.from_address(buffer_ptr + HDR_RC_OFF).value;
             assert refs == 1 , (
                 f"{name} has {refs} native references after materialization; "
                 "only the caller's reference may survive the parse region"

--- a/jac/tests/compiler/test_native_kernel.jac
+++ b/jac/tests/compiler/test_native_kernel.jac
@@ -156,7 +156,8 @@ test "kernel materialization releases every borrowed input reference" {
     try {
         assert kernel.lib.jc_run(
             source_root, source_root, len(src), path_root, path_root, len(path)
-        ) == 0;
+        )
+            == 0;
         mod = kernel.take_module();
         assert mod is not None;
         assert not kernel.take_diags();

--- a/jac/tests/compiler/test_native_kernel.jac
+++ b/jac/tests/compiler/test_native_kernel.jac
@@ -138,6 +138,43 @@ def _rss_kb -> (int | None) {
     return None;
 }
 
+test "kernel materialization releases every borrowed input reference" {
+    import ctypes;
+    import from jaclang.compiler.native_compiler { ensure_loaded }
+    import from jaclang.compiler.backends.native.na_constants { HDR_RC_OFF }
+    kernel = ensure_loaded();
+    if kernel is None {
+        return;
+    }
+    src = b'def f(x: int) -> int { return x + 1; }';
+    path = b'kernel_ownership.jac';
+    source_root = kernel.lib.jac_str_new(src, len(src));
+    path_root = kernel.lib.jac_str_new(path, len(path));
+    release = kernel.lib.jac_release;
+    release.argtypes = [ctypes.c_void_p];
+    release.restype = None;
+    try {
+        assert kernel.lib.jc_run(
+            source_root, source_root, len(src), path_root, path_root, len(path)
+        ) == 0;
+        mod = kernel.take_module();
+        assert mod is not None;
+        assert not kernel.take_diags();
+        assert not kernel.take_lexdiags();
+        kernel.take_comments();
+        for (name, root) in [("source", source_root), ("path", path_root)] {
+            refs = ctypes.c_int64.from_address(root + HDR_RC_OFF).value;
+            assert refs == 1 , (
+                f"{name} has {refs} native references after materialization; "
+                "only the caller's reference may survive the parse region"
+            );
+        }
+    } finally {
+        release(path_root);
+        release(source_root);
+    }
+}
+
 def _parse_and_drop(src: str, path: str) {
     import from jaclang.compiler.frontend.parser.frontend { parse_woven }
     parse_woven(src, path, None, []);

--- a/release_notes/unreleased/jaclang/9125.bugfix.md
+++ b/release_notes/unreleased/jaclang/9125.bugfix.md
@@ -1,0 +1,2 @@
+- Release compiler syntax trees before bundling standalone client builds while preserving native WASM assets and boundary metadata.
+- Balance native string references and constructor temporaries across compiler calls and scope cleanup.


### PR DESCRIPTION
Client builds retain compiler source/type graphs while Bun/Vite allocates its own working set. Repeated native parses also leak allocations after handing the syntax tree to Python. This change fixes the native ownership defects and releases compilation graphs before standalone client bundling.

Standalone builds prepare JavaScript, export metadata, WASM bytes, and boundary metadata, then release application and self-host compilation graphs through the existing closure-release API. Bundling consumes the prepared values and restores native assets after Vite clears its output directory. Application builds and hot reload retain their existing WASM emission entry point.

Native reference-count helpers now handle string descriptors across storage, overwrites, scope cleanup, calls, and temporary expressions. Converted string views have explicit ownership; dictionary operations release converted keys/values, graph deletion releases temporary target lists, and the Python bridge releases both parser input buffers.

Validation:

- [CI passed on the final commit](https://github.com/jaseci-labs/jac/actions/runs/34613784892), including full source-tree type checking and the native suite (1,619 passed, 4 skipped).

- Reproduced failing client-lifetime and native-reference regressions before implementation.
- 44 targeted tests pass: 2 client-lifetime regressions, 13 closure-release/hot-reload tests, 4 parser tests, 24 native compatibility tests, and a regression covering 23 string ownership cases plus temporary-list deletion.
- Targeted client and native type checks and formatting checks pass.
- Repeating the original parser workload grows allocated-in-use memory by **4,064 bytes across 900 parses**, versus **19,299,504 bytes** before. Source/path reference counts return to **1/1**, previously **369/3**.
- Valgrind reports identical definite/indirect byte and block counts after 1 and 40 parses, with no invalid accesses. Bounded one-time graph-registration losses remain.
- The rebuilt package successfully builds `jac/examples/jaclang_org/web/main.jac`; JavaScript, WASM, import/boundary manifests, and the HTML entry were verified. It peaks at **9.45 GiB process-tree RSS**, with Jac holding **3.35 GiB during bundling**. This uses a sealed package and different cache state from the original development-mode baseline, so it is not a controlled before/after performance comparison.

The remaining 3.35 GiB RSS has not been attributed to live objects versus allocator retention; it may overlap with the interface-preparation/filesystem-identity regression in #9135. That investigation is deferred. This PR does not claim to resolve #9135. Local testing is limited to affected compiler, native ownership, and client-build tests.
