### PR TITLE
fix(compiler): read import levels past a module's single-byte name pool when sealing

### DIFF
--- a/jac/jaclang/compiler/backends/py/artifact_imports.jac
+++ b/jac/jaclang/compiler/backends/py/artifact_imports.jac
@@ -2,6 +2,13 @@ import dis;
 import os;
 import types;
 import from pathlib { Path }
+"""Jac sources the prepared module imports at runtime.
+
+Each IMPORT_NAME is read with its level two instructions back and its
+fromlist one back. EXTENDED_ARG prefixes any instruction whose oparg exceeds
+a byte, so a module carrying more than 255 names would push both off those
+offsets and the level would read as the fromlist tuple; dropping EXTENDED_ARG
+from the list first keeps the offsets true at any name pool size."""
 def runtime_sources(code: types.CodeType, source: str, `root: str) -> set[str] {
     sources: set[str] = `set();
     pending = [code];
@@ -12,9 +19,7 @@ def runtime_sources(code: types.CodeType, source: str, `root: str) -> set[str] {
             for c in unit.co_consts
             if isinstance(c, types.CodeType)
         );
-        # EXTENDED_ARG prefixes an instruction whose oparg exceeds a byte, so a
-        # module with more than 255 names makes IMPORT_NAME carry one and shifts
-        # the level and fromlist off the fixed offsets below.
+
         instructions = [
             instruction
             for instruction in dis.get_instructions(unit)

--- a/jac/jaclang/compiler/backends/py/artifact_imports.jac
+++ b/jac/jaclang/compiler/backends/py/artifact_imports.jac
@@ -12,7 +12,14 @@ def runtime_sources(code: types.CodeType, source: str, `root: str) -> set[str] {
             for c in unit.co_consts
             if isinstance(c, types.CodeType)
         );
-        instructions = `list(dis.get_instructions(unit));
+        # EXTENDED_ARG prefixes an instruction whose oparg exceeds a byte, so a
+        # module with more than 255 names makes IMPORT_NAME carry one and shifts
+        # the level and fromlist off the fixed offsets below.
+        instructions = [
+            instruction
+            for instruction in dis.get_instructions(unit)
+            if instruction.opname != 'EXTENDED_ARG'
+        ];
         for (index, instruction) in enumerate(instructions) {
             if ((instruction.opname != 'IMPORT_NAME') or (index < 2)) {
                 continue;

--- a/jac/tests/compiler/test_application_preparation.jac
+++ b/jac/tests/compiler/test_application_preparation.jac
@@ -1,5 +1,6 @@
 """Application preparation owns compilation; loading consumes its artifacts."""
 
+import dis;
 import os;
 import shutil;
 import tempfile;
@@ -93,6 +94,33 @@ test "executable import discovery includes package initializers and deferred imp
             source,
             'exec'
         );
+        assert runtime_sources(code, source, tmp)
+            == {str(base / name) for name in expected};
+    } finally {
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+
+test "import discovery reads levels past a module's single-byte name pool" {
+    import from jaclang.compiler.backends.py.artifact_imports { runtime_sources }
+    tmp = tempfile.mkdtemp(prefix="jac-prepared-extended-");
+    try {
+        base = Path(tmp);
+        (base / 'pkg').mkdir();
+        expected = ['pkg/__init__.jac', 'pkg/util.jac'];
+        for name in expected {
+            (base / name).write_text('');
+        }
+        source = str(base / 'pkg' / 'main.jac');
+        padding = '\n'.join(f'name{index}()' for index in range(300));
+        code = compile(padding + '\nfrom .util import loader\n', source, 'exec');
+        imports = [
+            instruction
+            for instruction in dis.get_instructions(code)
+            if instruction.opname == 'IMPORT_NAME'
+        ];
+        assert imports[0].arg > 255;
         assert runtime_sources(code, source, tmp)
             == {str(base / name) for name in expected};
     } finally {

--- a/release_notes/unreleased/jaclang/9148.bugfix.md
+++ b/release_notes/unreleased/jaclang/9148.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Read import levels past a module's single-byte name pool when sealing**: Sealing dropped `EXTENDED_ARG` before reading the import level two instructions before each `IMPORT_NAME`, so a module carrying more than 255 names no longer aborts preparation with "Nonconstant import level".


### PR DESCRIPTION
Sealing an application disassembles each prepared module and, for every
`IMPORT_NAME`, reads the import level from the instruction two positions
earlier. CPython prefixes an instruction whose oparg exceeds one byte with
`EXTENDED_ARG`, so once a module carries more than 255 names that prefix
shifts both fixed offsets and the scan reads the **fromlist tuple** as the
level. It is not an `int`, and the seal aborts with:

```
Seal aborted: application preparation failed: Nonconstant import level in
prepared module .../main.jac
```

## Why it is easy to misdiagnose

Nothing is wrong with the module's imports. The failure is a property of how
many *names* the module holds, so it looks like a specific construct is at
fault. On the app that surfaced this, `main.jac` carried 504 names and its
last 8 imports sat at `co_names` indices 261-294. A bisect over the module's
347 top-level constructs pointed at a `with entry` block, which merely pushed
the name pool past the threshold; no construct is responsible.

Reproducing it takes only a name pool and one import:

```python
src = "\n".join("n%d()" % i for i in range(300)) + "\nfrom os import path"
code = compile(src, "<t>", "exec")
# EXTENDED_ARG now sits between the fromlist and IMPORT_NAME, so
# instructions[index - 2] is ('path',) rather than the level 0
```

Below 256 names the same source scans correctly, which is why small apps and
the test suite never hit it.

## The fix

Drop `EXTENDED_ARG` from the instruction list before indexing. That restores
the invariant the two fixed offsets rely on, so the level sits at `-2` and the
fromlist at `-1` at any name pool size.

## Test

Extends the existing test that owns this surface,
`tests/compiler/test_application_preparation.jac`. It pads a module to 300
names so the import's oparg needs `EXTENDED_ARG`, asserts
`imports[0].arg > 255` so the test cannot silently stop exercising the case,
and then asserts discovery still finds the package initializer and the
imported module.
