### PR TITLE
fix: bound interface resolution and compiler working memory

### DIFF
--- a/jac/jaclang/compiler/driver/compilation_context.jac
+++ b/jac/jaclang/compiler/driver/compilation_context.jac
@@ -20,10 +20,13 @@ glob _active_options: ContextVar[CompileOptions | None] = ContextVar(
 def cache_scope(
     identity: str, options: CompileOptions | None = None
 ) -> Iterator[None] {
+    import from jaclang.compiler.placement.workspace { workspace_scope }
     token = _cache_context.set(identity);
     option_token = _active_options.set(options);
     try {
-        yield ;
+        with workspace_scope() {
+            yield ;
+        }
     } finally {
         _cache_context.reset(token);
         _active_options.reset(option_token);

--- a/jac/jaclang/compiler/driver/compilation_context.jac
+++ b/jac/jaclang/compiler/driver/compilation_context.jac
@@ -20,16 +20,23 @@ glob _active_options: ContextVar[CompileOptions | None] = ContextVar(
 def cache_scope(
     identity: str, options: CompileOptions | None = None
 ) -> Iterator[None] {
-    import from jaclang.compiler.placement.workspace { workspace_scope }
     token = _cache_context.set(identity);
     option_token = _active_options.set(options);
     try {
-        with workspace_scope() {
-            yield ;
-        }
+        yield ;
     } finally {
         _cache_context.reset(token);
         _active_options.reset(option_token);
+    }
+}
+
+@contextmanager
+def compilation_scope(
+    identity: str, options: CompileOptions | None = None
+) -> Iterator[None] {
+    import from jaclang.compiler.placement.workspace { workspace_scope }
+    with cache_scope(identity, options), workspace_scope() {
+        yield ;
     }
 }
 

--- a/jac/jaclang/compiler/driver/ifacecache.jac
+++ b/jac/jaclang/compiler/driver/ifacecache.jac
@@ -371,21 +371,21 @@ obj IfaceRegistry {
     }
 
     @contextmanager
-    def _cache_scope -> Iterator[None] {
+    def _compilation_scope -> Iterator[None] {
         import from jaclang.compiler.driver.compilation_context {
-            cache_scope,
+            compilation_scope,
             context_identity
         }
         identity = ''
             if self.prog._get_compiler().selfhost.is_selfhost(self.prog)
             else self.prog.context_key or context_identity(self.prog.options);
-        with cache_scope(identity, self.prog.options) {
+        with compilation_scope(identity, self.prog.options) {
             yield ;
         }
     }
 
     def _module_jir(resolved: str) -> tuple[bytes, str] | None {
-        with self._cache_scope() {
+        with self._compilation_scope() {
             return self._module_jir_in_context(resolved);
         }
     }
@@ -396,19 +396,19 @@ obj IfaceRegistry {
         if actual is not self.prog {
             return actual.iface_registry().ensure(path, compile_on_miss);
         }
-        with self._cache_scope() {
+        with self._compilation_scope() {
             return self._ensure_in_context(path, compile_on_miss);
         }
     }
 
     def serve(compiler: any, resolved: str, options: any) -> any {
-        with self._cache_scope() {
+        with self._compilation_scope() {
             return self._serve_in_context(compiler, resolved, options);
         }
     }
 
     def prepare_interface(resolved: str, mod: any) -> bool {
-        with self._cache_scope() {
+        with self._compilation_scope() {
             return self._prepare_interface_in_context(resolved, mod);
         }
     }
@@ -416,7 +416,7 @@ obj IfaceRegistry {
     def persist_after_compile(
         resolved: str, mod: any, options: any, err_start: int, warn_start: int
     ) {
-        with self._cache_scope() {
+        with self._compilation_scope() {
             self._persist_in_context(resolved, mod, options, err_start, warn_start);
         }
     }

--- a/jac/jaclang/compiler/driver/impl/compiler.impl.jac
+++ b/jac/jaclang/compiler/driver/impl/compiler.impl.jac
@@ -123,14 +123,14 @@ impl JacCompiler.get_bytecode(
     import from jaclang.compiler.driver.compilation_context {
         bind_options,
         context_program,
-        cache_scope
+        compilation_scope
     }
     actual = self.selfhost.resolve(full_target, target_program);
     if not self.selfhost.is_selfhost(actual) {
         options = bind_options(full_target, actual, actual.options);
         actual = context_program(actual, options);
     }
-    with cache_scope(
+    with compilation_scope(
         '' if self.selfhost.is_selfhost(actual) else actual.context_key, actual.options
     ) {
         return self._get_bytecode(full_target, actual);
@@ -1242,11 +1242,11 @@ impl JacCompiler.compile(
     }
     context_errors = len(target_program.errors_had);
     context_warnings = len(target_program.warnings_had);
-    import from jaclang.compiler.driver.compilation_context { cache_scope }
+    import from jaclang.compiler.driver.compilation_context { compilation_scope }
     identity = ''
         if self.selfhost.is_selfhost(target_program)
         else target_program.context_key;
-    with cache_scope(identity, options) {
+    with compilation_scope(identity, options) {
         import from jaclang.compiler.native_scope {
             activate_scope_lowering,
             deactivate_scope_lowering,
@@ -2018,14 +2018,14 @@ impl JacCompiler.get_client_artifact(
     import from jaclang.compiler.driver.compilation_context {
         bind_options,
         context_program,
-        cache_scope
+        compilation_scope
     }
     actual = self.selfhost.resolve(full_target, target_program);
     if not self.selfhost.is_selfhost(actual) {
         options = bind_options(full_target, actual, actual.options);
         actual = context_program(actual, options);
     }
-    with cache_scope(
+    with compilation_scope(
         '' if self.selfhost.is_selfhost(actual) else actual.context_key, actual.options
     ) {
         return self._get_client_artifact(full_target, actual);

--- a/jac/jaclang/compiler/placement/impl/workspace.impl.jac
+++ b/jac/jaclang/compiler/placement/impl/workspace.impl.jac
@@ -43,7 +43,16 @@ impl WorkspaceSpec.module_dot_path(abs_path: str) -> str {
 }
 
 impl _real(path: str) -> str {
-    return os.path.normcase(os.path.realpath(os.path.abspath(path)));
+    absolute = os.path.abspath(path);
+    scope = _resolution.get();
+    if scope is not None and absolute in scope.paths {
+        return scope.paths[absolute];
+    }
+    resolved = os.path.normcase(os.path.realpath(absolute));
+    if scope is not None {
+        scope.paths[absolute] = resolved;
+    }
+    return resolved;
 }
 
 impl _read_toml(toml_path: str) -> dict {
@@ -225,6 +234,19 @@ impl workspace_for_path(path: str) -> (WorkspaceSpec | None) {
     if not path {
         return None;
     }
+    absolute = os.path.abspath(path);
+    scope = _resolution.get();
+    if scope is not None and absolute in scope.workspaces {
+        return scope.workspaces[absolute];
+    }
+    found = _workspace_for_path(absolute);
+    if scope is not None {
+        scope.workspaces[absolute] = found;
+    }
+    return found;
+}
+
+impl _workspace_for_path(path: str) -> (WorkspaceSpec | None) {
     root_dir = find_jac_project_root(path);
     if not root_dir {
         return None;

--- a/jac/jaclang/compiler/placement/workspace.jac
+++ b/jac/jaclang/compiler/placement/workspace.jac
@@ -2,6 +2,9 @@ import fnmatch;
 import hashlib;
 import json;
 import os;
+import from collections.abc { Iterator }
+import from contextlib { contextmanager }
+import from contextvars { ContextVar }
 import from jaclang.compiler.driver.modresolver { find_jac_project_root }
 
 import from jaclang.project.app_kinds {
@@ -44,9 +47,34 @@ obj WorkspaceSpec {
     def module_dot_path(abs_path: str) -> str;
 }
 
-glob _ws_cache: dict[str, tuple[tuple, WorkspaceSpec]] = {};
+obj WorkspaceResolution {
+    has paths: dict[str, str] = {},
+        workspaces: dict[str, WorkspaceSpec | None] = {};
+}
+
+glob _ws_cache: dict[str, tuple[tuple, WorkspaceSpec]] = {},
+     _resolution: ContextVar[WorkspaceResolution | None] = ContextVar(
+         'jac_workspace_resolution', `default=None
+     );
+
+@contextmanager
+def workspace_scope -> Iterator[None] {
+    # Nested compilation contexts share filesystem facts, but select their
+    # own app. A new outer request observes workspace and symlink edits.
+    if _resolution.get() is not None {
+        yield ;
+        return;
+    }
+    token = _resolution.set(WorkspaceResolution());
+    try {
+        yield ;
+    } finally {
+        _resolution.reset(token);
+    }
+}
 
 def workspace_for_path(path: str) -> (WorkspaceSpec | None);
+def _workspace_for_path(path: str) -> (WorkspaceSpec | None);
 def app_for_path(path: str) -> (AppSpec | None);
 def app_fact_digest(app: (AppSpec | None)) -> str;
 def serving_apps(ws: WorkspaceSpec) -> list[AppSpec];

--- a/jac/jaclang/compiler/placement/workspace.jac
+++ b/jac/jaclang/compiler/placement/workspace.jac
@@ -59,8 +59,6 @@ glob _ws_cache: dict[str, tuple[tuple, WorkspaceSpec]] = {},
 
 @contextmanager
 def workspace_scope -> Iterator[None] {
-    # Nested compilation contexts share filesystem facts, but select their
-    # own app. A new outer request observes workspace and symlink edits.
     if _resolution.get() is not None {
         yield ;
         return;

--- a/jac/jaclang/compiler/types/stubcat/writer.jac
+++ b/jac/jaclang/compiler/types/stubcat/writer.jac
@@ -296,6 +296,7 @@ obj CatalogWriter {
         type_ids: dict[any, int] postinit,
         _ident_visiting: set[int] postinit,
         _type_ident_memo: dict[int, any] postinit,
+        _canonical_paths: dict[str, str] postinit,
         types: list[TypeBase] postinit,
         pending_types: list[int] postinit,
         shared_ids: dict[any, int] postinit,
@@ -344,10 +345,22 @@ obj CatalogWriter {
         self.sym_types = {};
         self.sym_props = {};
         self.forced_scopes = set();
-        self.base_dir = os.path.realpath(self.pkg_dir);
+        self._canonical_paths = {};
+        self.base_dir = self._real_path(self.pkg_dir);
         self.external_modules = set();
         self._ident_visiting = set();
         self._type_ident_memo = {};
+    }
+
+    def _real_path(path: str) -> str {
+        # A writer owns one immutable interface snapshot. Identity comparisons
+        # must reuse canonical paths throughout its symbol/type traversal.
+        found = self._canonical_paths.get(path);
+        if found is None {
+            found = os.path.realpath(path);
+            self._canonical_paths[path] = found;
+        }
+        return found;
     }
 
     def in_boundary(mod: (Module | None)) -> bool {
@@ -366,7 +379,7 @@ obj CatalogWriter {
             if not bpath or not mpath {
                 return False;
             }
-            return os.path.realpath(mpath) == os.path.realpath(bpath);
+            return self._real_path(mpath) == self._real_path(bpath);
         } except Exception {
             return False;
         }
@@ -385,7 +398,7 @@ obj CatalogWriter {
             mpath = "";
         }
         if mpath {
-            return os.path.realpath(mpath);
+            return self._real_path(mpath);
         }
         return id(mod);
     }
@@ -483,7 +496,7 @@ obj CatalogWriter {
         if not path {
             return "";
         }
-        real = os.path.realpath(path);
+        real = self._real_path(path);
         prefix = self.base_dir + os.sep;
         if real.startswith(prefix) {
             return real[len(prefix):].replace(os.sep, "/");

--- a/jac/jaclang/compiler/types/stubcat/writer.jac
+++ b/jac/jaclang/compiler/types/stubcat/writer.jac
@@ -353,8 +353,6 @@ obj CatalogWriter {
     }
 
     def _real_path(path: str) -> str {
-        # A writer owns one immutable interface snapshot. Identity comparisons
-        # must reuse canonical paths throughout its symbol/type traversal.
         found = self._canonical_paths.get(path);
         if found is None {
             found = os.path.realpath(path);

--- a/jac/jaclang/dist/fused/embed.jac
+++ b/jac/jaclang/dist/fused/embed.jac
@@ -5,7 +5,6 @@ import from ._libc { peek, poke, c_string, c_alloc_string }
 
 glob PY_VER: str = "3.14",
      PY_VER_COMPACT: str = "314",
-     # PyMemAllocatorName in the bundled CPython's public C API.
      PYMEM_ALLOCATOR_MIMALLOC: int = 7;
 
 import from c {
@@ -136,8 +135,7 @@ obj Embed {
         self.check(
             cfg, a.PyInitConfig_SetInt(cfg, "use_environment", 0), "use_environment"
         );
-        # Sparse, long-lived compiler objects otherwise pin pymalloc arenas
-        # containing gigabytes of already released syntax and type data.
+
         self.check(
             cfg,
             a.PyInitConfig_SetInt(cfg, "allocator", PYMEM_ALLOCATOR_MIMALLOC),
@@ -234,9 +232,7 @@ obj CStrArray {
 def:pub open_tree(rt: str, exe_path: str) -> Embed {
     os.environ["JAC_STANDALONE"] = "1";
     os.environ["JAC_EXECUTABLE"] = exe_path;
-    # Return unused pages even when compilation is followed by an idle wait
-    # for an external bundler. Configure before libpython initializes its
-    # allocator; preserve an explicit host tuning choice.
+
     if not os.environ.get("MIMALLOC_PURGE_DELAY", "") {
         os.environ["MIMALLOC_PURGE_DELAY"] = "0";
     }

--- a/jac/jaclang/dist/fused/embed.jac
+++ b/jac/jaclang/dist/fused/embed.jac
@@ -4,7 +4,9 @@ import from _dl_native { dlopen, dlsym, dl_error, RTLD_NOW, RTLD_GLOBAL, SHLIB_E
 import from ._libc { peek, poke, c_string, c_alloc_string }
 
 glob PY_VER: str = "3.14",
-     PY_VER_COMPACT: str = "314";
+     PY_VER_COMPACT: str = "314",
+     # PyMemAllocatorName in the bundled CPython's public C API.
+     PYMEM_ALLOCATOR_MIMALLOC: int = 7;
 
 import from c {
     def malloc(size: int) -> int;  def free(ptr: int) -> None;  obj PyApi {
@@ -134,6 +136,13 @@ obj Embed {
         self.check(
             cfg, a.PyInitConfig_SetInt(cfg, "use_environment", 0), "use_environment"
         );
+        # Sparse, long-lived compiler objects otherwise pin pymalloc arenas
+        # containing gigabytes of already released syntax and type data.
+        self.check(
+            cfg,
+            a.PyInitConfig_SetInt(cfg, "allocator", PYMEM_ALLOCATOR_MIMALLOC),
+            "allocator"
+        );
         self.check(
             cfg,
             a.PyInitConfig_SetInt(cfg, "user_site_directory", 0),
@@ -225,6 +234,12 @@ obj CStrArray {
 def:pub open_tree(rt: str, exe_path: str) -> Embed {
     os.environ["JAC_STANDALONE"] = "1";
     os.environ["JAC_EXECUTABLE"] = exe_path;
+    # Return unused pages even when compilation is followed by an idle wait
+    # for an external bundler. Configure before libpython initializes its
+    # allocator; preserve an explicit host tuning choice.
+    if not os.environ.get("MIMALLOC_PURGE_DELAY", "") {
+        os.environ["MIMALLOC_PURGE_DELAY"] = "0";
+    }
 
     ca_bundle = rt + "/python/floor/cacert.pem";
     if not os.environ.get("SSL_CERT_FILE", "")

--- a/jac/tests/cli/test_allocator_memory.jac
+++ b/jac/tests/cli/test_allocator_memory.jac
@@ -1,0 +1,50 @@
+"""The embedded interpreter returns sparse compiler working memory to the OS."""
+import json;
+import os;
+import subprocess;
+import sys;
+import from unittest { SkipTest }
+
+glob SPARSE_HEAP: str = '''
+import gc, json
+from pathlib import Path
+
+def rss():
+    return int(next(line for line in Path('/proc/self/status').read_text().splitlines()
+                    if line.startswith('VmRSS:')).split()[1])
+
+gc.collect()
+baseline = rss()
+# Small, persistent objects interspersed with transient syntax nodes pin
+# pymalloc's entire 1 MiB arenas, even after almost every object is freed.
+transient = [bytearray(400) for _ in range(500000)]
+survivors = transient[::1500]
+peak = rss()
+del transient
+gc.collect()
+print(json.dumps(dict(baseline=baseline, peak=peak, remaining=rss(),
+                     survivors=len(survivors))))
+''';
+
+test "sparse survivors do not pin a released compiler sized heap" {
+    if sys.platform != 'linux' {
+        raise SkipTest('current resident memory is measured through /proc');
+    }
+    env = dict(os.environ);
+    env.pop('MIMALLOC_PURGE_DELAY', None);
+    result = subprocess.run(
+        [sys.executable, '-c', SPARSE_HEAP],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30
+    );
+    assert result.returncode == 0 , result.stderr;
+    memory = json.loads(result.stdout);
+    working = memory['peak'] - memory['baseline'];
+    retained = memory['remaining'] - memory['baseline'];
+    assert memory['survivors'] > 0 and working > 128 * 1024 , memory;
+    assert retained < working / 2 , (
+        f'released objects left {retained} KiB resident from {working} KiB of working memory'
+    );
+}

--- a/jac/tests/compiler/test_interface_memory.jac
+++ b/jac/tests/compiler/test_interface_memory.jac
@@ -9,9 +9,7 @@ import from jaclang.compiler.types.stubcat.writer { CatalogWriter }
 
 test "interface symbol identities resolve each module path once" {
     program = JacProgram();
-    source = '\n'.join(
-        f'def function_{i} -> int {{ return {i}; }}' for i in range(40)
-    );
+    source = '\n'.join(f'def function_{i} -> int {{ return {i}; }}' for i in range(40));
     options = CompileOptions(symtab_ir_only=True, force_target_program=True);
     boundary = program.compile('identity.jac', use_str=source, options=options);
     twin = JacProgram().compile('identity.jac', use_str=source, options=options);
@@ -35,7 +33,7 @@ test "interface symbol identities resolve each module path once" {
     for name in boundary.names_in_scope.keys() {
         assert (
             writer._sym_ident(boundary.names_in_scope[name])
-                == writer._sym_ident(twin.names_in_scope[name])
+            == writer._sym_ident(twin.names_in_scope[name])
         );
     }
 }

--- a/jac/tests/compiler/test_interface_memory.jac
+++ b/jac/tests/compiler/test_interface_memory.jac
@@ -1,0 +1,58 @@
+"""Interface identity work scales with source modules, not symbol visits."""
+import os;
+import from pathlib { Path }
+import from tempfile { TemporaryDirectory }
+import from unittest.mock { patch }
+import from jaclang.compiler.driver.compile_options { CompileOptions }
+import from jaclang.compiler.driver.program { JacProgram }
+import from jaclang.compiler.types.stubcat.writer { CatalogWriter }
+
+test "interface symbol identities resolve each module path once" {
+    program = JacProgram();
+    source = '\n'.join(
+        f'def function_{i} -> int {{ return {i}; }}' for i in range(40)
+    );
+    options = CompileOptions(symtab_ir_only=True, force_target_program=True);
+    boundary = program.compile('identity.jac', use_str=source, options=options);
+    twin = JacProgram().compile('identity.jac', use_str=source, options=options);
+    external = JacProgram().compile('external.jac', use_str=source, options=options);
+    writer = CatalogWriter(evaluator=None, pkg_dir=os.getcwd(), boundary=boundary);
+    with patch('os.path.realpath', wraps=os.path.realpath) as resolve {
+        for mod in [boundary, twin, external] {
+            for sym in mod.names_in_scope.values() {
+                writer._sym_ident(sym);
+                writer._scope_ident(sym.parent_tab);
+                writer.ref_module(mod);
+                writer.rel_of(mod.loc.mod_path);
+            }
+        }
+        assert resolve.call_count <= 2 , (
+            f'two module paths required {resolve.call_count} filesystem resolutions'
+        );
+    }
+    assert writer._mod_ident(boundary) == writer._mod_ident(twin);
+    assert writer.in_boundary(twin) and not writer.in_boundary(external);
+    for name in boundary.names_in_scope.keys() {
+        assert (
+            writer._sym_ident(boundary.names_in_scope[name])
+                == writer._sym_ident(twin.names_in_scope[name])
+        );
+    }
+}
+
+test "interface path identities expire with the writer" {
+    with TemporaryDirectory() as td {
+        base = Path(td);
+        for name in ['first', 'second'] {
+            (base / name).mkdir();
+        }
+        alias = base / 'alias';
+        alias.symlink_to(base / 'first', target_is_directory=True);
+        writer = CatalogWriter(evaluator=None, pkg_dir=td);
+        assert writer.rel_of(str(alias / 'unit.jac')) == 'first/unit.jac';
+        alias.unlink();
+        alias.symlink_to(base / 'second', target_is_directory=True);
+        next_writer = CatalogWriter(evaluator=None, pkg_dir=td);
+        assert next_writer.rel_of(str(alias / 'unit.jac')) == 'second/unit.jac';
+    }
+}

--- a/jac/tests/compiler/test_workspace_facts.jac
+++ b/jac/tests/compiler/test_workspace_facts.jac
@@ -41,13 +41,16 @@ test "only declared entries have a filesystem app identity" {
 
 test "workspace probes scale with modules within a compilation request" {
     import from unittest.mock { patch }
-    import from jaclang.compiler.driver.compilation_context { context_app }
+    import from jaclang.compiler.driver.compilation_context {
+        compilation_scope,
+        context_app
+    }
     with TemporaryDirectory() as td {
         base = Path(td);
         workspace(base);
         path = str(base / 'shared.jac');
         options = CompileOptions(project_root=td, target_app='web');
-        with cache_scope('web', options) {
+        with compilation_scope('web', options) {
             with patch('os.lstat', wraps=os.lstat) as probe {
                 app = context_app(path);
                 assert app is not None and app.name == 'web';
@@ -60,7 +63,7 @@ test "workspace probes scale with modules within a compilation request" {
                         - first} extra filesystem probes'
                 );
             }
-            with cache_scope(
+            with compilation_scope(
                 'api', CompileOptions(project_root=td, target_app='api')
             ) {
                 other = context_app(path);
@@ -72,7 +75,7 @@ test "workspace probes scale with modules within a compilation request" {
         stamp = os.path.getmtime(toml) + 2.0;
         toml.write_text(CONFIG.replace('web-app', 'desktop'));
         os.utime(toml, (stamp, stamp));
-        with cache_scope('web', options) {
+        with compilation_scope('web', options) {
             refreshed = context_app(path);
             assert refreshed is not None and refreshed.kind == 'desktop' , (
                 f'workspace edit was not observed: {refreshed}'

--- a/jac/tests/compiler/test_workspace_facts.jac
+++ b/jac/tests/compiler/test_workspace_facts.jac
@@ -39,6 +39,40 @@ test "only declared entries have a filesystem app identity" {
     }
 }
 
+test "workspace probes scale with modules within a compilation request" {
+    import from unittest.mock { patch }
+    import from jaclang.compiler.driver.compilation_context { context_app }
+    with TemporaryDirectory() as td {
+        base = Path(td);
+        workspace(base);
+        path = str(base / 'shared.jac');
+        options = CompileOptions(project_root=td, target_app='web');
+        with cache_scope('web', options) {
+            with patch('os.lstat', wraps=os.lstat) as probe {
+                app = context_app(path);
+                assert app is not None and app.name == 'web';
+                first = probe.call_count;
+                for i in range(40) {
+                    assert context_app(path) is app;
+                }
+                assert probe.call_count == first , (
+                    f'repeated module facts made {probe.call_count - first} extra filesystem probes'
+                );
+            }
+            with cache_scope('api', CompileOptions(project_root=td, target_app='api')) {
+                other = context_app(path);
+                assert other is not None and other.name == 'api';
+            }
+            assert context_app(path) is app;
+        }
+        (base / 'jac.toml').write_text(CONFIG.replace('web-app', 'desktop-app'));
+        with cache_scope('web', options) {
+            refreshed = context_app(path);
+            assert refreshed is not None and refreshed.kind == 'desktop-app';
+        }
+    }
+}
+
 test "a normal import inherits its app and an entry import changes context" {
     with TemporaryDirectory() as td {
         base = Path(td);

--- a/jac/tests/compiler/test_workspace_facts.jac
+++ b/jac/tests/compiler/test_workspace_facts.jac
@@ -68,10 +68,15 @@ test "workspace probes scale with modules within a compilation request" {
             }
             assert context_app(path) is app;
         }
-        (base / 'jac.toml').write_text(CONFIG.replace('web-app', 'desktop-app'));
+        toml = base / 'jac.toml';
+        stamp = os.path.getmtime(toml) + 2.0;
+        toml.write_text(CONFIG.replace('web-app', 'desktop'));
+        os.utime(toml, (stamp, stamp));
         with cache_scope('web', options) {
             refreshed = context_app(path);
-            assert refreshed is not None and refreshed.kind == 'desktop-app';
+            assert refreshed is not None and refreshed.kind == 'desktop' , (
+                f'workspace edit was not observed: {refreshed}'
+            );
         }
     }
 }

--- a/jac/tests/compiler/test_workspace_facts.jac
+++ b/jac/tests/compiler/test_workspace_facts.jac
@@ -56,10 +56,13 @@ test "workspace probes scale with modules within a compilation request" {
                     assert context_app(path) is app;
                 }
                 assert probe.call_count == first , (
-                    f'repeated module facts made {probe.call_count - first} extra filesystem probes'
+                    f'repeated module facts made {probe.call_count
+                        - first} extra filesystem probes'
                 );
             }
-            with cache_scope('api', CompileOptions(project_root=td, target_app='api')) {
+            with cache_scope(
+                'api', CompileOptions(project_root=td, target_app='api')
+            ) {
                 other = context_app(path);
                 assert other is not None and other.name == 'api';
             }

--- a/jac/tests/compiler/test_workspace_facts.jac
+++ b/jac/tests/compiler/test_workspace_facts.jac
@@ -81,6 +81,28 @@ test "workspace probes scale with modules within a compilation request" {
     }
 }
 
+test "application identity scopes observe workspace edits between requests" {
+    import from jaclang.compiler.driver.compilation_context { context_app }
+    with TemporaryDirectory() as td {
+        base = Path(td);
+        workspace(base);
+        path = str(base / 'shared.jac');
+        options = CompileOptions(project_root=td, target_app='web');
+        with cache_scope('web', options) {
+            first = context_app(path);
+            assert first is not None and first.kind == 'web-app';
+            toml = base / 'jac.toml';
+            stamp = os.path.getmtime(toml) + 2.0;
+            toml.write_text(CONFIG.replace('web-app', 'desktop'));
+            os.utime(toml, (stamp, stamp));
+            refreshed = context_app(path);
+            assert refreshed is not None and refreshed.kind == 'desktop' , (
+                'an application identity scope must not retain old workspace facts'
+            );
+        }
+    }
+}
+
 test "a normal import inherits its app and an entry import changes context" {
     with TemporaryDirectory() as td {
         base = Path(td);

--- a/release_notes/unreleased/jaclang/9141.bugfix.md
+++ b/release_notes/unreleased/jaclang/9141.bugfix.md
@@ -1,6 +1,1 @@
-Reduce compiler memory retention and repeated filesystem work during client builds.
-Interface writers reuse canonical module identities throughout serialization, and
-nested compilation contexts share workspace resolution for the duration of a
-request. The embedded runtime uses CPython's mimalloc allocator with immediate
-page purging so sparse surviving objects do not keep large released compiler heaps
-resident while the client bundler runs.
+- **Compiler: Reduce client build memory retention and filesystem work**: Reuse canonical module identities throughout interface serialization and share workspace resolution within compilation requests. Configure the embedded runtime's allocator to return unused pages so sparse surviving objects do not keep large released compiler heaps resident while the client bundler runs.

--- a/release_notes/unreleased/jaclang/9141.bugfix.md
+++ b/release_notes/unreleased/jaclang/9141.bugfix.md
@@ -1,0 +1,6 @@
+Reduce compiler memory retention and repeated filesystem work during client builds.
+Interface writers reuse canonical module identities throughout serialization, and
+nested compilation contexts share workspace resolution for the duration of a
+request. The embedded runtime uses CPython's mimalloc allocator with immediate
+page purging so sparse surviving objects do not keep large released compiler heaps
+resident while the client bundler runs.


### PR DESCRIPTION
Client builds repeatedly resolve the same module and workspace paths while writing interfaces. After compilation, sparse surviving Python objects also pin large pymalloc arenas even though the source graphs have been collected. This follow-up to #9125 addresses the hot paths and remaining RSS investigated in #9135, including the [reported cloud-build regression](https://github.com/jaseci-labs/jac/issues/9135#issuecomment-5635619309).

- Memoize canonical paths for each interface writer, preserving stable identities for equivalent module trees.
- Share workspace and path resolution across nested compiler and interface operations. The new `compilation_scope` composes the existing application identity scope with a filesystem snapshot. Application selection stays contextual, and a persistent identity scope still observes config edits between operations.
- Select CPython's supported mimalloc allocator in the shared embedded-runtime initialization and default to immediate page purging. CLI, worker, and desktop hosts use the same initialization path; explicit purge tuning is preserved.

Failing regressions reproduced 807 realpath calls for two module paths, 680 extra lstat calls for 40 repeated workspace lookups, and 231 MiB remaining resident after releasing a 234 MiB transient heap with sparse survivors. The tests now pass: interface resolution uses at most two realpath calls, repeated workspace lookups add no lstat calls, and the allocator probe retains 43 MiB. Additional guards cover symlink retargeting, nested app selection, and config invalidation across compiler operations.

Cold `jac build --as client web/main.jac` comparison on the jaclang.org example, with fresh project copies and separate empty runtime caches:

| Measurement | Merged baseline | This PR (`109daba8b`) |
|---|---:|---:|
| Jac peak RSS | 4.99 GiB | 5.04 GiB |
| Jac RSS after compiler cleanup | 4.29 GiB | 1.86 GiB |
| Peak RSS across Jac, Bun, and esbuild | 9.67 GiB | 7.10 GiB |
| End-to-end wall time | 377 s | 310 s |

Post-cleanup RSS falls **57%** and the full process peak falls **27%**. Both builds succeed. All 61 JavaScript/CSS outputs match byte for byte; the Wasm output matches after normalizing initializer suffixes derived from the different project paths. The active compilation peak remains about 5 GiB. These are single runs on a shared host, not a throughput guarantee.

Targeted local validation on the final commit:

- **59 tests pass** using the CI-built production package: 9 workspace, 2 interface identity, 23 interface cache, 24 importer, and 1 allocator (37.39 seconds).
- The revised compilation-context, compiler, and interface modules pass source-compiler type checking (293.27 seconds). All changed Jac files pass the exact CI `fmt --check --lintfix` check.
- An additional source-compiler run passes 57 of 58 tests, including all new regressions and importer tests. The existing “an interface is identical however many twins of its module are reachable” test fails in source mode. The same test also fails on the unmodified PR base `9e37f2b7d` with the old allocator in a clean worktree; it passes in the production-package run. The test remains unchanged.
- Eleven startup/isolation checks also pass with the rebuilt shared launcher. No broader local test suites were run.

CI: [run 34631562072](https://github.com/jaseci-labs/jac/actions/runs/34631562072) is **green** on `109daba8b`, including repository type checking, compiler/runtime/client suites, native tests, scale tests, Android packaging, and the full website/desktop packaging smoke test. Pre-commit and contribution checks also pass.
